### PR TITLE
Scope read pagination to nodes, not edge rows (#285)

### DIFF
--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -434,6 +434,58 @@ defmodule AshNeo4j.Cypher.Query do
   def add_limit(%__MODULE__{} = query, nil), do: query
   def add_limit(%__MODULE__{} = query, n), do: %{query | clauses: query.clauses ++ [%Limit{value: n}]}
 
+  @doc """
+  Applies `SKIP`/`LIMIT` pagination (and the `ORDER BY` that makes them
+  deterministic) to the distinct source nodes `s`, **before** the edge-expansion
+  step of a node read.
+
+  The node-read shapes (`node_read/1`, `node_read_filtered/3`, `node_read_by_ids/2`,
+  `relationship_read/7`, and the combination final read) all expand one row per
+  edge via the clause immediately preceding the `RETURN`
+  (`OPTIONAL MATCH (s)-[r]-(d)` etc.). A trailing `SKIP`/`LIMIT` would therefore
+  truncate *edges*, not *nodes* — dropping relationships (e.g. a `belongs_to`
+  edge) from nodes that have more edges than the limit. This inserts
+  `WITH s [ORDER BY …] [SKIP …] [LIMIT …]` ahead of that expansion so pagination
+  is scoped to nodes.
+
+  No-op when there is no `skip` and no `limit` (a sort alone is handled by the
+  trailing `add_order_by/2`, which orders the per-edge rows by node property and
+  so keeps each node's rows grouped).
+  """
+  @spec paginate_nodes(t(), [{atom() | String.t(), :asc | :desc}], non_neg_integer() | nil, pos_integer() | nil) :: t()
+  def paginate_nodes(%__MODULE__{} = query, order_terms, skip, limit) do
+    order_terms = order_terms || []
+
+    if skip in [nil, 0] and is_nil(limit) do
+      query
+    else
+      page = pagination_subclauses(order_terms, skip, limit)
+      return_idx = Enum.find_index(query.clauses, &match?(%Return{}, &1))
+      {before, rest} = Enum.split(query.clauses, return_idx - 1)
+
+      new_before =
+        case List.last(before) do
+          %With{} -> before ++ page
+          _ -> before ++ [%With{items: ["s"]} | page]
+        end
+
+      %{query | clauses: new_before ++ rest}
+    end
+  end
+
+  defp pagination_subclauses(order_terms, skip, limit) do
+    order =
+      case order_terms do
+        [] -> []
+        terms -> [%OrderBy{terms: Enum.map(terms, fn {prop, dir} -> {"s.#{prop}", dir} end)}]
+      end
+
+    skip_clause = if skip in [nil, 0], do: [], else: [%Skip{value: skip}]
+    limit_clause = if is_nil(limit), do: [], else: [%Limit{value: limit}]
+
+    order ++ skip_clause ++ limit_clause
+  end
+
   # ---------------------------------------------------------------------------
   # Aggregate builders
   # ---------------------------------------------------------------------------

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -28,13 +28,13 @@ defmodule AshNeo4j.QueryHelper do
 
   defp run_simple_query(ash_query) do
     mapping = ResourceInfo.mapping(ash_query.resource)
+    terms = sort_terms(ash_query, mapping)
 
     query =
       ash_query
       |> build_query(mapping)
-      |> Query.add_order_by(sort_terms(ash_query, mapping))
-      |> Query.add_skip(ash_query.offset)
-      |> Query.add_limit(ash_query.limit)
+      |> Query.paginate_nodes(terms, ash_query.offset, ash_query.limit)
+      |> Query.add_order_by(terms)
 
     run_cypher_query(query)
   end
@@ -62,12 +62,13 @@ defmodule AshNeo4j.QueryHelper do
         build_branch_query(branch_dl_query, mapping, "b#{idx}_", :nodes)
       end)
 
+    terms = sort_terms(ash_query, mapping)
+
     query =
       branch_queries
       |> Query.combination_block(union_type: union_type)
-      |> Query.add_order_by(sort_terms(ash_query, mapping))
-      |> Query.add_skip(ash_query.offset)
-      |> Query.add_limit(ash_query.limit)
+      |> Query.paginate_nodes(terms, ash_query.offset, ash_query.limit)
+      |> Query.add_order_by(terms)
 
     run_cypher_query(query)
   end
