### PR TITLE
fix #252 aggregate filters silently dropped

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -1072,8 +1072,16 @@ defmodule AshNeo4j.DataLayer do
         embedded = embedded_field_type(dest_mapping.module, aggregate.field)
 
         cond do
+          # Expression-based aggregates always load full records in Elixir;
+          # run_expr_agg handles aggregate.filter internally via apply_record_filter.
           is_struct(aggregate.field, Ash.Query.Calculation) ->
             run_expr_agg(mapping, neo4j_pk, ids, aggregate, mode, path_segments, dest_mapping)
+
+          # When a filter is present on a plain or embedded aggregate, load full
+          # destination records in Elixir so Ash.Filter.Runtime can evaluate it.
+          # Honouring the filter is a contract implied by can?({:aggregate, kind}).
+          aggregate.filter ->
+            run_filtered_aggregate(mapping, neo4j_pk, ids, aggregate, mode, path_segments, dest_mapping)
 
           embedded ->
             {field_type, field_constraints} = embedded
@@ -1116,6 +1124,67 @@ defmodule AshNeo4j.DataLayer do
       {:error, e} ->
         {:error, e}
     end
+  end
+
+  # Handles any aggregate that carries a filter expression. Loads all destination
+  # records for the given source IDs via Elixir, applies the Ash runtime filter,
+  # then computes the aggregate in Elixir.
+  #
+  # This path is also used for expression-based aggregates (Ash.Query.Calculation
+  # field) when a filter is present, because we already load full records there.
+  defp run_filtered_aggregate(mapping, neo4j_pk, ids, aggregate, mode, path_segments, dest_mapping) do
+    query = CypherQuery.related_nodes(mapping.label, neo4j_pk, ids, path_segments)
+    dest_resource = dest_mapping.module
+    domain = Ash.Resource.Info.domain(dest_resource)
+
+    with {:ok, %Bolty.Response{results: rows}} <- Cypher.run(query) do
+      pairs =
+        Enum.flat_map(rows, fn row ->
+          source_id = Map.get(row, "source_id")
+          dest_node = Map.get(row, "dest_node")
+
+          if dest_node do
+            case convert_node_to_resource(dest_resource, dest_node) do
+              {:ok, record} -> [{source_id, record}]
+              _ -> []
+            end
+          else
+            []
+          end
+        end)
+
+      case mode do
+        :per_record ->
+          grouped = Enum.group_by(pairs, &elem(&1, 0), &elem(&1, 1))
+          result =
+            Map.new(grouped, fn {source_id, records} ->
+              {:ok, filtered} = Ash.Filter.Runtime.filter_matches(domain, records, aggregate.filter)
+              values = extract_aggregate_field_values(filtered, aggregate)
+              {source_id, apply_elixir_aggregate(aggregate.kind, values, aggregate.default_value)}
+            end)
+          {:ok, result}
+
+        :total ->
+          all_records = Enum.map(pairs, &elem(&1, 1))
+          {:ok, filtered} = Ash.Filter.Runtime.filter_matches(domain, all_records, aggregate.filter)
+          values = extract_aggregate_field_values(filtered, aggregate)
+          {:ok, apply_elixir_aggregate(aggregate.kind, values, aggregate.default_value)}
+      end
+    end
+  end
+
+  # Extracts the aggregate's target field value from each record, respecting uniq?.
+  defp extract_aggregate_field_values(records, aggregate) do
+    values =
+      Enum.map(records, fn record ->
+        case aggregate.field do
+          nil -> record
+          field when is_atom(field) -> Map.get(record, field)
+          _ -> record
+        end
+      end)
+
+    if aggregate.uniq?, do: Enum.uniq(values), else: values
   end
 
   defp embedded_field_type(resource_module, field_name) when is_atom(field_name) do
@@ -1174,6 +1243,7 @@ defmodule AshNeo4j.DataLayer do
   defp run_expr_agg(mapping, neo4j_pk, ids, aggregate, mode, path_segments, dest_mapping) do
     query = CypherQuery.related_nodes(mapping.label, neo4j_pk, ids, path_segments)
     dest_resource = dest_mapping.module
