### PR TITLE
feat: serialize Ash.CiString and ashs now() function into cypher query

### DIFF
--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -185,5 +185,10 @@ defmodule AshNeo4j.QueryHelper do
   defp convert_value(values) when is_struct(values, MapSet),
     do: "[#{Enum.map(values, fn value -> convert_value(value) end) |> Enum.join(",")}]"
 
+  defp convert_value(value) when is_struct(value, Ash.CiString), do: "'#{Ash.CiString.value(value)}'"
+
+  # Ash expression functions that need runtime evaluation
+  defp convert_value(%Ash.Query.Function.Now{}), do: "datetime('#{DateTime.to_iso8601(DateTime.utc_now())}')"
+
   defp convert_value(value), do: value
 end


### PR DESCRIPTION
## Changes

adds two new functions to serialize `Ash.CiString` und `Ash.Query.Function.Now` to cypher.

This was needed by Ash Auth [tested with magic link logins]