@@ -98,12 +99,13 @@ defmodule AshNeo4j.QueryHelper do
         if keep_ids == [] do
           {:ok, []}
         else
+          terms = sort_terms(ash_query, mapping)
+
           final =
             mapping.label_pair
             |> Query.node_read_by_ids(keep_ids)
-            |> Query.add_order_by(sort_terms(ash_query, mapping))
-            |> Query.add_skip(ash_query.offset)
-            |> Query.add_limit(ash_query.limit)
+            |> Query.paginate_nodes(terms, ash_query.offset, ash_query.limit)
+            |> Query.add_order_by(terms)
 
           run_cypher_query(final)
         end

--- a/test/cypher_test.exs
+++ b/test/cypher_test.exs
@@ -325,4 +325,80 @@ defmodule AshNeo4j.CypherTest do
       assert miss.results == []
     end
   end
+
+  # The node-read shapes RETURN one row per edge (OPTIONAL MATCH (s)-[r]-(d)).
+  # A trailing SKIP/LIMIT would truncate *edges*, not *nodes* — silently dropping
+  # relationships (e.g. a belongs_to edge) from any node with more edges than the
+  # limit. paginate_nodes/4 must scope SKIP/LIMIT to the distinct source nodes,
+  # ahead of the edge expansion. Regression for #285.
+  describe "paginate_nodes — pagination is scoped to nodes, not edge rows" do
+    alias AshNeo4j.Cypher.Query
+
+    test "node_read with a limit puts LIMIT on the nodes before the edge expansion" do
+      {cypher, _} =
+        Query.node_read(:Thing)
+        |> Query.paginate_nodes([], 0, 2)
+        |> Query.add_order_by([])
+        |> Cypher.render()
+
+      assert cypher == "MATCH (s:Thing) WITH s LIMIT 2 OPTIONAL MATCH (s)-[r]-(d) RETURN s, r, d"
+      # the LIMIT must precede the edge expansion, never truncate the RETURN rows
+      [pre, _post] = String.split(cypher, "OPTIONAL MATCH", parts: 2)
+      assert pre =~ "LIMIT 2"
+      refute String.ends_with?(cypher, "LIMIT 2")
+    end
+
+    test "node_read_filtered keeps the WHERE and scopes pagination to nodes" do
+      {cypher, _} =
+        Query.node_read_filtered(:Thing, [{"uuid", :==, "x", false}])
+        |> Query.paginate_nodes([], 0, 2)
+        |> Query.add_order_by([])
+        |> Cypher.render()
+
+      assert cypher ==
+               "MATCH (s:Thing) WHERE s.uuid = $s_uuid_0 WITH s LIMIT 2 OPTIONAL MATCH (s)-[r]-(d) RETURN s, r, d"
+    end
+
+    test "sort + skip + limit orders/paginates nodes, with a trailing ORDER BY for output order" do
+      {cypher, _} =
+        Query.node_read(:Thing)
+        |> Query.paginate_nodes([{"name", :asc}], 5, 10)
+        |> Query.add_order_by([{"name", :asc}])
+        |> Cypher.render()
+
+      assert cypher ==
+               "MATCH (s:Thing) WITH s ORDER BY s.name ASC SKIP 5 LIMIT 10 " <>
+                 "OPTIONAL MATCH (s)-[r]-(d) RETURN s, r, d ORDER BY s.name ASC"
+    end
+
+    test "sort alone (no skip/limit) is a no-op for paginate_nodes — trailing ORDER BY only" do
+      {cypher, _} =
+        Query.node_read(:Thing)
+        |> Query.paginate_nodes([{"name", :asc}], 0, nil)
+        |> Query.add_order_by([{"name", :asc}])
+        |> Cypher.render()
+
+      assert cypher == "MATCH (s:Thing) OPTIONAL MATCH (s)-[r]-(d) RETURN s, r, d ORDER BY s.name ASC"
+    end
+
+    test "relationship_read reuses its existing WITH s rather than adding a second" do
+      {cypher, _} =
+        Query.relationship_read(:Thing, :HAS, :outgoing, :ThingTag, "uuid", :==, "x")
+        |> Query.paginate_nodes([], 0, 2)
+        |> Query.add_order_by([])
+        |> Cypher.render()
+
+      assert cypher ==
+               "MATCH (s:Thing)-[r:HAS]->(d:ThingTag) WHERE d.uuid = $d_uuid WITH s LIMIT 2 " <>
+                 "MATCH (s)-[r0]-(d0) RETURN s, r0, d0"
+
+      refute cypher =~ "WITH s WITH s"
+    end
+
+    test "no pagination and no sort leaves the query untouched" do
+      base = Query.node_read(:Thing)
+      assert Query.paginate_nodes(base, [], 0, nil) == base
+      assert Query.paginate_nodes(base, [], nil, nil) == base
+    end
+  end
 end