+    domain = Ash.Resource.Info.domain(dest_resource)
     calc = aggregate.field
     expr = calc.opts[:expr]
 
@@ -1181,22 +1251,28 @@ defmodule AshNeo4j.DataLayer do
       {:ok, hydrated} ->
         case Cypher.run(query) do
           {:ok, %Bolty.Response{results: rows}} ->
-            pairs =
+            record_pairs =
               Enum.flat_map(rows, fn row ->
                 source_id = Map.get(row, "source_id")
                 dest_node = Map.get(row, "dest_node")
 
                 if dest_node do
                   case convert_node_to_resource(dest_resource, dest_node) do
-                    {:ok, record} ->
-                      case Ash.Expr.eval_hydrated(hydrated, record: record, resource: dest_resource, unknown_on_unknown_refs?: true) do
-                        {:ok, value} when not is_nil(value) -> [{source_id, value}]
-                        _ -> []
-                      end
+                    {:ok, record} -> [{source_id, record}]
                     _ -> []
                   end
                 else
                   []
+                end
+              end)
+
+            # Apply aggregate filter if present, then evaluate the expression.
+            pairs =
+              apply_record_filter(record_pairs, aggregate.filter, domain)
+              |> Enum.flat_map(fn {source_id, record} ->
+                case Ash.Expr.eval_hydrated(hydrated, record: record, resource: dest_resource, unknown_on_unknown_refs?: true) do
+                  {:ok, value} when not is_nil(value) -> [{source_id, value}]
+                  _ -> []
                 end
               end)
 
@@ -1217,6 +1293,20 @@ defmodule AshNeo4j.DataLayer do
 
       {:error, e} -> {:error, e}
     end
+  end
+
+  # Applies an Ash filter (if any) to a list of {source_id, record} pairs,
+  # keeping per-source grouping so filter predicates referencing destination
+  # attributes are evaluated correctly.
+  defp apply_record_filter(pairs, nil, _domain), do: pairs
+
+  defp apply_record_filter(pairs, filter, domain) do
+    grouped = Enum.group_by(pairs, &elem(&1, 0), &elem(&1, 1))
+
+    Enum.flat_map(grouped, fn {source_id, records} ->
+      {:ok, filtered} = Ash.Filter.Runtime.filter_matches(domain, records, filter)
+      Enum.map(filtered, &{source_id, &1})
+    end)
   end
 
   defp cast_raw_list(raw_list, field_type, field_constraints) when is_list(raw_list) do

--- a/test/aggregate_test.exs
+++ b/test/aggregate_test.exs
@@ -165,6 +165,88 @@ defmodule AshNeo4j.AggregateTest do
     end
   end
 
