### PR TITLE
fix: use Code.ensure_compiled/1 to resolve domain fragment label unde…

### DIFF
--- a/lib/persisters/persist_labels.ex
+++ b/lib/persisters/persist_labels.ex
@@ -19,7 +19,7 @@ defmodule AshNeo4j.Persisters.PersistLabels do
     resource_label = Transformer.get_option(dsl, [:neo4j], :label, module_label)
 
     domain_fragment_label =
-      if Code.ensure_loaded?(domain_module) and
+      if match?({:module, _}, Code.ensure_compiled(domain_module)) and
            function_exported?(domain_module, :spark_dsl_config, 0) do
         case AshNeo4j.DataLayer.Domain.Info.neo4j_label(domain_module) do
           {:ok, label} -> label


### PR DESCRIPTION
…r any compilation order (#295)

Code.ensure_loaded?/1 only returns true if the module is already in the code server — it does not trigger compilation. When a resource module is compiled before its domain, the domain fragment label was silently missing from __ash_neo4j_mapping__/0 and all_labels. Replacing with Code.ensure_compiled/1 forces the domain to be compiled first if needed.