--- a/test/support/resource/thing.ex
+++ b/test/support/resource/thing.ex
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Test.Resource.Thing do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshNeo4j.Test.SRM,
+    extensions: [AshStateMachine],
+    data_layer: AshNeo4j.DataLayer
+
+  neo4j do
+    label :Thing
+
+    relate [
+      {:category, :CATEGORISED_BY, :outgoing, :ThingCategory},
+      {:tags, :HAS, :outgoing, :ThingTag},
+      {:notes, :HAS, :outgoing, :ThingNote}
+    ]
+  end
+
+  state_machine do
+    initial_states([:initial])
+    default_initial_state(:initial)
+    state_attribute(:state)
+
+    transitions do
+      transition(:activate, from: :initial, to: [:active])
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy]
+
+    create :create do
+      primary? true
+
+      argument :category_id, :uuid
+      argument :tags, {:array, :uuid}
+      argument :notes, {:array, :uuid}
+
+      change manage_relationship(:category_id, :category, type: :append)
+      change manage_relationship(:tags, type: :append)
+      change manage_relationship(:notes, type: :append)
+    end
+
+    update :activate do
+      change transition_state(:active)
+    end
+  end
+
+  attributes do
+    uuid_primary_key :id, writable?: true
+    attribute :name, :string, public?: true
+  end
+
+  relationships do
+    belongs_to :category, AshNeo4j.Test.Resource.ThingCategory, public?: true
+    has_many :tags, AshNeo4j.Test.Resource.ThingTag, destination_attribute: :thing_id, public?: true
+    has_many :notes, AshNeo4j.Test.Resource.ThingNote, destination_attribute: :thing_id, public?: true
+  end
+end

--- a/test/support/resource/thing_category.ex
+++ b/test/support/resource/thing_category.ex
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Test.Resource.ThingCategory do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshNeo4j.Test.SRM,
+    data_layer: AshNeo4j.DataLayer
+
+  neo4j do
+    label :ThingCategory
+  end
+
+  actions do
+    default_accept :*
+    defaults [:read, :create, :destroy]
+  end
+
+  attributes do
+    uuid_primary_key :id, writable?: true
+    attribute :name, :string, public?: true
+  end
+end

--- a/test/support/resource/thing_note.ex
+++ b/test/support/resource/thing_note.ex
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Test.Resource.ThingNote do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshNeo4j.Test.SRM,
+    data_layer: AshNeo4j.DataLayer
+
+  neo4j do
+    label :ThingNote
+    relate [{:thing, :HAS, :incoming, :Thing}]
+    skip [:thing_id]
+  end
+
+  actions do
+    default_accept :*
+    defaults [:read, :create, :destroy, update: :*]
+  end
+
+  attributes do
+    uuid_primary_key :id, writable?: true
+    attribute :body, :string, public?: true
+    attribute :thing_id, :uuid, public?: true
+  end
+
+  relationships do
+    belongs_to :thing, AshNeo4j.Test.Resource.Thing, public?: true
+  end
+end

--- a/test/support/resource/thing_tag.ex
+++ b/test/support/resource/thing_tag.ex
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Test.Resource.ThingTag do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshNeo4j.Test.SRM,
+    data_layer: AshNeo4j.DataLayer
+
+  neo4j do
+    label :ThingTag
+    relate [{:thing, :HAS, :incoming, :Thing}]
+    skip [:thing_id]
+  end
+
+  actions do
+    default_accept :*
+    defaults [:read, :create, :destroy, update: :*]
+  end
+
+  attributes do
+    uuid_primary_key :id, writable?: true
+    attribute :value, :string, public?: true
+    attribute :thing_id, :uuid, public?: true
+  end
+
+  relationships do
+    belongs_to :thing, AshNeo4j.Test.Resource.Thing, public?: true
+  end
+end

