### PR TITLE
fix: drop stale geo companions when a geo value changes shape (#287)

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -375,7 +375,7 @@ defmodule AshNeo4j.DataLayer do
 
     update_properties = dump_properties(mapping, changeset.attributes)
 
-    remove_property_names = remove_property_names(mapping, changeset.attributes, changeset.data)
+    remove_property_names = stale_property_names(mapping, update_properties, changeset)
 
     property_update_result =
       if !Enum.empty?(update_properties) or !Enum.empty?(remove_property_names) do
@@ -1047,61 +1047,28 @@ defmodule AshNeo4j.DataLayer do
     end
   end
 
-  defp remove_property_names(%ResourceMapping{} = mapping, map, data) when is_map(map) do
-    map
-    |> Enum.filter(fn {_field, value} -> is_nil(value) end)
-    |> Enum.flat_map(fn {field, _} ->
-      case Keyword.get(mapping.properties, field) do
-        nil -> []
-        translated_key -> removal_property_names(mapping, field, translated_key, data)
-      end
-    end)
-  end
-
-  # The on-disk property names to REMOVE when `field` is being cleared to nil.
+  # Property names to REMOVE on update: those the OLD value of each changed
+  # attribute occupied that the NEW value no longer writes. Diffing the dumped
+  # property KEYS of old vs new keeps removal exactly consistent with the write
+  # path (dump_properties/2), and covers every companion-shape mismatch with one
+  # mechanism:
   #
-  # A geo-classified attribute stores no bare property — only companions
-  # (`<attr>.json` plus `<attr>.point` for a Point, or `<attr>.bbSW`/`<attr>.bbNE`
-  # for other geometries — see promote_geo/3). Removing the bare key (the old
-  # behaviour) therefore cleared nothing and the next read reconstructed the
-  # geometry from the still-present companions. Remove every companion variant;
-  # REMOVE of an absent property is a no-op, so this is safe regardless of which
-  # geometry kind was stored.
+  #   * cleared to nil           — the new value writes nothing, so every old key
+  #                                goes, including geo companions (#283)
+  #   * geometry kind changed    — a Point's `<attr>.point` and an area's
+  #                                `<attr>.bbSW`/`<attr>.bbNE` swap out (#287)
+  #   * nested geo added/removed — dotted `<attr>.<path>.point|bbSW|bbNE`
+  #                                companions the new value no longer promotes (#287)
   #
-  # A non-geo attribute clears at its bare key, but may also have promoted
-  # indexable companions for any nested %Geo.*{} structs (see dump_properties'
-  # geo_walk branch). The new value is nil, so dump_properties writes no fresh
-  # companions — the stale ones from the *old* value must be removed too, at
-  # their dotted paths.
-  defp removal_property_names(%ResourceMapping{} = mapping, field, translated_key, data) do
-    attribute = Ash.Resource.Info.attribute(mapping.module, field)
+  # Only changed attributes are considered (unchanged ones keep their companions).
+  # REMOVE of an absent property is a no-op; a key present in both old and new is
+  # left in place for SET (`n += {…}`) to overwrite.
+  defp stale_property_names(%ResourceMapping{} = mapping, new_properties, changeset)
+       when is_map(new_properties) do
+    old_properties =
+      dump_properties(mapping, Map.take(changeset.data, Map.keys(changeset.attributes)))
 
-    case attribute && TypeClassifier.classify(Ash.Type.get_type!(attribute.type)) do
-      {:ok, :geo, _} ->
-        [
-          "#{translated_key}.json",
-          "#{translated_key}.point",
-          "#{translated_key}.bbSW",
-          "#{translated_key}.bbNE"
-        ]
-
-      _ ->
-        nested =
-          data
-          |> Map.get(field)
-          |> geo_walk([translated_key])
-          |> Enum.flat_map(fn {path, geo} -> nested_companion_names(Enum.join(path, "."), geo) end)
-
-        [translated_key | nested]
-    end
-  end
-
-  # The indexable companion property names promoted for a nested %Geo.*{}
-  # (mirrors promote_geo_indexable/3).
-  defp nested_companion_names(path, %Geo.Point{}), do: ["#{path}.point"]
-
-  defp nested_companion_names(path, %_{} = geo) do
-    if AshGeo.is_geo(geo.__struct__), do: ["#{path}.bbSW", "#{path}.bbNE"], else: []
+    Map.keys(old_properties) -- Map.keys(new_properties)
   end
 
   def cast_attribute(_resource, _name, nil) do

--- a/test/geo_type_change_test.exs
+++ b/test/geo_type_change_test.exs
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.GeoTypeChangeTest do
+  @moduledoc """
+  Updating a geo attribute to a value with a *different* companion shape must
+  drop the companions the new value no longer writes. Regression for #287 —
+  under 0.8.0 `SET n += {…}` overwrote same-named companions but never removed
+  the ones that no longer applied, so a Point↔area transition (on a multi-kind
+  attribute) left a stale indexable companion, and a nested geo field going from
+  present to absent left a stale dotted sidecar. The canonical `<attr>.json` is
+  always overwritten, so the read value is correct — the danger is a stale
+  indexable companion corrupting spatial pushdown / a POINT index.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Cypher
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.Place
+  require Ash.Query
+
+  setup_all do
+    BoltyHelper.start()
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  defp shape_companions(id) do
+    {:ok, %Bolty.Response{results: [row]}} =
+      Cypher.run(
+        """
+        MATCH (n:Place {uuid: $id})
+        RETURN n.`shape.json` AS json, n.`shape.point` AS point,
+               n.`shape.bbSW` AS bbsw, n.`shape.bbNE` AS bbne
+        """,
+        %{"id" => id}
+      )
+
+    row
+  end
+
+  defp point, do: %Geo.Point{coordinates: {151.25, -33.75}, srid: 4326}
+
+  defp polygon do
+    %Geo.Polygon{
+      coordinates: [[{151.0, -34.0}, {151.5, -34.0}, {151.5, -33.5}, {151.0, -33.5}, {151.0, -34.0}]],
+      srid: 4326
+    }
+  end
+
+  test "Point -> area drops the stale .point companion (#287)" do
+    place = Place |> Ash.create!(%{shape: point()})
+
+    row = shape_companions(place.id)
+    assert row["point"] != nil
+    assert row["bbsw"] == nil
+
+    Place |> Ash.get!(place.id) |> Ash.update!(%{shape: polygon()})
+
+    row = shape_companions(place.id)
+    assert row["point"] == nil, "stale shape.point left after Point -> area"
+    assert row["bbsw"] != nil
+    assert row["bbne"] != nil
+    assert row["json"] != nil
+
+    assert %Geo.Polygon{} = Ash.get!(Place, place.id).shape
+  end
+
+  test "area -> Point drops the stale .bbSW/.bbNE companions (#287)" do
+    place = Place |> Ash.create!(%{shape: polygon()})
+
+    row = shape_companions(place.id)
+    assert row["bbsw"] != nil
+    assert row["point"] == nil
+
+    Place |> Ash.get!(place.id) |> Ash.update!(%{shape: point()})
+
+    row = shape_companions(place.id)
+    assert row["bbsw"] == nil, "stale shape.bbSW left after area -> Point"
+    assert row["bbne"] == nil, "stale shape.bbNE left after area -> Point"
+    assert row["point"] != nil
+    assert row["json"] != nil
+
+    assert %Geo.Point{} = Ash.get!(Place, place.id).shape
+  end
+
+  test "same-family change (Polygon -> different Polygon) keeps companions, only values change (#287)" do
+    place = Place |> Ash.create!(%{shape: polygon()})
+
+    bigger = %Geo.Polygon{
+      coordinates: [[{150.0, -35.0}, {152.0, -35.0}, {152.0, -33.0}, {150.0, -33.0}, {150.0, -35.0}]],
+      srid: 4326
+    }
+
+    Place |> Ash.get!(place.id) |> Ash.update!(%{shape: bigger})
+
+    row = shape_companions(place.id)
+    assert row["point"] == nil
+    assert row["bbsw"] != nil
+    assert row["bbne"] != nil
+    assert %Geo.Polygon{} = Ash.get!(Place, place.id).shape
+  end
+
+  test "nested geo field removed drops its stale dotted sidecar (#287)" do
+    with_home = %AshNeo4j.Test.Type.LocatedDogTypedStruct{
+      name: "Rex",
+      breed: :kelpie,
+      home: %Geo.Point{coordinates: {151.2, -33.8}, srid: 4326}
+    }
+
+    place = Place |> Ash.create!(%{pet: with_home})
+
+    {:ok, %Bolty.Response{results: [before]}} =
+      Cypher.run("MATCH (n:Place {uuid: $id}) RETURN n.`pet.home.point` AS sidecar", %{"id" => place.id})
+
+    assert before["sidecar"] != nil
+
+    without_home = %AshNeo4j.Test.Type.LocatedDogTypedStruct{name: "Rex", breed: :kelpie, home: nil}
+    Place |> Ash.get!(place.id) |> Ash.update!(%{pet: without_home})
+
+    {:ok, %Bolty.Response{results: [after_change]}} =
+      Cypher.run(
+        "MATCH (n:Place {uuid: $id}) RETURN n.pet AS pet, n.`pet.home.point` AS sidecar",
+        %{"id" => place.id}
+      )
+
+    assert after_change["pet"] != nil, "pet json should still be present"
+    assert after_change["sidecar"] == nil, "stale pet.home.point left after the nested home was cleared"
+
+    assert Ash.get!(Place, place.id).pet.home == nil
+  end
+end

--- a/test/support/resource/place.ex
+++ b/test/support/resource/place.ex
@@ -44,6 +44,11 @@ defmodule AshNeo4j.Test.Resource.Place do
       public?: true,
       constraints: [geo_types: [:multi_line_string], force_srid: 4326]
 
+    # #287 — a multi-kind geo attribute (accepts any geometry) so tests can
+    # transition the same attribute across the Point / non-Point companion
+    # boundary and assert the stale indexable companion is removed.
+    attribute :shape, AshGeo.GeoAny, public?: true
+
     # Test fixture for #274's recursive geo-promotion: a TypedStruct
     # with a nested Geo field. The whole struct stores as JSON at
     # <attr>; the nested home Point's indexable companion gets


### PR DESCRIPTION
update_node writes companions with SET n += {…}, which overwrites same-named keys but never removes ones the new value no longer writes. So changing a geo attribute across the Point / non-Point boundary (on a multi-kind attribute) left a stale <attr>.point or <attr>.bbSW/<attr>.bbNE, and a nested geo field going from present to absent left a stale dotted <attr>.<path>.point sidecar. The canonical <attr>.json is always overwritten, so the read value stays correct — but the stale indexable companion corrupts spatial pushdown / POINT-index results.

Replace the nil-only removal (#283) with a diff of the dumped property KEYS of the old value (changeset.data) vs the new value: REMOVE the keys the old value occupied that the new value no longer writes. Diffing dumped keys keeps removal exactly consistent with the write path and handles clear-to-nil, geometry-kind change, and nested add/remove with one mechanism. Adds a multi-kind :shape attribute to the Place test fixture.