+  describe "filtered aggregates (#252 — filter must not be silently dropped)" do
+    test "first aggregate with filter returns the matching record's field, not whichever comes first" do
+      author = create_author()
+      post = create_post(author, "post")
+      # Create beta first so Neo4j is likely to return it first without a filter
+      create_comment(post, "beta")
+      create_comment(post, "alpha")
+
+      [loaded] = Post |> Ash.read!() |> Ash.load!([:first_alpha_comment_title])
+      assert loaded.first_alpha_comment_title == "alpha"
+    end
+
+    test "count aggregate with filter counts only matching records" do
+      author = create_author()
+      post1 = create_post(author, "post1")
+      post2 = create_post(author, "post2")
+      create_comment(post1, "alpha")
+      create_comment(post1, "beta")
+      create_comment(post1, "alpha")
+      create_comment(post2, "beta")
+
+      [p1, p2] = Post |> Ash.read!() |> Ash.load!([:alpha_comment_count]) |> Enum.sort_by(& &1.title)
+      assert p1.alpha_comment_count == 2
+      assert p2.alpha_comment_count == 0
+    end
+
+    test "exists aggregate with filter is false when only non-matching records exist" do
+      author = create_author()
+      post = create_post(author, "post")
+      create_comment(post, "beta")
+
+      [loaded] = Post |> Ash.read!() |> Ash.load!([:has_alpha_comment])
+      assert loaded.has_alpha_comment == false
+    end
+
+    test "exists aggregate with filter is true when a matching record exists" do
+      author = create_author()
+      post = create_post(author, "post")
+      create_comment(post, "beta")
+      create_comment(post, "alpha")
+
+      [loaded] = Post |> Ash.read!() |> Ash.load!([:has_alpha_comment])
+      assert loaded.has_alpha_comment == true
+    end
+
+    test "list aggregate with filter returns only matching field values" do
+      author = create_author()
+      post = create_post(author, "post")
+      create_comment(post, "alpha")
+      create_comment(post, "beta")
+      create_comment(post, "alpha")
+
+      [loaded] = Post |> Ash.read!() |> Ash.load!([:alpha_comment_titles])
+      assert Enum.sort(loaded.alpha_comment_titles) == ["alpha", "alpha"]
+    end
+
+    test "count with filter returns 0 for post with no comments" do
+      author = create_author()
+      create_post(author, "empty post")
+
+      [loaded] = Post |> Ash.read!() |> Ash.load!([:alpha_comment_count])
+      assert loaded.alpha_comment_count == 0
+    end
+
+    test "multiple posts each see only their own filtered count" do
+      author = create_author()
+      post1 = create_post(author, "aaa")
+      post2 = create_post(author, "bbb")
+      create_comment(post1, "alpha")
+      create_comment(post1, "alpha")
+      create_comment(post1, "beta")
+      create_comment(post2, "beta")
+      create_comment(post2, "beta")
+
+      [p1, p2] = Post |> Ash.read!() |> Ash.load!([:alpha_comment_count, :has_alpha_comment]) |> Enum.sort_by(& &1.title)
+      assert p1.alpha_comment_count == 2
+      assert p1.has_alpha_comment == true
+      assert p2.alpha_comment_count == 0
+      assert p2.has_alpha_comment == false
+    end
+  end
+
   describe "aggregates on embedded struct fields" do
     test "list aggregate returns deserialized typed structs" do
       author = create_author()

--- a/test/support/resource/post.ex
+++ b/test/support/resource/post.ex
@@ -83,6 +83,23 @@ defmodule AshNeo4j.Test.Resource.Post do
     list :comment_titles, :comments, field: :title
     list :comment_dogs, :comments, field: :dog
     first :first_comment_dog, :comments, field: :dog
+
+    # Filtered aggregates — used to verify #252 (filters must not be silently dropped).
+    first :first_alpha_comment_title, :comments, field: :title do
+      filter expr(title == "alpha")
+    end
+
+    count :alpha_comment_count, :comments do
+      filter expr(title == "alpha")
+    end
+
+    exists :has_alpha_comment, :comments do
+      filter expr(title == "alpha")
+    end
+
+    list :alpha_comment_titles, :comments, field: :title do
+      filter expr(title == "alpha")
+    end
   end
 
   preparations do


### PR DESCRIPTION
Aggregate filters declared via `filter expr(...)` in the Ash DSL were never applied — they were silently ignored by every code path in run_aggregate_for_ids.

## Root cause

All three aggregate execution paths (Cypher push-down for plain fields, Elixir-side for embedded JSON types, Elixir-side for expression calculations) received `aggregate.filter` but never consulted it.

## Fix

Routing in run_aggregate_for_ids/5 is now:

1. Expression-calc field (Ash.Query.Calculation) → run_expr_agg, which now applies the filter via apply_record_filter/3 before evaluating the expression.

2. Any filter present on a plain or embedded aggregate → run_filtered_aggregate/7 (new): loads full destination records via related_nodes, applies Ash.Filter.Runtime.filter_matches/3 per-source group, extracts field values, then reduces with apply_elixir_aggregate.

3. Embedded field (no filter) → run_embedded_agg (unchanged).

4. Plain field (no filter) → Cypher push-down (unchanged).

This keeps the fast Cypher path for the common unfiltered case while fully honouring the data-layer contract for filtered aggregates.

## New helpers

- run_filtered_aggregate/7 — Elixir-side aggregate with runtime filter
- extract_aggregate_field_values/2 — extracts field from records, uniq?
- apply_record_filter/3 — applies Ash runtime filter to {id, record} pairs

## Tests

Added describe "filtered aggregates (#252)" covering: first, count, exists (true and false), list, zero-record base case, and multi-post correctness. Four filtered resource aggregates added to Post test fixture.