--- a/test/thing_test.exs
+++ b/test/thing_test.exs
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.ThingTest do
+  @moduledoc false
+  use ExUnit.Case, async: false
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.Thing
+  alias AshNeo4j.Test.Resource.ThingCategory
+  alias AshNeo4j.Test.Resource.ThingNote
+  alias AshNeo4j.Test.Resource.ThingTag
+  require Ash.Query
+
+  setup_all do
+    BoltyHelper.start()
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  test "loading a belongs_to returns it when the node has >=2 same-label collection edges (#285)" do
+    cat = ThingCategory |> Ash.create!(%{name: "c"})
+    tags = for i <- 1..3, do: ThingTag |> Ash.create!(%{value: "t#{i}"})
+    notes = for i <- 1..3, do: ThingNote |> Ash.create!(%{body: "n#{i}"})
+
+    thing =
+      Thing
+      |> Ash.create!(
+        %{
+          category_id: cat.id,
+          tags: Enum.map(tags, & &1.id),
+          notes: Enum.map(notes, & &1.id)
+        },
+        action: :create
+      )
+
+    # The :CATEGORISED_BY edge is present in the graph
+    assert AshNeo4j.Neo4jHelper.nodes_relate_how?(
+             :Thing,
+             %{uuid: thing.id},
+             :ThingCategory,
+             %{uuid: cat.id},
+             :CATEGORISED_BY,
+             :outgoing
+           )
+
+    # Loading only :category must surface it — read-path must not be truncated
+    # by a row LIMIT that lands on the edge-expanded result.
+    reloaded = Ash.get!(Thing, thing.id, load: [:category])
+
+    assert reloaded.category != nil, "reloaded.category came back nil (read-path truncated by LIMIT)"
+    assert reloaded.category.id == cat.id
+  end
+
+  test "a row LIMIT counts distinct nodes, not edge rows (#285)" do
+    # Each Thing carries several edges (category + 2 tags + 2 notes = 5 edges).
+    # The node read RETURNs one row per edge, so a LIMIT applied to those rows
+    # would be swallowed by a single node's edges and return fewer than `limit`
+    # distinct nodes. This is deterministic regardless of Neo4j edge ordering.
+    for n <- 1..3 do
+      cat = ThingCategory |> Ash.create!(%{name: "c#{n}"})
+      tags = for i <- 1..2, do: ThingTag |> Ash.create!(%{value: "t#{n}-#{i}"})
+      notes = for i <- 1..2, do: ThingNote |> Ash.create!(%{body: "no#{n}-#{i}"})
+
+      Thing
+      |> Ash.create!(
+        %{category_id: cat.id, tags: Enum.map(tags, & &1.id), notes: Enum.map(notes, & &1.id)},
+        action: :create
+      )
+    end
+
+    results = Thing |> Ash.Query.limit(3) |> Ash.read!()
+
+    assert length(results) == 3, "expected 3 distinct nodes, got #{length(results)} (LIMIT truncated edge rows)"
+  end
+end


### PR DESCRIPTION
Node reads RETURN one row per edge (`OPTIONAL MATCH (s)-[r]-(d) RETURN s, r, d`), but SKIP/LIMIT/ORDER BY were appended after the RETURN — so the limit truncated edges, not nodes. `Ash.get` reads with `LIMIT 2`, so any node with >=3 edges lost an edge row; when the dropped row was the belongs_to edge, the relationship resolved to nil on load even though the edge was present in the graph. Which edge dropped is Neo4j storage-order dependent, which is why the same topology reproduced in one graph but not another.

Add `Query.paginate_nodes/4`, which inserts
`WITH s [ORDER BY ...] [SKIP ...] [LIMIT ...]` ahead of the edge expansion so pagination is scoped to the distinct source nodes; a trailing `add_order_by/2` preserves output ordering. Wire it into all three read paths (simple, native-combination, in-memory combination). This also fixes the same latent bug in `relationship_read` (reusing its existing `WITH s`), and leaves `match_nodes`/`read_limited` (no edge expansion) untouched.

Regression tests: render-level assertions pinning the `WITH s ... LIMIT` placement for each read shape, and an order-independent end-to-end test (read with `limit: 3` over nodes with >=3 edges each must return 3 distinct nodes — fails pre-fix with 1).