### PR TITLE
fix: clear geo companions when a geo attribute is cleared to nil (#283)

### DIFF
--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -638,7 +638,10 @@ defmodule AshNeo4j.Cypher.Query do
     {props_cypher, set_params} = Cypher.parameterized_properties(:n, set_props)
 
     set_clauses = if map_size(set_props) > 0, do: [%Set{expression: "n += #{props_cypher}"}], else: []
-    remove_clauses = if remove_props != [], do: [%Remove{items: Enum.map(remove_props, &"n.#{&1}")}], else: []
+    remove_clauses =
+      if remove_props != [],
+        do: [%Remove{items: Enum.map(remove_props, &"n.#{Cypher.quote_if_dotted(&1)}")}],
+        else: []
 
     %__MODULE__{
       clauses: [%Match{pattern: match_pattern}] ++ set_clauses ++ remove_clauses ++ [%Return{items: ["n"]}],

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -375,7 +375,7 @@ defmodule AshNeo4j.DataLayer do
 
     update_properties = dump_properties(mapping, changeset.attributes)
 
-    remove_property_names = remove_property_names(mapping, changeset.attributes)
+    remove_property_names = remove_property_names(mapping, changeset.attributes, changeset.data)
 
     property_update_result =
       if !Enum.empty?(update_properties) or !Enum.empty?(remove_property_names) do
@@ -1047,11 +1047,61 @@ defmodule AshNeo4j.DataLayer do
     end
   end
 
-  defp remove_property_names(%ResourceMapping{} = mapping, map) when is_map(map) do
+  defp remove_property_names(%ResourceMapping{} = mapping, map, data) when is_map(map) do
     map
-    |> Map.reject(fn {_k, v} -> v != nil end)
-    |> Enum.into([], fn {field, _} -> Keyword.get(mapping.properties, field, nil) end)
-    |> Enum.reject(fn field -> field == nil end)
+    |> Enum.filter(fn {_field, value} -> is_nil(value) end)
+    |> Enum.flat_map(fn {field, _} ->
+      case Keyword.get(mapping.properties, field) do
+        nil -> []
+        translated_key -> removal_property_names(mapping, field, translated_key, data)
+      end
+    end)
+  end
+
+  # The on-disk property names to REMOVE when `field` is being cleared to nil.
+  #
+  # A geo-classified attribute stores no bare property — only companions
+  # (`<attr>.json` plus `<attr>.point` for a Point, or `<attr>.bbSW`/`<attr>.bbNE`
+  # for other geometries — see promote_geo/3). Removing the bare key (the old
+  # behaviour) therefore cleared nothing and the next read reconstructed the
+  # geometry from the still-present companions. Remove every companion variant;
+  # REMOVE of an absent property is a no-op, so this is safe regardless of which
+  # geometry kind was stored.
+  #
+  # A non-geo attribute clears at its bare key, but may also have promoted
+  # indexable companions for any nested %Geo.*{} structs (see dump_properties'
+  # geo_walk branch). The new value is nil, so dump_properties writes no fresh
+  # companions — the stale ones from the *old* value must be removed too, at
+  # their dotted paths.
+  defp removal_property_names(%ResourceMapping{} = mapping, field, translated_key, data) do
+    attribute = Ash.Resource.Info.attribute(mapping.module, field)
+
+    case attribute && TypeClassifier.classify(Ash.Type.get_type!(attribute.type)) do
+      {:ok, :geo, _} ->
+        [
+          "#{translated_key}.json",
+          "#{translated_key}.point",
+          "#{translated_key}.bbSW",
+          "#{translated_key}.bbNE"
+        ]
+
+      _ ->
+        nested =
+          data
+          |> Map.get(field)
+          |> geo_walk([translated_key])
+          |> Enum.flat_map(fn {path, geo} -> nested_companion_names(Enum.join(path, "."), geo) end)
+
+        [translated_key | nested]
+    end
+  end
+
+  # The indexable companion property names promoted for a nested %Geo.*{}
+  # (mirrors promote_geo_indexable/3).
+  defp nested_companion_names(path, %Geo.Point{}), do: ["#{path}.point"]
+
+  defp nested_companion_names(path, %_{} = geo) do
+    if AshGeo.is_geo(geo.__struct__), do: ["#{path}.bbSW", "#{path}.bbNE"], else: []
   end
 
   def cast_attribute(_resource, _name, nil) do

--- a/test/geo_nil_clear_test.exs
+++ b/test/geo_nil_clear_test.exs
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.GeoNilClearTest do
+  @moduledoc """
+  Updating an `AshGeo.GeoJson` attribute to `nil` must clear all of its on-disk
+  companions (`<attr>.json` plus `<attr>.point` for a Point, or
+  `<attr>.bbSW`/`<attr>.bbNE` for other geometries). Regression for #283 — under
+  0.8.0 the companions were left on the node, so the next read reconstructed the
+  geometry and `record.<attr>` came back non-nil.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Cypher
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.Place
+  require Ash.Query
+
+  setup_all do
+    BoltyHelper.start()
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  defp companions(id) do
+    {:ok, %Bolty.Response{results: [row]}} =
+      Cypher.run(
+        """
+        MATCH (n:Place {uuid: $id})
+        RETURN n.`location.json` AS json, n.`location.point` AS point,
+               n.`bounds.json` AS bjson, n.`bounds.bbSW` AS bbsw, n.`bounds.bbNE` AS bbne
+        """,
+        %{"id" => id}
+      )
+
+    row
+  end
+
+  test "clearing a Point attribute to nil removes .json and .point companions (#283)" do
+    place = Place |> Ash.create!(%{location: %Geo.Point{coordinates: {151.25, -33.75}, srid: 4326}})
+
+    row = companions(place.id)
+    assert row["json"] != nil
+    assert row["point"] != nil
+
+    Place |> Ash.get!(place.id) |> Ash.update!(%{location: nil})
+
+    row = companions(place.id)
+    assert row["json"] == nil, "location.json companion was left on the node"
+    assert row["point"] == nil, "location.point companion was left on the node"
+
+    reloaded = Ash.get!(Place, place.id)
+    assert reloaded.location == nil
+  end
+
+  test "clearing a Polygon attribute to nil removes .json, .bbSW and .bbNE companions (#283)" do
+    polygon = %Geo.Polygon{
+      coordinates: [[{151.0, -34.0}, {151.5, -34.0}, {151.5, -33.5}, {151.0, -33.5}, {151.0, -34.0}]],
+      srid: 4326
+    }
+
+    place = Place |> Ash.create!(%{bounds: polygon})
+
+    row = companions(place.id)
+    assert row["bjson"] != nil
+    assert row["bbsw"] != nil
+    assert row["bbne"] != nil
+
+    Place |> Ash.get!(place.id) |> Ash.update!(%{bounds: nil})
+
+    row = companions(place.id)
+    assert row["bjson"] == nil, "bounds.json companion was left on the node"
+    assert row["bbsw"] == nil, "bounds.bbSW companion was left on the node"
+    assert row["bbne"] == nil, "bounds.bbNE companion was left on the node"
+
+    reloaded = Ash.get!(Place, place.id)
+    assert reloaded.bounds == nil
+  end
+
+  test "clearing a non-geo attribute with nested promoted geo removes the dotted sidecar (#283)" do
+    pet = %AshNeo4j.Test.Type.LocatedDogTypedStruct{
+      name: "Rex",
+      breed: :kelpie,
+      home: %Geo.Point{coordinates: {151.2, -33.8}, srid: 4326}
+    }
+
+    place = Place |> Ash.create!(%{pet: pet})
+
+    {:ok, %Bolty.Response{results: [before]}} =
+      Cypher.run(
+        "MATCH (n:Place {uuid: $id}) RETURN n.pet AS pet, n.`pet.home.point` AS sidecar",
+        %{"id" => place.id}
+      )
+
+    assert before["pet"] != nil
+    assert before["sidecar"] != nil
+
+    Place |> Ash.get!(place.id) |> Ash.update!(%{pet: nil})
+
+    {:ok, %Bolty.Response{results: [after_nil]}} =
+      Cypher.run(
+        "MATCH (n:Place {uuid: $id}) RETURN n.pet AS pet, n.`pet.home.point` AS sidecar",
+        %{"id" => place.id}
+      )
+
+    assert after_nil["pet"] == nil
+    assert after_nil["sidecar"] == nil, "pet.home.point sidecar was left on the node"
+
+    assert Ash.get!(Place, place.id).pet == nil
+  end
+
+  test "transitioning location -> bounds in one update clears the old location on disk (#283)" do
+    polygon = %Geo.Polygon{
+      coordinates: [[{151.0, -34.0}, {151.5, -34.0}, {151.5, -33.5}, {151.0, -33.5}, {151.0, -34.0}]],
+      srid: 4326
+    }
+
+    place = Place |> Ash.create!(%{location: %Geo.Point{coordinates: {151.25, -33.75}, srid: 4326}})
+
+    Place |> Ash.get!(place.id) |> Ash.update!(%{location: nil, bounds: polygon})
+
+    row = companions(place.id)
+    assert row["json"] == nil
+    assert row["point"] == nil
+    assert row["bbsw"] != nil
+
+    reloaded = Ash.get!(Place, place.id)
+    assert reloaded.location == nil
+    refute is_nil(reloaded.bounds)
+  end
+end

--- a/test/support/resource/place.ex
+++ b/test/support/resource/place.ex
@@ -10,7 +10,7 @@ defmodule AshNeo4j.Test.Resource.Place do
 
   actions do
     default_accept :*
-    defaults [:read, :create, :destroy]
+    defaults [:read, :create, :destroy, update: :*]
   end
 
   attributes do


### PR DESCRIPTION
remove_property_names emitted only the bare attribute name, but a geo attribute stores nothing there — its data lives at <attr>.json plus <attr>.point (Point) or <attr>.bbSW/<attr>.bbNE (other geometries). So REMOVE n.<attr> matched nothing and every companion survived; the next read reconstructed the geometry and the attribute came back non-nil. A non-geo attribute with nested promoted geo leaked its dotted indexable sidecar the same way. update_node's REMOVE also didn't backtick-escape dotted keys, so a dotted companion name would render as nested access and miss.

Expand a nil geo attribute to all its companions, and for a non-geo attribute geo_walk the old value (changeset.data) to remove any nested sidecars; escape dotted REMOVE keys via quote_if_dotted, mirroring SET. REMOVE of an absent property is a no-op, so covering every variant is safe.