### PR TITLE
feat: vector embeddings — Types.Vector, similarity/distance search, index lifecycle (#74)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,17 @@ lib/
   cypher/query.ex              — Typed clause structs (Match, Where, Return, …) and builder
                                  functions for every query shape used by the data layer
   query_helper.ex              — Translates Ash.Query (filter, sort, offset, limit) into
-                                 a Cypher.Query; entry point is query_nodes/1
+                                 a Cypher.Query; entry point is query_nodes/1. sort_terms/2
+                                 pushes vector-similarity sorts into ORDER BY expressions
+  bolty_helper.ex              — Pool lifecycle + capability detection: current_pool/0,
+                                 with_pool/2, policy/1, cypher25?/1 (cached per pool)
+  error.ex                     — AshNeo4j.Error.RequiresCypher25
+  spatial.ex                   — AshNeo4j.Spatial: POINT index lifecycle (operator-invoked)
+  vector.ex                    — AshNeo4j.Vector: VECTOR index lifecycle (operator-invoked)
+  types/vector.ex              — AshNeo4j.Types.Vector: embedding attribute (LIST<FLOAT>)
+  functions/                   — Ash.Query.Function modules pushed down to Cypher:
+                                 st_* (spatial), vector_similarity / vector_cosine_distance,
+                                 and vector_math.ex (shared in-memory cosine for evaluate/1)
   resource/info.ex             — All DSL introspection: label/1, module_label/1, domain_label/1,
                                  domain_fragment_label/1, all_labels/1, label_pair/1,
                                  mapping/1, relate/1, translations/1, and relationship helpers
@@ -214,15 +224,37 @@ aggregate builders, use `labels_string/1` for the source pattern, not direct ato
 
 ## Running tests
 
-Tests require a running Neo4j instance (configured in `config/runtime.exs` via `BOLT_URL`
-or similar). `AshNeo4j.Sandbox` wraps each test in a transaction that rolls back on completion.
+Tests require a running Neo4j instance. Pools are configured in `config/test.exs` (the
+preferred config method — the old `BOLT_URL`-style env var is deprecated). The primary
+`Bolt` pool targets a Neo4j 5.x server; a second `Bolt6` pool targets Neo4j 2026.05 (Bolt
+6.0 / Cypher 25) for the version-gated tests. `AshNeo4j.Sandbox` wraps each test in a
+transaction that rolls back on completion.
 
 ```sh
-mix test                          # full suite
+mix test                          # full suite (excludes :show_neo4j, :bolt6, :cypher25)
 mix test test/blog_test.exs       # single file
 mix test test/blog_test.exs:LINE  # single test
 mix test --max-failures 5         # stop early
+mix test --include cypher25       # also run the Cypher 25 vector tests (needs the Bolt6 pool)
 ```
+
+### Pool routing and version tags
+
+The data layer talks to `AshNeo4j.BoltyHelper.current_pool/0` (default `Bolt`). A test routes
+its queries — and the `cypher25?/1` / `policy/1` capability checks — to another pool with
+`Process.put(:ash_neo4j_pool, Bolt6)` in `setup`, or `BoltyHelper.with_pool/2` for code in a
+separate process (e.g. an `on_exit`). The sandbox holder captures the pool at `checkout/0`.
+
+- `:cypher25` — needs a Neo4j ≥ 2025.06 server (the `Bolt6` pool). Tag vector/Cypher-25 tests
+  with it; excluded by default. Run `async: false` (the pool is small and the sandbox holds a
+  connection per test).
+- `:bolt6` — reserved for tests that genuinely require the Bolt 6.0 protocol (vectors do not —
+  see the vector gotcha below).
+
+**Start a long-lived pool from `test_helper.exs`, never a per-test `setup`.** `Bolty.start_link/1`
+links the pool to the calling process, so starting it inside a test ties the pool's lifetime to
+that one test — later tests then hit a dead pool (`:closed` / "no process"). `setup_all` is
+longer-lived than `setup` but `test_helper.exs` (whole-run) is the right place for a shared pool.
 
 The sandbox uses `Process` dictionary flags (`ash_neo4j_in_sandbox_tx`,
 `ash_neo4j_tx_stack`). Tests that bypass the sandbox or start their own transactions may
@@ -289,3 +321,22 @@ as a follow-up comment, then leave it with the upstream maintainers.
 - **Modifying `Cypher.render/1` to reorder clauses.** The clause list is ordered; render
   outputs them in insertion order. Query correctness depends on this ordering. Always add
   clauses in the correct semantic position in the builder, not in render.
+
+- **Giving a pushed-down query function an `evaluate/1` that returns `:unknown`.** The data
+  layer **always re-applies the filter in-memory** via `Ash.Filter.Runtime.filter_matches`
+  after the Cypher read (`filter_matches/3` in `DataLayer`) — the pushdown is treated as an
+  over-selecting prefilter. A custom `Ash.Query.Function` (e.g. `vector_similarity`) whose
+  `evaluate/1` returns `:unknown` will have all its filtered rows **dropped** by that re-filter,
+  even though the Cypher `WHERE` was correct (symptom: correct Cypher, empty result; a `sort`
+  using the same function still "works" because there's no filter to re-apply). Implement
+  `evaluate/1` to compute the real value, and make it **numerically match the pushdown** —
+  e.g. Neo4j's `vector.similarity.cosine` is normalised `(1 + raw_cosine)/2`, so the in-memory
+  cosine must use the same normalisation (`AshNeo4j.Functions.VectorMath`) or the re-filter
+  disagrees with the `WHERE` threshold.
+
+- **Storing a native `%Bolty.Types.Vector{}` as a node property.** Neo4j cannot persist the
+  Bolt 6.0 VECTOR type as a property — `CREATE (n {embedding: $vector})` errors. Embeddings are
+  stored as `LIST<FLOAT>` (`AshNeo4j.Types.Vector.dump_to_native/2`), which is what
+  `vector.similarity.cosine/2` operates on and what the vector index indexes. The native VECTOR
+  type is a query-parameter wire type only. Consequently vector search is gated on **Cypher 25
+  (≥ 2025.06)**, not Bolt 6.0 — it works over Bolt 5.8.

--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ setup do
 end
 ```
 
+### Targeting a second Neo4j (pool routing)
+
+The data layer talks to a configurable Bolty pool — `AshNeo4j.BoltyHelper.current_pool/0`, defaulting to `Bolt`. Override it per-process with `with_pool/2` (or `Process.put(:ash_neo4j_pool, Pool)`) to route a test's queries — and the `cypher25?/1` / `policy/1` capability checks — to a different server. AshNeo4j's own suite uses this to run Cypher-25 vector tests against a Neo4j 2026.05 pool (`Bolt6`) while the rest of the suite stays on a 5.x pool; those tests are tagged `:cypher25` and excluded by default. Start a long-lived pool from `test_helper.exs` (not a per-test `setup`) — `Bolty.start_link/1` links the pool to the calling process, so starting it inside a test ties the pool's lifetime to that one test. See `usage-rules/vectors.md`.
+
 ## Installing Neo4j and Configuring Bolty
 
 ash_neo4j uses [neo4j](https://github.com/neo4j/neo4j) which must be installed and running.
@@ -199,7 +203,17 @@ ash_neo4j uses [bolty](https://github./com/diffo-dev/bolty), a reluctant fork of
 
 Your Ash application needs to configure, start and supervise bolty see [bolty documentation](https://hexdocs.pm/bolty/). Make sure to configure any required authorisation.
 
-I've used a few Neo4j 5.x community edition's up to 5.6.22 (bolty limits to bolt 5.4). I've also used [DozerDB](https://dozerdb.org) 5.26.3 with multi-database. I don't recommend either Neo4j 4.x or Neo4 5.x with BOLT BOLT 4.x, while it *should* work I haven't regressioned tested these.
+Tested against Neo4j 5.26.x community (Bolt 5.x) and the calendar-versioned Neo4j 2026.05 community (Bolt 6.0), as well as [DozerDB](https://dozerdb.org) 5.26.x with multi-database. bolty `~> 0.1.0` negotiates Bolt 5.6–6.0 and drops the older Bolt 1–4.x protocols; Neo4j 4.x / Bolt 4.x are not supported.
+
+## Cypher 25 and Cypher 5
+
+Neo4j 2025.06 introduced **versioned Cypher**: the long-standing language is now **Cypher 5** (the default on Neo4j 5.x and on 2025.x servers), and **Cypher 25** is the new calendar-versioned language available from Neo4j 2025.06 onward. The two coexist on a 2025.06+ server and are selected per-query with a leading `CYPHER 5` / `CYPHER 25` clause.
+
+AshNeo4j detects the connected server version (from `Bolty.connection_info/1`'s `server_version`) and, on **Neo4j ≥ 2025.06**, automatically prepends `CYPHER 25 ` to every query so it runs against the Cypher 25 language. On older servers no prefix is emitted and queries run against the server default (Cypher 5). The result is cached per pool; `AshNeo4j.BoltyHelper.cypher25?/0` reports it.
+
+This is distinct from the **Bolt protocol** version (5.6–6.0) — the Bolt version is how the driver talks to the server, while Cypher 5 / 25 is the query language version. Some features require Cypher 25 regardless of Bolt version: for example vector similarity search (see `usage-rules/vectors.md`) needs Neo4j ≥ 2025.06 but works over Bolt 5.8. A feature that requires it calls `AshNeo4j.Cypher.require_cypher25!/0`, which raises `AshNeo4j.Error.RequiresCypher25` on an older server.
+
+> Until [bolty#47](https://github.com/diffo-dev/bolty/issues/47) adds a `cypher25` indicator to `Bolty.Policy`, AshNeo4j derives this from the `server_version` string (`"Neo4j/YYYY.MM.*"` ≥ `2025.06`).
 
 ## Elixir, Ash and Neo4j Types
 
@@ -236,6 +250,7 @@ We've made some decisions around how Ash/Elixir types are used to persist attrib
 | :utc_datetime_usec   | Ash.Type.UtcDatetimeUsec             | DateTime           | ~U[2025-05-11 07:45:41.429903Z]                         | 2025-05-11T07:45:41.429903000Z.                        | DATETIME       |
 | :uuid                | Ash.Type.UUID                        | BitString          | "0274972c-161c-4dc9-882f-6851704c2af9"                  | "0274972c-161c-4dc9-882f-6851704c2af9"                 | STRING         |
 | :uuid7               | Ash.Type.UUIDv7                      | BitString          | "019d85f7-8450-7695-9426-4ede74026140"                  | "019d85f7-8450-7695-9426-4ede74026140"                 | STRING         |
+| (vector embedding)   | AshNeo4j.Types.Vector                | List               | [0.12, -0.04, 0.98]                                     | [0.12, -0.04, 0.98]                                    | LIST<FLOAT>    |
 
 Ash :date, :datetime, :time and :naive_datetime are second precision, whereas :utc_datetime_usec and :time_usec are microsecond precision. Neo4j is capable of nanoseconds however Ash/Elixir is not. 
 
@@ -243,7 +258,7 @@ Struct is supported, however must implement Ash.Type. Ash arrays are supported a
 
 Ash.Type.NewType including Ash.TypedStruct are supported, as are embedded resources.
 
-Ash.Type.File, Ash.Type.Term and Ash.Type.Vector are not supported.
+Ash.Type.File and Ash.Type.Term are not supported. The built-in `Ash.Type.Vector` is also not supported — AshNeo4j ships its own `AshNeo4j.Types.Vector` for embeddings (stored as a Neo4j `LIST<FLOAT>`), with `vector_similarity` / `vector_cosine_distance` search expressions. See `usage-rules/vectors.md`.
 
 ## Storage Types
 
@@ -335,9 +350,11 @@ Only `expr(...)` calculations are currently supported. Custom `:calculate` callb
 
 ## Limitations and Future Work
 
-Ash Neo4j has support for Ash create, update, read, destroy actions, aggregates, and expression calculations. The cypher is now parameterised but is by no means optimised. The DSL is likely to evolve further and this may break back compatibility. Storage formats are subject to infrequent change so upgrade *may* require data migration (not included).
+Ash Neo4j has support for Ash create, update, read, destroy actions, aggregates, expression calculations, spatial types, and vector embeddings. The cypher is now parameterised but is by no means optimised. The DSL is likely to evolve further and this may break back compatibility. Storage formats are subject to infrequent change so upgrade *may* require data migration (not included).
 
-Future work may include: cached calculations and aggregates, vectors/semantic search, geospatial support.
+Vector similarity search is currently a full scan — Neo4j does not use the HNSW vector index for `vector.similarity.cosine` in a `WHERE`/`ORDER BY`. Indexed top-K (via `db.index.vector.queryNodes` / the Cypher 25 `SEARCH` clause) is tracked in [#297](https://github.com/diffo-dev/ash_neo4j/issues/297).
+
+Future work may include: cached calculations and aggregates, indexed vector/semantic search ([#297](https://github.com/diffo-dev/ash_neo4j/issues/297)), and broader geospatial support.
 
 Collaboration on ash_neo4j welcome via github, please use discussions and/or raise issues as you encounter them. If going straight for a PR, please include explanation and test cases.
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -25,7 +25,7 @@ config :bolty, Bolt,
   level: level
 
 config :bolty, Bolt6,
-  uri: "bolt://localhost:7690",
+  uri: "bolt://localhost:7689",
   auth: [username: "neo4j", password: "password"],
   versions: [6.0],
   user_agent: "boltyTest/1",

--- a/lib/bolty_helper.ex
+++ b/lib/bolty_helper.ex
@@ -37,6 +37,34 @@ defmodule AshNeo4j.BoltyHelper do
     end
   end
 
+  @default_pool Bolt
+
+  @doc """
+  The Bolty pool the data layer should use for the current process.
+
+  Defaults to the primary `Bolt` pool. Override per-process with `with_pool/2`
+  (or by setting `:ash_neo4j_pool` in the process dictionary) — used to route a
+  test's queries and capability checks to a different Neo4j server (e.g. the
+  Bolt 6.0 / Cypher 25 pool).
+  """
+  def current_pool(), do: Process.get(:ash_neo4j_pool, @default_pool)
+
+  @doc """
+  Runs `fun` with the data-layer pool overridden to `pool` for the current
+  process, restoring the previous value afterwards. Query execution and the
+  `policy/0` / `cypher25?/0` capability checks all follow the override.
+  """
+  def with_pool(pool, fun) when is_function(fun, 0) do
+    prev = Process.get(:ash_neo4j_pool)
+    Process.put(:ash_neo4j_pool, pool)
+
+    try do
+      fun.()
+    after
+      if prev, do: Process.put(:ash_neo4j_pool, prev), else: Process.delete(:ash_neo4j_pool)
+    end
+  end
+
   @doc """
   Checks Bolty connectivity
   """
@@ -49,15 +77,19 @@ defmodule AshNeo4j.BoltyHelper do
   end
 
   @doc """
-  Returns the negotiated `%Bolty.Policy{}` for the primary pool, or `nil` when
-  the pool is not yet started. Cached in `:persistent_term` after the first call.
+  Returns the negotiated `%Bolty.Policy{}` for the current pool (see
+  `current_pool/0`), or `nil` when that pool is not started. Cached per pool in
+  `:persistent_term` after the first call.
   """
-  def policy() do
-    case :persistent_term.get({__MODULE__, :policy}, :not_cached) do
+  def policy(), do: policy(current_pool())
+
+  @doc "Returns the `%Bolty.Policy{}` for an explicit `pool`, or `nil` when not started."
+  def policy(pool) do
+    case :persistent_term.get({__MODULE__, :policy, pool}, :not_cached) do
       :not_cached ->
         try do
-          %{policy: policy} = Bolty.connection_info(Bolt)
-          :persistent_term.put({__MODULE__, :policy}, policy)
+          %{policy: policy} = Bolty.connection_info(pool)
+          :persistent_term.put({__MODULE__, :policy, pool}, policy)
           policy
         catch
           :exit, _ -> nil
@@ -69,40 +101,23 @@ defmodule AshNeo4j.BoltyHelper do
   end
 
   @doc """
-  Returns the `%Bolty.Policy{}` for the Bolt6 pool, or `nil` when not started.
-  Cached separately from the primary pool policy.
-  """
-  def policy(:bolt6) do
-    case :persistent_term.get({__MODULE__, :policy_bolt6}, :not_cached) do
-      :not_cached ->
-        try do
-          %{policy: policy} = Bolty.connection_info(Bolt6)
-          :persistent_term.put({__MODULE__, :policy_bolt6}, policy)
-          policy
-        catch
-          :exit, _ -> nil
-        end
-
-      policy ->
-        policy
-    end
-  end
-
-  @doc """
-  Returns `true` when the primary pool is connected to a Neo4j server that
-  supports Cypher 25 (date-versioned Neo4j ≥ 2025.06).
+  Returns `true` when the current pool (see `current_pool/0`) is connected to a
+  Neo4j server that supports Cypher 25 (date-versioned Neo4j ≥ 2025.06).
 
   Derived from the `server_version` string in `Bolty.connection_info/1` and
-  cached in `:persistent_term`. Once diffo-dev/bolty#47 lands this can be
-  simplified to reading `policy().cypher25` directly.
+  cached per pool in `:persistent_term`. Once diffo-dev/bolty#47 lands this can
+  be simplified to reading `policy().cypher25` directly.
   """
-  def cypher25?() do
-    case :persistent_term.get({__MODULE__, :cypher25}, :not_cached) do
+  def cypher25?(), do: cypher25?(current_pool())
+
+  @doc "Cypher 25 support for an explicit `pool`."
+  def cypher25?(pool) do
+    case :persistent_term.get({__MODULE__, :cypher25, pool}, :not_cached) do
       :not_cached ->
         try do
-          %{server_version: server_version} = Bolty.connection_info(Bolt)
+          %{server_version: server_version} = Bolty.connection_info(pool)
           result = cypher25_from_server_version(server_version)
-          :persistent_term.put({__MODULE__, :cypher25}, result)
+          :persistent_term.put({__MODULE__, :cypher25, pool}, result)
           result
         catch
           :exit, _ -> false

--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -382,6 +382,17 @@ defmodule AshNeo4j.Cypher do
   end
 
   @doc """
+  Raises `AshNeo4j.Error.RequiresCypher25` when the connected server does not
+  support Cypher 25 (negotiated server version < 2025.06). Call at the top of
+  any function that emits Cypher 25-only syntax.
+  """
+  def require_cypher25!() do
+    unless BoltyHelper.cypher25?() do
+      raise AshNeo4j.Error.RequiresCypher25
+    end
+  end
+
+  @doc """
   Runs some cypher
 
   ## Examples
@@ -397,17 +408,6 @@ defmodule AshNeo4j.Cypher do
   :ok
   ```
   """
-  @doc """
-  Raises `AshNeo4j.Error.RequiresCypher25` when the connected server does not
-  support Cypher 25 (negotiated server version < 2025.06). Call at the top of
-  any function that emits Cypher 25-only syntax.
-  """
-  def require_cypher25!() do
-    unless BoltyHelper.cypher25?() do
-      raise AshNeo4j.Error.RequiresCypher25
-    end
-  end
-
   def run(%Query{} = query) do
     {cypher, params} = render(query)
     run(cypher, params)

--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -74,6 +74,8 @@ defmodule AshNeo4j.Cypher do
   "point.distance(n.location, $test_point) < $threshold"
   iex> AshNeo4j.Cypher.expression(:n, "location", "dwithin", {"$test_point", "$threshold"})
   "point.distance(n.location, $test_point) <= $threshold"
+  iex> AshNeo4j.Cypher.expression(:s, "embedding", "vector_similarity", {">", "$s_embedding_0_vec", "$s_embedding_0_t"})
+  "vector.similarity.cosine(s.embedding, $s_embedding_0_vec) > $s_embedding_0_t"
   ```
   """
   def expression(variable, left, operator, right, opts \\ [])
@@ -106,6 +108,10 @@ defmodule AshNeo4j.Cypher do
       operator == "dwithin" ->
         {test_ref, threshold_ref} = right
         "point.distance(#{variable}.#{quote_if_dotted(left)}, #{test_ref}) <= #{threshold_ref}"
+
+      operator == "vector_similarity" ->
+        {comp_op, vec_ref, threshold_ref} = right
+        "vector.similarity.cosine(#{variable}.#{left}, #{vec_ref}) #{comp_op} #{threshold_ref}"
 
       case_insensitive? ->
         "toLower(#{variable}.#{left}) #{String.upcase(operator)} toLower(#{right})"
@@ -362,8 +368,8 @@ defmodule AshNeo4j.Cypher do
   ```
   """
   @doc """
-  Raises `AshNeo4j.Error.RequiresCypher25` when the connected Neo4j server does
-  not support Cypher 25 (i.e. is older than 2025.06). Call this at the top of
+  Raises `AshNeo4j.Error.RequiresCypher25` when the connected server does not
+  support Cypher 25 (negotiated server version < 2025.06). Call at the top of
   any function that emits Cypher 25-only syntax.
   """
   def require_cypher25!() do

--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -76,6 +76,8 @@ defmodule AshNeo4j.Cypher do
   "point.distance(n.location, $test_point) <= $threshold"
   iex> AshNeo4j.Cypher.expression(:s, "embedding", "vector_similarity", {">", "$s_embedding_0_vec", "$s_embedding_0_t"})
   "vector.similarity.cosine(s.embedding, $s_embedding_0_vec) > $s_embedding_0_t"
+  iex> AshNeo4j.Cypher.expression(:s, "embedding", "vector_cosine_distance", {"<", "$s_embedding_0_vec", "$s_embedding_0_t"})
+  "(2.0 * (1.0 - vector.similarity.cosine(s.embedding, $s_embedding_0_vec))) < $s_embedding_0_t"
   ```
   """
   def expression(variable, left, operator, right, opts \\ [])
@@ -111,7 +113,11 @@ defmodule AshNeo4j.Cypher do
 
       operator == "vector_similarity" ->
         {comp_op, vec_ref, threshold_ref} = right
-        "vector.similarity.cosine(#{variable}.#{left}, #{vec_ref}) #{comp_op} #{threshold_ref}"
+        "#{vector_scalar(:vector_similarity, variable, left, vec_ref)} #{comp_op} #{threshold_ref}"
+
+      operator == "vector_cosine_distance" ->
+        {comp_op, vec_ref, threshold_ref} = right
+        "#{vector_scalar(:vector_cosine_distance, variable, left, vec_ref)} #{comp_op} #{threshold_ref}"
 
       case_insensitive? ->
         "toLower(#{variable}.#{left}) #{String.upcase(operator)} toLower(#{right})"
@@ -119,6 +125,30 @@ defmodule AshNeo4j.Cypher do
       true ->
         "#{variable}.#{left} #{String.upcase(operator)} #{right}"
     end
+  end
+
+  @doc """
+  Bare scalar Cypher for a vector function, e.g. for use in `ORDER BY`.
+
+  `vec_ref` is the parameter reference holding the query embedding (`"$q"`).
+  `vector_similarity` is Neo4j's normalised cosine similarity in `[0, 1]`
+  (higher = closer); `vector_cosine_distance` rescales it to pgvector-style
+  distance in `[0, 2]` (lower = closer) via `2 * (1 - similarity)`.
+
+  ## Examples
+  ```
+  iex> AshNeo4j.Cypher.vector_scalar(:vector_similarity, :s, "embedding", "$q")
+  "vector.similarity.cosine(s.embedding, $q)"
+  iex> AshNeo4j.Cypher.vector_scalar(:vector_cosine_distance, :s, "embedding", "$q")
+  "(2.0 * (1.0 - vector.similarity.cosine(s.embedding, $q)))"
+  ```
+  """
+  def vector_scalar(:vector_similarity, variable, prop, vec_ref) do
+    "vector.similarity.cosine(#{variable}.#{prop}, #{vec_ref})"
+  end
+
+  def vector_scalar(:vector_cosine_distance, variable, prop, vec_ref) do
+    "(2.0 * (1.0 - vector.similarity.cosine(#{variable}.#{prop}, #{vec_ref})))"
   end
 
   @doc """
@@ -229,7 +259,7 @@ defmodule AshNeo4j.Cypher do
 
       [] ->
         case AshNeo4j.Sandbox.run(cypher, params) do
-          nil -> Bolty.query(Bolt, cypher, params)
+          nil -> Bolty.query(BoltyHelper.current_pool(), cypher, params)
           result -> result
         end
     end

--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -421,7 +421,7 @@ defmodule AshNeo4j.Cypher.Query do
   Each term is `{order_expression, :asc | :desc}` where `order_expression` is a
   fully-formed Cypher expression — e.g. `"s.name"` for a plain property or
   `"vector.similarity.cosine(s.embedding, $q)"` for an expression sort. The
-  caller (see `AshNeo4j.QueryHelper.sort_terms/2`) is responsible for the `s.`
+  caller (`AshNeo4j.QueryHelper`'s sort handling) is responsible for the `s.`
   prefix and for merging any referenced params via `merge_params/2`.
   """
   @spec add_order_by(t(), [{String.t(), :asc | :desc}]) :: t()

--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -897,6 +897,15 @@ defmodule AshNeo4j.Cypher.Query do
             params = acc_params |> Map.put(test_key, test_point) |> Map.put(thresh_key, threshold)
             {expr, params}
 
+          op == :vector_similarity ->
+            {comp_op_atom, query_vec, threshold} = val
+            prop_seg = Cypher.sanitize_param(prop)
+            vec_key = "#{param_prefix}#{variable}_#{prop_seg}_#{index}_vec"
+            thresh_key = "#{param_prefix}#{variable}_#{prop_seg}_#{index}_t"
+            expr = Cypher.expression(variable, prop, "vector_similarity", {convert_operator(comp_op_atom), "$#{vec_key}", "$#{thresh_key}"})
+            params = acc_params |> Map.put(vec_key, query_vec) |> Map.put(thresh_key, threshold)
+            {expr, params}
+
           true ->
             prop_seg = Cypher.sanitize_param(prop)
             param_key = "#{param_prefix}#{variable}_#{prop_seg}_#{index}"

--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -415,13 +415,26 @@ defmodule AshNeo4j.Cypher.Query do
     %__MODULE__{clauses: [%Match{pattern: pattern}, %Return{items: ["n"]}], params: params}
   end
 
-  @doc "Appends an `ORDER BY` clause. No-op when `terms` is empty."
-  @spec add_order_by(t(), [{atom() | String.t(), :asc | :desc}]) :: t()
+  @doc """
+  Appends an `ORDER BY` clause. No-op when `terms` is empty.
+
+  Each term is `{order_expression, :asc | :desc}` where `order_expression` is a
+  fully-formed Cypher expression — e.g. `"s.name"` for a plain property or
+  `"vector.similarity.cosine(s.embedding, $q)"` for an expression sort. The
+  caller (see `AshNeo4j.QueryHelper.sort_terms/2`) is responsible for the `s.`
+  prefix and for merging any referenced params via `merge_params/2`.
+  """
+  @spec add_order_by(t(), [{String.t(), :asc | :desc}]) :: t()
   def add_order_by(%__MODULE__{} = query, []), do: query
 
   def add_order_by(%__MODULE__{} = query, terms) when is_list(terms) do
-    order_terms = Enum.map(terms, fn {prop, order} -> {"s.#{prop}", order} end)
-    %{query | clauses: query.clauses ++ [%OrderBy{terms: order_terms}]}
+    %{query | clauses: query.clauses ++ [%OrderBy{terms: terms}]}
+  end
+
+  @doc "Merges `params` into the query's param map. Later keys win."
+  @spec merge_params(t(), map()) :: t()
+  def merge_params(%__MODULE__{} = query, params) when is_map(params) do
+    %{query | params: Map.merge(query.params, params)}
   end
 
   @doc "Appends a `SKIP` clause. No-op when `n` is `nil` or `0`."
@@ -452,7 +465,7 @@ defmodule AshNeo4j.Cypher.Query do
   trailing `add_order_by/2`, which orders the per-edge rows by node property and
   so keeps each node's rows grouped).
   """
-  @spec paginate_nodes(t(), [{atom() | String.t(), :asc | :desc}], non_neg_integer() | nil, pos_integer() | nil) :: t()
+  @spec paginate_nodes(t(), [{String.t(), :asc | :desc}], non_neg_integer() | nil, pos_integer() | nil) :: t()
   def paginate_nodes(%__MODULE__{} = query, order_terms, skip, limit) do
     order_terms = order_terms || []
 
@@ -477,7 +490,7 @@ defmodule AshNeo4j.Cypher.Query do
     order =
       case order_terms do
         [] -> []
-        terms -> [%OrderBy{terms: Enum.map(terms, fn {prop, dir} -> {"s.#{prop}", dir} end)}]
+        terms -> [%OrderBy{terms: terms}]
       end
 
     skip_clause = if skip in [nil, 0], do: [], else: [%Skip{value: skip}]
@@ -897,12 +910,12 @@ defmodule AshNeo4j.Cypher.Query do
             params = acc_params |> Map.put(test_key, test_point) |> Map.put(thresh_key, threshold)
             {expr, params}
 
-          op == :vector_similarity ->
+          op in [:vector_similarity, :vector_cosine_distance] ->
             {comp_op_atom, query_vec, threshold} = val
             prop_seg = Cypher.sanitize_param(prop)
             vec_key = "#{param_prefix}#{variable}_#{prop_seg}_#{index}_vec"
             thresh_key = "#{param_prefix}#{variable}_#{prop_seg}_#{index}_t"
-            expr = Cypher.expression(variable, prop, "vector_similarity", {convert_operator(comp_op_atom), "$#{vec_key}", "$#{thresh_key}"})
+            expr = Cypher.expression(variable, prop, Atom.to_string(op), {convert_operator(comp_op_atom), "$#{vec_key}", "$#{thresh_key}"})
             params = acc_params |> Map.put(vec_key, query_vec) |> Map.put(thresh_key, threshold)
             {expr, params}
 

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -68,6 +68,8 @@ defmodule AshNeo4j.DataLayer do
   # spatial — st_distance_in_meters: alias for st_distance, same pushdown
   def can?(_, {:filter_expr, %AshNeo4j.Functions.StDistanceInMeters{}}), do: true
 
+  def can?(_, {:filter_expr, %AshNeo4j.Functions.VectorSimilarity{}}), do: true
+
   # All other filter expressions are accepted so Ash can hydrate and then evaluate
   # them in-memory via filter_stream / RuntimeExpression. Cypher builder falls
   # back to TRUE for unrecognised predicates; filter_stream corrects the results.
@@ -97,7 +99,8 @@ defmodule AshNeo4j.DataLayer do
       AshNeo4j.Functions.StDistanceInMeters,
       AshNeo4j.Functions.StDwithin,
       AshNeo4j.Functions.StIntersects,
-      AshNeo4j.Functions.StWithin
+      AshNeo4j.Functions.StWithin,
+      AshNeo4j.Functions.VectorSimilarity
     ]
   end
 

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -69,6 +69,7 @@ defmodule AshNeo4j.DataLayer do
   def can?(_, {:filter_expr, %AshNeo4j.Functions.StDistanceInMeters{}}), do: true
 
   def can?(_, {:filter_expr, %AshNeo4j.Functions.VectorSimilarity{}}), do: true
+  def can?(_, {:filter_expr, %AshNeo4j.Functions.VectorCosineDistance{}}), do: true
 
   # All other filter expressions are accepted so Ash can hydrate and then evaluate
   # them in-memory via filter_stream / RuntimeExpression. Cypher builder falls
@@ -100,7 +101,8 @@ defmodule AshNeo4j.DataLayer do
       AshNeo4j.Functions.StDwithin,
       AshNeo4j.Functions.StIntersects,
       AshNeo4j.Functions.StWithin,
-      AshNeo4j.Functions.VectorSimilarity
+      AshNeo4j.Functions.VectorSimilarity,
+      AshNeo4j.Functions.VectorCosineDistance
     ]
   end
 
@@ -642,7 +644,7 @@ defmodule AshNeo4j.DataLayer do
         Process.delete({:neo4j_in_transaction, label})
       end
     else
-      Bolty.transaction(Bolt, fn conn ->
+      Bolty.transaction(AshNeo4j.BoltyHelper.current_pool(), fn conn ->
         stack = Process.get(:ash_neo4j_tx_stack, [])
         Process.put(:ash_neo4j_tx_stack, [conn | stack])
         Process.put({:neo4j_in_transaction, label}, true)

--- a/lib/data_layer/cast.ex
+++ b/lib/data_layer/cast.ex
@@ -4,7 +4,6 @@
 
 defmodule AshNeo4j.DataLayer.Cast do
   @moduledoc "Casting for AshNeo4j.DataLayer"
-  require Logger
 
   alias AshNeo4j.DataLayer.TypeClassifier
   alias AshNeo4j.Util

--- a/lib/data_layer/type_classifier.ex
+++ b/lib/data_layer/type_classifier.ex
@@ -4,7 +4,6 @@
 
 defmodule AshNeo4j.DataLayer.TypeClassifier do
   @moduledoc "Type Classifier for AshNeo4j.DataLayer"
-  require Logger
 
   @doc """
   Classifies the type to assist Cast and Dump

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -9,3 +9,4 @@ defmodule AshNeo4j.Error.RequiresCypher25 do
   """
   defexception message: "This operation requires Cypher 25 (Neo4j ≥ 2025.06)"
 end
+

--- a/lib/functions/vector_cosine_distance.ex
+++ b/lib/functions/vector_cosine_distance.ex
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Functions.VectorCosineDistance do
+  @moduledoc """
+  Cosine *distance* between a stored vector attribute and a query embedding —
+  the ash_ai-compatible counterpart to `AshNeo4j.Functions.VectorSimilarity`.
+
+  Returns a float in `[0.0, 2.0]` where `0.0` is identical direction and larger
+  is further apart (lower = closer). This matches pgvector's `<=>` operator
+  (`vector_cosine_distance` in ash_ai), so the same `read` action expression —
+
+      Ash.Query.filter(query, vector_cosine_distance(embedding, ^q) < 0.5)
+      |> Ash.Query.sort({calc(vector_cosine_distance(embedding, ^q), type: :float), :asc})
+      |> Ash.Query.limit(10)
+
+  — works against AshNeo4j and AshPostgres alike.
+
+  Neo4j's `vector.similarity.cosine/2` returns a *normalised similarity* in
+  `[0.0, 1.0]` (`1.0` identical, `0.5` orthogonal, `0.0` opposite). The data
+  layer maps it back to pgvector-style distance as `2 * (1 - similarity)`.
+
+  Requires Cypher 25 (Neo4j ≥ 2025.06). The data layer pushes this down to
+  `2 * (1 - vector.similarity.cosine(s.embedding, $q))`. `evaluate/1` mirrors
+  that exact maths in Elixir (`1 - raw_cosine`) so the data layer's in-memory
+  correctness re-filter agrees with the pushdown.
+  """
+  use Ash.Query.Function, name: :vector_cosine_distance, predicate?: false
+
+  import AshNeo4j.Functions.VectorMath, only: [raw_cosine: 2, comparable_vectors?: 2]
+
+  def args, do: [[:any, :any]]
+
+  def returns, do: [:float]
+
+  def evaluate(%{arguments: [a, b]}) do
+    if comparable_vectors?(a, b) do
+      {:known, 1.0 - raw_cosine(a, b)}
+    else
+      {:known, nil}
+    end
+  end
+end

--- a/lib/functions/vector_math.ex
+++ b/lib/functions/vector_math.ex
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Functions.VectorMath do
+  @moduledoc """
+  Shared in-memory cosine maths for the vector query functions.
+
+  Used by `evaluate/1` in `AshNeo4j.Functions.VectorSimilarity` and
+  `AshNeo4j.Functions.VectorCosineDistance` so the data layer's in-memory
+  correctness re-filter (`Ash.Filter.Runtime`) produces the same values as the
+  Cypher pushdown. Neo4j normalises cosine similarity to `[0, 1]` as
+  `(1 + raw_cosine) / 2`; the callers derive their results from `raw_cosine/2`
+  accordingly.
+  """
+
+  @doc "True when `a` and `b` are equal-length, non-empty numeric lists."
+  def comparable_vectors?(a, b) do
+    is_list(a) and is_list(b) and a != [] and length(a) == length(b) and
+      Enum.all?(a, &is_number/1) and Enum.all?(b, &is_number/1)
+  end
+
+  @doc """
+  Raw cosine similarity in `[-1.0, 1.0]` — `dot(a, b) / (‖a‖ · ‖b‖)`.
+
+  Returns `0.0` if either vector has zero magnitude. Assumes
+  `comparable_vectors?/2` already held.
+  """
+  def raw_cosine(a, b) do
+    dot = a |> Enum.zip(b) |> Enum.reduce(0.0, fn {x, y}, acc -> acc + x * y end)
+    mag_a = :math.sqrt(Enum.reduce(a, 0.0, fn x, acc -> acc + x * x end))
+    mag_b = :math.sqrt(Enum.reduce(b, 0.0, fn x, acc -> acc + x * x end))
+
+    if mag_a == 0.0 or mag_b == 0.0, do: 0.0, else: dot / (mag_a * mag_b)
+  end
+end

--- a/lib/functions/vector_similarity.ex
+++ b/lib/functions/vector_similarity.ex
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Functions.VectorSimilarity do
+  @moduledoc """
+  Cosine similarity between a stored vector attribute and a query embedding.
+
+  Returns a float in `[-1.0, 1.0]` (1.0 = identical direction). Typically used
+  in `order_by` to rank results by relevance.
+
+      Item
+      |> Ash.Query.sort(vector_similarity(embedding, ^query_embedding), :desc)
+      |> Ash.read!()
+
+  Requires Bolt 6.0 vector support (`policy.vectors` must be `true`). The data
+  layer pushes this down to:
+
+      vector.similarity.cosine(s.embedding, $query_embedding)
+
+  In-memory evaluation is not supported — the database does the work.
+  """
+  use Ash.Query.Function, name: :vector_similarity, predicate?: false
+
+  def args, do: [[:any, :any]]
+
+  def returns, do: [:float]
+
+  def evaluate(_), do: :unknown
+end

--- a/lib/functions/vector_similarity.ex
+++ b/lib/functions/vector_similarity.ex
@@ -4,27 +4,35 @@
 
 defmodule AshNeo4j.Functions.VectorSimilarity do
   @moduledoc """
-  Cosine similarity between a stored vector attribute and a query embedding.
+  Normalised cosine similarity between a stored vector attribute and a query
+  embedding, matching Neo4j's `vector.similarity.cosine/2`.
 
-  Returns a float in `[-1.0, 1.0]` (1.0 = identical direction). Typically used
-  in `order_by` to rank results by relevance.
+  Returns a float in `[0.0, 1.0]` — `1.0` identical direction, `0.5` orthogonal,
+  `0.0` opposite — i.e. `(1 + raw_cosine) / 2`. Higher is closer. Typically used
+  in `sort` to rank results by relevance:
 
       Item
-      |> Ash.Query.sort(vector_similarity(embedding, ^query_embedding), :desc)
+      |> Ash.Query.sort({calc(vector_similarity(embedding, ^q), type: :float), :desc})
       |> Ash.read!()
 
-  Requires Bolt 6.0 vector support (`policy.vectors` must be `true`). The data
-  layer pushes this down to:
-
-      vector.similarity.cosine(s.embedding, $query_embedding)
-
-  In-memory evaluation is not supported — the database does the work.
+  Requires Cypher 25 (Neo4j ≥ 2025.06). The data layer pushes this down to
+  `vector.similarity.cosine(s.embedding, $q)`. `evaluate/1` mirrors that exact
+  normalisation in Elixir so the data layer's in-memory correctness re-filter
+  agrees with the pushdown (and so filters/sorts also work without pushdown).
   """
   use Ash.Query.Function, name: :vector_similarity, predicate?: false
+
+  import AshNeo4j.Functions.VectorMath, only: [raw_cosine: 2, comparable_vectors?: 2]
 
   def args, do: [[:any, :any]]
 
   def returns, do: [:float]
 
-  def evaluate(_), do: :unknown
+  def evaluate(%{arguments: [a, b]}) do
+    if comparable_vectors?(a, b) do
+      {:known, (1.0 + raw_cosine(a, b)) / 2.0}
+    else
+      {:known, nil}
+    end
+  end
 end

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -319,6 +319,12 @@ defmodule AshNeo4j.QueryHelper do
           {prop, :st_dwithin, {to_param_value(test_point), threshold}, false}
         end
 
+      %{operator: op, left: %AshNeo4j.Functions.VectorSimilarity{arguments: [ref, query_vec]}, right: threshold}
+      when op in [:<, :<=, :>, :>=, :==, :!=] and is_number(threshold) ->
+        AshNeo4j.Cypher.require_cypher25!()
+        prop = property_name(mapping, ref)
+        {prop, :vector_similarity, {op, to_vector_param(query_vec), threshold}, false}
+
       predicate ->
         Logger.debug("AshNeo4j.QueryHelper: predicate #{inspect(predicate)} not handled")
         nil
@@ -406,6 +412,17 @@ defmodule AshNeo4j.QueryHelper do
   defp to_param_value(%MapSet{} = ms), do: MapSet.to_list(ms)
   defp to_param_value(%Geo.Point{coordinates: {x, y}}), do: Bolty.Types.Point.create(:wgs_84, x, y)
   defp to_param_value(value), do: value
+
+  defp to_vector_param(value) when is_list(value) do
+    policy = AshNeo4j.BoltyHelper.policy()
+    if policy && policy.vectors do
+      %Bolty.Types.Vector{type: :float32, data: Enum.map(value, &(&1 / 1))}
+    else
+      Enum.map(value, &(&1 / 1))
+    end
+  end
+
+  defp to_vector_param(%Bolty.Types.Vector{} = v), do: v
 
   # Builds the on-disk property name for a Point attribute under the symmetric
   # split — `<attr>.point` is where the native Neo4j POINT lives (the indexable

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -28,11 +28,12 @@ defmodule AshNeo4j.QueryHelper do
 
   defp run_simple_query(ash_query) do
     mapping = ResourceInfo.mapping(ash_query.resource)
-    terms = sort_terms(ash_query, mapping)
+    {terms, sort_params} = sort_terms(ash_query, mapping)
 
     query =
       ash_query
       |> build_query(mapping)
+      |> Query.merge_params(sort_params)
       |> Query.paginate_nodes(terms, ash_query.offset, ash_query.limit)
       |> Query.add_order_by(terms)
 
@@ -62,11 +63,12 @@ defmodule AshNeo4j.QueryHelper do
         build_branch_query(branch_dl_query, mapping, "b#{idx}_", :nodes)
       end)
 
-    terms = sort_terms(ash_query, mapping)
+    {terms, sort_params} = sort_terms(ash_query, mapping)
 
     query =
       branch_queries
       |> Query.combination_block(union_type: union_type)
+      |> Query.merge_params(sort_params)
       |> Query.paginate_nodes(terms, ash_query.offset, ash_query.limit)
       |> Query.add_order_by(terms)
 
@@ -99,11 +101,12 @@ defmodule AshNeo4j.QueryHelper do
         if keep_ids == [] do
           {:ok, []}
         else
-          terms = sort_terms(ash_query, mapping)
+          {terms, sort_params} = sort_terms(ash_query, mapping)
 
           final =
             mapping.label_pair
             |> Query.node_read_by_ids(keep_ids)
+            |> Query.merge_params(sort_params)
             |> Query.paginate_nodes(terms, ash_query.offset, ash_query.limit)
             |> Query.add_order_by(terms)
 
@@ -325,6 +328,12 @@ defmodule AshNeo4j.QueryHelper do
         prop = property_name(mapping, ref)
         {prop, :vector_similarity, {op, to_vector_param(query_vec), threshold}, false}
 
+      %{operator: op, left: %AshNeo4j.Functions.VectorCosineDistance{arguments: [ref, query_vec]}, right: threshold}
+      when op in [:<, :<=, :>, :>=, :==, :!=] and is_number(threshold) ->
+        AshNeo4j.Cypher.require_cypher25!()
+        prop = property_name(mapping, ref)
+        {prop, :vector_cosine_distance, {op, to_vector_param(query_vec), threshold}, false}
+
       predicate ->
         Logger.debug("AshNeo4j.QueryHelper: predicate #{inspect(predicate)} not handled")
         nil
@@ -380,18 +389,54 @@ defmodule AshNeo4j.QueryHelper do
   defp attribute_name(atom) when is_atom(atom), do: atom
   defp attribute_name(_), do: nil
 
+  # Builds the ORDER BY terms and any params they reference.
+  #
+  # Returns `{terms, params}` where each term is `{order_expression, :asc | :desc}`
+  # with `order_expression` a fully-formed Cypher expression (including the `s.`
+  # prefix). Plain properties render to `"s.<prop>"`; a `calc(vector_similarity(…))`
+  # or `calc(vector_cosine_distance(…))` sort renders to the corresponding scalar
+  # expression with the query embedding bound as a param. Other calculations are
+  # dropped (Ash evaluates them in-memory).
   defp sort_terms(ash_query, %ResourceMapping{} = mapping) do
     case ash_query.sort do
       sort when sort in [nil, []] ->
-        []
+        {[], %{}}
 
       sort ->
         sort
-        |> Enum.reject(fn {name, _order} -> is_struct(name, Ash.Query.Calculation) end)
-        |> Enum.map(fn {name, order} ->
-          {Keyword.get(mapping.properties, name, name), order}
+        |> Enum.with_index()
+        |> Enum.reduce({[], %{}}, fn {{name, order}, index}, {terms, params} ->
+          case sort_term(mapping, name, order, index) do
+            nil -> {terms, params}
+            {term, term_params} -> {terms ++ [term], Map.merge(params, term_params)}
+          end
         end)
     end
+  end
+
+  # vector_similarity / vector_cosine_distance sort — pushed down as the scalar
+  # expression, with the query embedding bound as a param.
+  defp sort_term(mapping, %Ash.Query.Calculation{module: Ash.Resource.Calculation.Expression, opts: opts}, order, index) do
+    case Keyword.get(opts, :expr) do
+      %Ash.Query.Call{name: fname, args: [ref, query_vec]} when fname in [:vector_similarity, :vector_cosine_distance] ->
+        AshNeo4j.Cypher.require_cypher25!()
+        prop = property_name(mapping, ref)
+        key = "sort_#{Cypher.sanitize_param(prop)}_#{index}_vec"
+        expr = Cypher.vector_scalar(fname, :s, prop, "$#{key}")
+        {{expr, order}, %{key => to_vector_param(query_vec)}}
+
+      _ ->
+        nil
+    end
+  end
+
+  # Any other calculation — Ash evaluates it in-memory, so drop from pushdown.
+  defp sort_term(_mapping, %Ash.Query.Calculation{}, _order, _index), do: nil
+
+  # Plain property sort.
+  defp sort_term(mapping, name, order, _index) do
+    prop = Keyword.get(mapping.properties, name, name)
+    {{"s.#{prop}", order}, %{}}
   end
 
   defp ref_or_atom?(%Ash.Query.Ref{}), do: true
@@ -413,16 +458,10 @@ defmodule AshNeo4j.QueryHelper do
   defp to_param_value(%Geo.Point{coordinates: {x, y}}), do: Bolty.Types.Point.create(:wgs_84, x, y)
   defp to_param_value(value), do: value
 
-  defp to_vector_param(value) when is_list(value) do
-    policy = AshNeo4j.BoltyHelper.policy()
-    if policy && policy.vectors do
-      %Bolty.Types.Vector{type: :float32, data: Enum.map(value, &(&1 / 1))}
-    else
-      Enum.map(value, &(&1 / 1))
-    end
-  end
-
-  defp to_vector_param(%Bolty.Types.Vector{} = v), do: v
+  # The query embedding is passed as a plain LIST<FLOAT> param — what
+  # `vector.similarity.cosine/2` expects, and consistent with list storage.
+  defp to_vector_param(value) when is_list(value), do: Enum.map(value, &(&1 / 1))
+  defp to_vector_param(%Bolty.Types.Vector{data: data}), do: Enum.map(data, &(&1 / 1))
 
   # Builds the on-disk property name for a Point attribute under the symmetric
   # split — `<attr>.point` is where the native Neo4j POINT lives (the indexable

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -4,7 +4,6 @@
 
 defmodule AshNeo4j.QueryHelper do
   require Logger
-  require Ash.Query
 
   alias AshNeo4j.Cypher
   alias AshNeo4j.Cypher.Query

--- a/lib/sandbox.ex
+++ b/lib/sandbox.ex
@@ -71,6 +71,10 @@ defmodule AshNeo4j.Sandbox do
     end
 
     parent = self()
+    # Capture the pool in the parent — the spawned holder does not inherit the
+    # parent's process dictionary, so a `:bolt6` test's pool override has to be
+    # read here and passed in.
+    pool = AshNeo4j.BoltyHelper.current_pool()
 
     holder =
       spawn_link(fn ->
@@ -78,7 +82,7 @@ defmodule AshNeo4j.Sandbox do
         # killing the holder before Bolty.rollback/2 can be called.
         Process.flag(:trap_exit, true)
 
-        Bolty.transaction(Bolt, fn conn ->
+        Bolty.transaction(pool, fn conn ->
           send(parent, {:ash_neo4j_sandbox_ready, self()})
           holder_loop(conn)
         end)

--- a/lib/types/vector.ex
+++ b/lib/types/vector.ex
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Types.Vector do
+  @moduledoc """
+  Ash attribute type for vector embeddings, backed by `%Bolty.Types.Vector{}` on the Bolt wire.
+
+  The Elixir-side value is a plain `[float()]` list. On write, vectors travel as
+  `%Bolty.Types.Vector{}` when the connection has `policy.vectors: true` (Bolt 6.0,
+  Neo4j ≥ 2025.10), and as a plain float list otherwise. On read, both forms are
+  unwrapped back to `[float()]`.
+
+  > #### Cypher 25 required {: .warning}
+  > Vector operations require Cypher 25 (Neo4j ≥ 2025.06). This is an AshNeo4j-level
+  > requirement — see `AshNeo4j.Cypher.require_cypher25!/0`.
+
+  ## Constraints
+
+    * `:element_type` — `:float32` (default) or `:float64`
+    * `:dimensions` — expected number of dimensions; validated on cast when set
+
+  ## Usage
+
+      attribute :embedding, AshNeo4j.Types.Vector,
+        constraints: [element_type: :float32, dimensions: 1536]
+
+  See `AshNeo4j.Vector` for index creation helpers and `AshNeo4j.Functions.VectorSimilarity`
+  for cosine similarity filtering/sorting.
+  """
+
+  use Ash.Type
+
+  @impl Ash.Type
+  def storage_type(_constraints), do: :string
+
+  @impl Ash.Type
+  def constraints do
+    [
+      element_type: [
+        type: {:one_of, [:float32, :float64]},
+        default: :float32,
+        doc: "Element precision: `:float32` (IEEE-754 single, default) or `:float64` (IEEE-754 double)."
+      ],
+      dimensions: [
+        type: :pos_integer,
+        doc: "Expected number of dimensions. Validated on cast when provided."
+      ]
+    ]
+  end
+
+  @impl Ash.Type
+  def apply_constraints(value, constraints) do
+    case constraints[:dimensions] do
+      nil -> {:ok, value}
+      dims when length(value) == dims -> {:ok, value}
+      dims -> {:error, "expected #{dims} dimensions, got #{length(value)}"}
+    end
+  end
+
+  @impl Ash.Type
+  def cast_input(nil, _constraints), do: {:ok, nil}
+
+  def cast_input(%Bolty.Types.Vector{data: data}, _constraints) do
+    {:ok, Enum.map(data, &(&1 / 1))}
+  end
+
+  def cast_input(value, _constraints) when is_list(value) do
+    if Enum.all?(value, &is_number/1) do
+      {:ok, Enum.map(value, &(&1 / 1))}
+    else
+      {:error, "expected a list of numbers, got non-numeric element"}
+    end
+  end
+
+  def cast_input(_, _), do: {:error, "expected a list of floats or a %Bolty.Types.Vector{}"}
+
+  @impl Ash.Type
+  def cast_stored(nil, _constraints), do: {:ok, nil}
+
+  def cast_stored(%Bolty.Types.Vector{data: data}, _constraints) do
+    {:ok, Enum.map(data, &(&1 / 1))}
+  end
+
+  def cast_stored(value, _constraints) when is_list(value) do
+    if Enum.all?(value, &is_number/1) do
+      {:ok, Enum.map(value, &(&1 / 1))}
+    else
+      {:error, "unexpected non-numeric element in vector from storage"}
+    end
+  end
+
+  def cast_stored(_, _), do: {:error, "unexpected value in Neo4j vector property"}
+
+  @impl Ash.Type
+  def dump_to_native(nil, _constraints), do: {:ok, nil}
+
+  def dump_to_native(value, constraints) when is_list(value) do
+    floats = Enum.map(value, &(&1 / 1))
+    policy = AshNeo4j.BoltyHelper.policy()
+
+    result =
+      if policy && policy.vectors do
+        %Bolty.Types.Vector{type: constraints[:element_type] || :float32, data: floats}
+      else
+        floats
+      end
+
+    {:ok, result}
+  end
+
+  def dump_to_native(_, _), do: :error
+end

--- a/lib/types/vector.ex
+++ b/lib/types/vector.ex
@@ -4,16 +4,19 @@
 
 defmodule AshNeo4j.Types.Vector do
   @moduledoc """
-  Ash attribute type for vector embeddings, backed by `%Bolty.Types.Vector{}` on the Bolt wire.
+  Ash attribute type for vector embeddings, stored as a Neo4j `LIST<FLOAT>`.
 
-  The Elixir-side value is a plain `[float()]` list. On write, vectors travel as
-  `%Bolty.Types.Vector{}` when the connection has `policy.vectors: true` (Bolt 6.0,
-  Neo4j ≥ 2025.10), and as a plain float list otherwise. On read, both forms are
-  unwrapped back to `[float()]`.
+  The Elixir-side value is a plain `[float()]` list, and it is persisted as a
+  `LIST<FLOAT>` node property — which is what Neo4j's vector indexes and
+  `vector.similarity.cosine/2` operate on. The native Bolt 6.0 `%Bolty.Types.Vector{}`
+  type is a *query-parameter* wire type and **cannot be written as a node
+  property**, so it is never used for storage. `cast_input/2` and `cast_stored/2`
+  still accept a `%Bolty.Types.Vector{}` defensively and unwrap it to `[float()]`.
 
   > #### Cypher 25 required {: .warning}
-  > Vector operations require Cypher 25 (Neo4j ≥ 2025.06). This is an AshNeo4j-level
-  > requirement — see `AshNeo4j.Cypher.require_cypher25!/0`.
+  > Vector operations require Cypher 25 (Neo4j ≥ 2025.06) — not Bolt 6.0. With
+  > list storage and list query params, similarity search works over Bolt 5.8.
+  > This is an AshNeo4j-level requirement — see `AshNeo4j.Cypher.require_cypher25!/0`.
 
   ## Constraints
 
@@ -95,18 +98,12 @@ defmodule AshNeo4j.Types.Vector do
   @impl Ash.Type
   def dump_to_native(nil, _constraints), do: {:ok, nil}
 
-  def dump_to_native(value, constraints) when is_list(value) do
-    floats = Enum.map(value, &(&1 / 1))
-    policy = AshNeo4j.BoltyHelper.policy()
-
-    result =
-      if policy && policy.vectors do
-        %Bolty.Types.Vector{type: constraints[:element_type] || :float32, data: floats}
-      else
-        floats
-      end
-
-    {:ok, result}
+  # Persisted as a LIST<FLOAT>. Neo4j stores embeddings as float lists and
+  # `vector.similarity.cosine/2` operates on them directly; the native Bolt 6.0
+  # VECTOR type cannot be written as a node property, so it is never used for
+  # storage.
+  def dump_to_native(value, _constraints) when is_list(value) do
+    {:ok, Enum.map(value, &(&1 / 1))}
   end
 
   def dump_to_native(_, _), do: :error

--- a/lib/vector.ex
+++ b/lib/vector.ex
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Vector do
+  @moduledoc """
+  Convenience helpers for creating the Neo4j VECTOR indexes that back
+  `AshNeo4j.Types.Vector` attributes.
+
+  Requires Cypher 25 (Neo4j ≥ 2025.06). Operations against an older server
+  raise `AshNeo4j.Error.RequiresCypher25`.
+
+      # Create the index for a vector attribute
+      AshNeo4j.Vector.create_index(Item, :embedding)
+
+      # Rebuild after a dimension or similarity-function change
+      AshNeo4j.Vector.create_index(Item, :embedding, recreate: true)
+
+      # Euclidean distance instead of the default cosine
+      AshNeo4j.Vector.create_index(Item, :embedding, similarity_function: :euclidean)
+
+  Consistent with AshNeo4j's "no automatic migrations" stance — this is an
+  ergonomic tool you call (e.g. from a start-up task). `create_index/3` uses
+  `IF NOT EXISTS`, so it is safe to run repeatedly.
+
+  ## Naming
+
+  The index is named `<base>_vector` where `base` defaults to
+  `<label_lower>_<property>` — e.g. `item_embedding_vector`. Pass `:name` to
+  override the base.
+
+  ## Dry run
+
+  `index_statements/3` returns the `CREATE` Cypher without touching the
+  database — useful for review or testing.
+  """
+
+  alias AshNeo4j.Cypher
+  alias AshNeo4j.Resource.Info, as: ResourceInfo
+
+  @doc """
+  Creates the VECTOR index for `attr` on `resource`.
+
+  Returns `{:ok, %Bolty.Response{}}` or `{:error, reason}`.
+
+  ## Options
+
+    * `:recreate` — `DROP INDEX ... IF EXISTS` before `CREATE`. Use after changing
+      `:dimensions` or `:similarity_function`. Defaults to `false`.
+    * `:name` — override the auto-derived base name. `_vector` is still appended.
+    * `:similarity_function` — `:cosine` (default) or `:euclidean`.
+  """
+  @spec create_index(Ash.Resource.t(), atom(), keyword()) ::
+          {:ok, Bolty.Response.t()} | {:error, term()}
+  def create_index(resource, attr, opts \\ []) do
+    Cypher.require_cypher25!()
+
+    with {:ok, spec} <- resolve_spec(resource, attr, opts) do
+      if Keyword.get(opts, :recreate, false) do
+        with {:ok, _} <- Cypher.run(drop_cypher(spec)), do: Cypher.run(create_cypher(spec))
+      else
+        Cypher.run(create_cypher(spec))
+      end
+    end
+  end
+
+  @doc """
+  Drops the VECTOR index for `attr`. Uses `IF EXISTS`, so it is a no-op when absent.
+  """
+  @spec drop_index(Ash.Resource.t(), atom(), keyword()) ::
+          {:ok, Bolty.Response.t()} | {:error, term()}
+  def drop_index(resource, attr, opts \\ []) do
+    Cypher.require_cypher25!()
+
+    with {:ok, spec} <- resolve_spec(resource, attr, opts) do
+      Cypher.run(drop_cypher(spec))
+    end
+  end
+
+  @doc """
+  Returns `{:ok, statement}` — the `CREATE VECTOR INDEX` Cypher that
+  `create_index/3` would run — without touching the database.
+
+      AshNeo4j.Vector.index_statements(Item, :embedding)
+      #=> {:ok, "CREATE VECTOR INDEX item_embedding_vector IF NOT EXISTS FOR (n:Item) ON (n.embedding) OPTIONS {indexConfig: {`vector.dimensions`: 1536, `vector.similarity_function`: 'cosine'}}"}
+  """
+  @spec index_statements(Ash.Resource.t(), atom(), keyword()) ::
+          {:ok, String.t()} | {:error, term()}
+  def index_statements(resource, attr, opts \\ []) do
+    with {:ok, spec} <- resolve_spec(resource, attr, opts) do
+      {:ok, create_cypher(spec)}
+    end
+  end
+
+  # --- guards ------------------------------------------------------------
+
+
+  # --- resolution --------------------------------------------------------
+
+  defp resolve_spec(resource, attr, opts) do
+    with {:ok, label} <- resolve_label(resource),
+         {:ok, attribute} <- resolve_attribute(resource, attr),
+         {:ok, dimensions} <- resolve_dimensions(attribute, attr) do
+      translated = ResourceInfo.translations(resource) |> Keyword.get(attr, attr)
+      property = to_string(translated)
+      base = opts[:name] || default_base_name(label, property)
+      similarity = opts[:similarity_function] || :cosine
+
+      {:ok,
+       %{
+         name: "#{base}_vector",
+         label: label,
+         property: property,
+         dimensions: dimensions,
+         similarity: similarity
+       }}
+    end
+  end
+
+  defp resolve_label(resource) do
+    case ResourceInfo.module_label(resource) do
+      nil ->
+        {:error,
+         "AshNeo4j.Vector: #{inspect(resource)} has no Neo4j module label — is it an AshNeo4j resource?"}
+
+      label ->
+        {:ok, label}
+    end
+  end
+
+  defp resolve_attribute(resource, attr) do
+    case Ash.Resource.Info.attribute(resource, attr) do
+      nil -> {:error, "AshNeo4j.Vector: #{inspect(resource)} has no attribute #{inspect(attr)}"}
+      attribute -> {:ok, attribute}
+    end
+  end
+
+  defp resolve_dimensions(attribute, attr) do
+    case attribute.type do
+      AshNeo4j.Types.Vector ->
+        case Keyword.get(attribute.constraints || [], :dimensions) do
+          nil ->
+            {:error,
+             "AshNeo4j.Vector: attribute #{inspect(attr)} has no :dimensions constraint — " <>
+               "add `constraints: [dimensions: N]` to set the vector size"}
+
+          dims ->
+            {:ok, dims}
+        end
+
+      other ->
+        {:error,
+         "AshNeo4j.Vector: attribute #{inspect(attr)} is #{inspect(other)}, not AshNeo4j.Types.Vector"}
+    end
+  end
+
+  defp default_base_name(label, property) do
+    "#{label |> to_string() |> String.downcase()}_#{String.replace(property, ".", "_")}"
+  end
+
+  # --- cypher ------------------------------------------------------------
+
+  defp create_cypher(%{name: name, label: label, property: property, dimensions: dims, similarity: similarity}) do
+    "CREATE VECTOR INDEX #{name} IF NOT EXISTS " <>
+      "FOR (n:#{label}) ON (n.#{property}) " <>
+      "OPTIONS {indexConfig: {`vector.dimensions`: #{dims}, `vector.similarity_function`: '#{similarity}'}}"
+  end
+
+  defp drop_cypher(%{name: name}), do: "DROP INDEX #{name} IF EXISTS"
+end

--- a/test/cypher_test.exs
+++ b/test/cypher_test.exs
@@ -362,8 +362,8 @@ defmodule AshNeo4j.CypherTest do
     test "sort + skip + limit orders/paginates nodes, with a trailing ORDER BY for output order" do
       {cypher, _} =
         Query.node_read(:Thing)
-        |> Query.paginate_nodes([{"name", :asc}], 5, 10)
-        |> Query.add_order_by([{"name", :asc}])
+        |> Query.paginate_nodes([{"s.name", :asc}], 5, 10)
+        |> Query.add_order_by([{"s.name", :asc}])
         |> Cypher.render()
 
       assert cypher ==
@@ -374,8 +374,8 @@ defmodule AshNeo4j.CypherTest do
     test "sort alone (no skip/limit) is a no-op for paginate_nodes — trailing ORDER BY only" do
       {cypher, _} =
         Query.node_read(:Thing)
-        |> Query.paginate_nodes([{"name", :asc}], 0, nil)
-        |> Query.add_order_by([{"name", :asc}])
+        |> Query.paginate_nodes([{"s.name", :asc}], 0, nil)
+        |> Query.add_order_by([{"s.name", :asc}])
         |> Cypher.render()
 
       assert cypher == "MATCH (s:Thing) OPTIONAL MATCH (s)-[r]-(d) RETURN s, r, d ORDER BY s.name ASC"

--- a/test/functions/vector_functions_test.exs
+++ b/test/functions/vector_functions_test.exs
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Functions.VectorFunctionsTest do
+  @moduledoc """
+  Pure `evaluate/1` maths for the vector query functions.
+
+  These mirror Neo4j's `vector.similarity.cosine/2` normalisation exactly so the
+  data layer's in-memory correctness re-filter agrees with the Cypher pushdown.
+  The normalisation is verified against the live server in
+  `AshNeo4j.VectorSearchTest`.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshNeo4j.Functions.VectorCosineDistance, as: Distance
+  alias AshNeo4j.Functions.VectorSimilarity, as: Similarity
+
+  defp sim(a, b), do: Similarity.evaluate(%{arguments: [a, b]})
+  defp dist(a, b), do: Distance.evaluate(%{arguments: [a, b]})
+
+  describe "VectorSimilarity.evaluate/1 (Neo4j-normalised, [0,1], higher = closer)" do
+    test "identical → 1.0, orthogonal → 0.5, opposite → 0.0" do
+      assert {:known, 1.0} = sim([1.0, 0.0, 0.0], [1.0, 0.0, 0.0])
+      assert {:known, 0.5} = sim([1.0, 0.0, 0.0], [0.0, 1.0, 0.0])
+      assert {:known, 0.0} = sim([1.0, 0.0, 0.0], [-1.0, 0.0, 0.0])
+    end
+
+    test "is magnitude-invariant" do
+      assert {:known, 1.0} = sim([2.0, 0.0, 0.0], [5.0, 0.0, 0.0])
+    end
+
+    test "returns nil for incomparable arguments" do
+      assert {:known, nil} = sim(nil, [1.0, 2.0])
+      assert {:known, nil} = sim([1.0, 2.0], [1.0, 2.0, 3.0])
+      assert {:known, nil} = sim([], [])
+    end
+  end
+
+  describe "VectorCosineDistance.evaluate/1 (pgvector-style, [0,2], lower = closer)" do
+    test "identical → 0.0, orthogonal → 1.0, opposite → 2.0" do
+      assert {:known, 0.0} = dist([1.0, 0.0, 0.0], [1.0, 0.0, 0.0])
+      assert {:known, 1.0} = dist([1.0, 0.0, 0.0], [0.0, 1.0, 0.0])
+      assert {:known, 2.0} = dist([1.0, 0.0, 0.0], [-1.0, 0.0, 0.0])
+    end
+
+    test "distance and similarity are consistent: distance == 2 * (1 - similarity)" do
+      a = [0.3, 0.9, -0.2]
+      b = [0.5, 0.1, 0.4]
+      {:known, s} = sim(a, b)
+      {:known, d} = dist(a, b)
+      assert_in_delta d, 2.0 * (1.0 - s), 1.0e-9
+    end
+
+    test "returns nil for incomparable arguments" do
+      assert {:known, nil} = dist([1.0], nil)
+    end
+  end
+end

--- a/test/support/resource/thing_note.ex
+++ b/test/support/resource/thing_note.ex
@@ -23,6 +23,10 @@ defmodule AshNeo4j.Test.Resource.ThingNote do
     uuid_primary_key :id, writable?: true
     attribute :body, :string, public?: true
     attribute :thing_id, :uuid, public?: true
+
+    attribute :embedding, AshNeo4j.Types.Vector,
+      public?: true,
+      constraints: [element_type: :float32, dimensions: 3]
   end
 
   relationships do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,4 +2,13 @@
 #
 # SPDX-License-Identifier: MIT
 
-ExUnit.start(exclude: [:show_neo4j, :bolt6])
+# Start the Bolt6 pool (Neo4j 2026.05 / Bolt 6.0) from the long-lived test_helper
+# process so it survives the whole run. Bolty.start_link/1 links the pool to the
+# calling process, so starting it from a per-test `setup` would tie its lifetime
+# to a single test. Harmless when the pool is absent — `:bolt6` tests are
+# excluded by default.
+AshNeo4j.BoltyHelper.start_bolt6()
+
+# `:cypher25` — needs a Neo4j ≥ 2025.06 server (the Bolt6 pool / 2026.05).
+# `:bolt6` — reserved for tests that genuinely require the Bolt 6.0 protocol.
+ExUnit.start(exclude: [:show_neo4j, :bolt6, :cypher25])

--- a/test/types/vector_test.exs
+++ b/test/types/vector_test.exs
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Types.VectorTest do
+  @moduledoc """
+  Pure cast/constraint tests for `AshNeo4j.Types.Vector` — no Neo4j connection.
+
+  `dump_to_native/2`'s wire-format choice (native `%Bolty.Types.Vector{}` vs
+  plain float list) depends on the negotiated `policy.vectors` and is exercised
+  end-to-end in the `:bolt6` integration suite.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshNeo4j.Types.Vector
+
+  describe "cast_input/2" do
+    test "accepts a list of numbers, coercing to floats" do
+      assert {:ok, [1.0, 2.0, 3.0]} = Vector.cast_input([1, 2, 3], [])
+      assert {:ok, [0.1, 0.2]} = Vector.cast_input([0.1, 0.2], [])
+    end
+
+    test "unwraps a %Bolty.Types.Vector{} to a float list" do
+      assert {:ok, [1.0, 2.0, 3.0]} =
+               Vector.cast_input(%Bolty.Types.Vector{type: :float32, data: [1.0, 2.0, 3.0]}, [])
+    end
+
+    test "passes nil through" do
+      assert {:ok, nil} = Vector.cast_input(nil, [])
+    end
+
+    test "rejects non-numeric elements" do
+      assert {:error, _} = Vector.cast_input([1.0, "x", 3.0], [])
+    end
+
+    test "rejects non-list, non-vector input" do
+      assert {:error, _} = Vector.cast_input("not a vector", [])
+    end
+  end
+
+  describe "cast_stored/2" do
+    test "unwraps a %Bolty.Types.Vector{} (Bolt 6.0 read)" do
+      assert {:ok, [1.0, 2.0, 3.0]} =
+               Vector.cast_stored(%Bolty.Types.Vector{type: :float32, data: [1.0, 2.0, 3.0]}, [])
+    end
+
+    test "accepts a plain float list (Bolt 5.x read)" do
+      assert {:ok, [1.0, 2.0, 3.0]} = Vector.cast_stored([1.0, 2.0, 3.0], [])
+    end
+
+    test "passes nil through" do
+      assert {:ok, nil} = Vector.cast_stored(nil, [])
+    end
+  end
+
+  describe "apply_constraints/2" do
+    test "accepts a vector of the declared dimensions" do
+      assert {:ok, [1.0, 2.0, 3.0]} = Vector.apply_constraints([1.0, 2.0, 3.0], dimensions: 3)
+    end
+
+    test "rejects a dimension mismatch" do
+      assert {:error, msg} = Vector.apply_constraints([1.0, 2.0], dimensions: 3)
+      assert msg =~ "expected 3 dimensions"
+    end
+
+    test "skips the dimension check when no :dimensions constraint is set" do
+      assert {:ok, [1.0, 2.0, 3.0]} = Vector.apply_constraints([1.0, 2.0, 3.0], [])
+    end
+  end
+
+  describe "storage_type/1" do
+    test "is :string" do
+      assert Vector.storage_type([]) == :string
+    end
+  end
+end

--- a/test/vector_test.exs
+++ b/test/vector_test.exs
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.VectorTest do
+  @moduledoc """
+  Pure `AshNeo4j.Vector.index_statements/3` dry-run tests — no Neo4j connection.
+
+  Live vector search and index-lifecycle tests are in
+  `AshNeo4j.VectorSearchTest` (tagged `:cypher25`).
+  """
+  use ExUnit.Case, async: true
+
+  alias AshNeo4j.Test.Resource.ThingNote
+  alias AshNeo4j.Vector
+
+  describe "index_statements/3 (dry run, no connection)" do
+    test "renders CREATE VECTOR INDEX for a vector attribute" do
+      assert {:ok, cypher} = Vector.index_statements(ThingNote, :embedding)
+
+      assert cypher ==
+               "CREATE VECTOR INDEX thingnote_embedding_vector IF NOT EXISTS " <>
+                 "FOR (n:ThingNote) ON (n.embedding) " <>
+                 "OPTIONS {indexConfig: {`vector.dimensions`: 3, `vector.similarity_function`: 'cosine'}}"
+    end
+
+    test "honours the :similarity_function option" do
+      assert {:ok, cypher} = Vector.index_statements(ThingNote, :embedding, similarity_function: :euclidean)
+      assert cypher =~ "'euclidean'"
+    end
+
+    test "errors when the attribute is not AshNeo4j.Types.Vector" do
+      assert {:error, msg} = Vector.index_statements(ThingNote, :body)
+      assert msg =~ "not AshNeo4j.Types.Vector"
+    end
+  end
+end
+
+defmodule AshNeo4j.VectorSearchTest do
+  @moduledoc """
+  Live vector search and index lifecycle (#74).
+
+  Tagged `:cypher25` and `async: false`: these need a Cypher 25 server
+  (Neo4j ≥ 2025.06), provided by the `Bolt6` pool (Neo4j 2026.05), which they
+  route to via the process-scoped pool override. Embeddings are stored and
+  queried as `LIST<FLOAT>`, so similarity search does not actually require Bolt
+  6.0 — Cypher 25 is the only requirement. Each `Sandbox.checkout/0` holds a
+  transaction on that small pool, so they run serially. Cosine
+  similarity/distance is a plain Cypher function and needs no vector index, so
+  the search tests run inside the sandbox transaction.
+  """
+  use ExUnit.Case, async: false
+
+  require Ash.Query
+  import Ash.Expr
+
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.ThingNote
+  alias AshNeo4j.Vector
+
+  describe "vector search" do
+    @describetag :cypher25
+
+    setup do
+      Process.put(:ash_neo4j_pool, Bolt6)
+      Sandbox.checkout()
+      on_exit(&Sandbox.rollback/0)
+      :ok
+    end
+
+    # Three notes spread around the query direction [1,0,0]:
+    #   a → identical (similarity 1.0, distance 0.0)
+    #   b → orthogonal (similarity 0.5, distance 1.0)
+    #   c → opposite   (similarity 0.0, distance 2.0)
+    defp seed_notes do
+      a = ThingNote |> Ash.create!(%{body: "a", embedding: [1.0, 0.0, 0.0]})
+      b = ThingNote |> Ash.create!(%{body: "b", embedding: [0.0, 1.0, 0.0]})
+      c = ThingNote |> Ash.create!(%{body: "c", embedding: [-1.0, 0.0, 0.0]})
+      {a, b, c}
+    end
+
+    test "round-trips a vector property as a float list" do
+      note = ThingNote |> Ash.create!(%{body: "rt", embedding: [1.0, 2.0, 3.0]})
+      reloaded = ThingNote |> Ash.get!(note.id)
+      assert reloaded.embedding == [1.0, 2.0, 3.0]
+    end
+
+    test "filters by vector_cosine_distance threshold" do
+      {a, b, _c} = seed_notes()
+      q = [1.0, 0.0, 0.0]
+
+      {:ok, results} =
+        ThingNote
+        |> Ash.Query.filter(vector_cosine_distance(embedding, ^q) < 1.5)
+        |> Ash.read()
+
+      ids = MapSet.new(results, & &1.id)
+      # a (0.0) and b (1.0) are within 1.5; c (2.0) is excluded.
+      assert MapSet.new([a.id, b.id]) == ids
+    end
+
+    test "sorts by vector_cosine_distance ascending (closest first)" do
+      {a, b, c} = seed_notes()
+      q = [1.0, 0.0, 0.0]
+
+      {:ok, results} =
+        ThingNote
+        |> Ash.Query.sort({calc(vector_cosine_distance(embedding, ^q), type: :float), :asc})
+        |> Ash.read()
+
+      assert Enum.map(results, & &1.id) == [a.id, b.id, c.id]
+    end
+
+    test "sorts by vector_similarity descending (closest first)" do
+      {a, b, c} = seed_notes()
+      q = [1.0, 0.0, 0.0]
+
+      {:ok, results} =
+        ThingNote
+        |> Ash.Query.sort({calc(vector_similarity(embedding, ^q), type: :float), :desc})
+        |> Ash.read()
+
+      assert Enum.map(results, & &1.id) == [a.id, b.id, c.id]
+    end
+
+    test "sort + limit returns the top-k nearest" do
+      {a, b, _c} = seed_notes()
+      q = [1.0, 0.0, 0.0]
+
+      {:ok, results} =
+        ThingNote
+        |> Ash.Query.sort({calc(vector_cosine_distance(embedding, ^q), type: :float), :asc})
+        |> Ash.Query.limit(2)
+        |> Ash.read()
+
+      assert Enum.map(results, & &1.id) == [a.id, b.id]
+    end
+  end
+
+  describe "index lifecycle (live)" do
+    @describetag :cypher25
+
+    setup do
+      # No sandbox: CREATE/DROP INDEX is a schema op and cannot share an explicit
+      # data transaction. Route to Bolt6 and clean up the index explicitly.
+      Process.put(:ash_neo4j_pool, Bolt6)
+      # on_exit runs in a separate process without the pool override — set it there too.
+      on_exit(fn -> BoltyHelper.with_pool(Bolt6, fn -> Vector.drop_index(ThingNote, :embedding) end) end)
+      :ok
+    end
+
+    test "create_index/3 then drop_index/3 succeed against the live server" do
+      assert {:ok, _} = Vector.create_index(ThingNote, :embedding)
+      # idempotent — IF NOT EXISTS
+      assert {:ok, _} = Vector.create_index(ThingNote, :embedding)
+      assert {:ok, _} = Vector.drop_index(ThingNote, :embedding)
+    end
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -150,6 +150,31 @@ Place
 
 WGS-84 2D only in this release. On disk, each geometry stores as a canonical RFC 7946 GeoJSON `STRING` at `<attr>.json` plus scalar Point companions for indexed bbox prefilter (`<attr>.bbSW`/`<attr>.bbNE`); Point additionally keeps a native `<attr>.point` for `point.distance` pushdown. **Geometries nested inside TypedStructs / embedded resources get their indexable companion promoted to a node-level property too** — a location buried in a characteristic is still indexable. Storage is **indexable, not yet indexed** — `AshNeo4j.Spatial.create_index(Place, :location)` builds and runs the POINT index Cypher from the resource + attribute (operator-invoked, not automatic). `AshNeo4j.Type.Point` / `AshNeo4j.Type.Box` were removed in 0.8.0 — full migration notes, recursive-promotion details, holiness composition, and limitations in `usage-rules/spatial.md`.
 
+## Vector embeddings and similarity search
+
+AshNeo4j stores vector embeddings with the `AshNeo4j.Types.Vector` attribute type (Elixir `[float()]`, persisted as a Neo4j `LIST<FLOAT>`) and ranks/filters them with the `vector_similarity` and `vector_cosine_distance` expression functions. The requirement is **Cypher 25 (Neo4j ≥ 2025.06), not Bolt 6.0** — with list storage and list params, similarity search works over Bolt 5.8. The built-in `Ash.Type.Vector` is a different module and is not supported; use `AshNeo4j.Types.Vector`.
+
+```elixir
+attributes do
+  attribute :embedding, AshNeo4j.Types.Vector,
+    constraints: [element_type: :float32, dimensions: 1536]
+end
+
+require Ash.Query
+import Ash.Expr
+
+# rank notes by relevance (ash_ai-compatible distance: ascending = closest first)
+Note
+|> Ash.Query.filter(vector_cosine_distance(embedding, ^query_vector) < 0.5)
+|> Ash.Query.sort({calc(vector_cosine_distance(embedding, ^query_vector), type: :float), :asc})
+|> Ash.Query.limit(10)
+|> Ash.read!()
+```
+
+`vector_similarity(attr, ^q)` is Neo4j's normalised cosine similarity in `[0,1]` (higher = closer); `vector_cosine_distance(attr, ^q)` is pgvector-style distance in `[0,2]` (lower = closer, same name/semantics as AshPostgres so a future ash_ai bridge composes). Both push down to `vector.similarity.cosine(...)` in `WHERE` and `ORDER BY` (distance as `2 * (1 - similarity)`), with an in-memory evaluation that mirrors the same normalisation. `AshNeo4j.Vector.create_index/3` / `drop_index/3` / `index_statements/3` build the `CREATE VECTOR INDEX` Cypher from a resource + attribute.
+
+Note: queries are currently a **full scan** — Neo4j does not use the HNSW vector index for `vector.similarity.cosine` in a `WHERE`/`ORDER BY`. Indexed top-K via `db.index.vector.queryNodes` / the `SEARCH` clause is tracked in [#297](https://github.com/diffo-dev/ash_neo4j/issues/297). Full details — normalisation maths, index lifecycle, and `:cypher25` test pool routing — in `usage-rules/vectors.md`.
+
 ## Combination queries
 
 AshNeo4j supports all five [Ash combination query types](https://hexdocs.pm/ash/combination-queries.html) — `:base`, `:union`, `:union_all`, `:intersect`, `:except`. Combinations of `:union` / `:union_all` push down to a single Cypher `CALL { … UNION/UNION ALL … }` block; combinations involving `:intersect` / `:except` (or mixed union types) are computed in Elixir over `MapSet`s of node ids, then the keep-set is fetched in one final query.

--- a/usage-rules/vectors.md
+++ b/usage-rules/vectors.md
@@ -1,0 +1,165 @@
+<!--
+SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+
+SPDX-License-Identifier: MIT
+-->
+
+# Vector embeddings and similarity search
+
+AshNeo4j stores vector embeddings with the `AshNeo4j.Types.Vector` attribute type and ranks/filters them with the `vector_similarity` and `vector_cosine_distance` expression functions. Both push down to Neo4j's `vector.similarity.cosine/2`, falling back to an exact in-memory evaluation otherwise.
+
+> **Cypher 25 is the requirement — not Bolt 6.0.** Embeddings are stored and queried as `LIST<FLOAT>`, which is what `vector.similarity.cosine/2` operates on, so similarity search works on any Neo4j ≥ 2025.06 server over Bolt 5.8. The native Bolt 6.0 `%Bolty.Types.Vector{}` type is a query-parameter wire type that **cannot be written as a node property**, so AshNeo4j never uses it for storage.
+
+## Declaring a vector attribute
+
+```elixir
+attributes do
+  attribute :embedding, AshNeo4j.Types.Vector,
+    public?: true,
+    constraints: [element_type: :float32, dimensions: 1536]
+end
+```
+
+| Constraint | Values | Meaning |
+|---|---|---|
+| `:element_type` | `:float32` (default), `:float64` | Element precision. Carried into the vector index config; storage is always a Neo4j float list. |
+| `:dimensions` | positive integer | Expected vector length. Validated on cast (a wrong-length vector is rejected) and used by `AshNeo4j.Vector.create_index/3`. |
+
+The Elixir-side value is a plain `[float()]` list:
+
+```elixir
+note = Note |> Ash.create!(%{body: "…", embedding: [0.12, -0.04, 0.98, ...]})
+note.embedding  #=> [0.12, -0.04, 0.98, ...]
+```
+
+`cast_input/2` and `cast_stored/2` also accept a `%Bolty.Types.Vector{}` defensively and unwrap it to `[float()]`, but Neo4j never returns one (it can't store one), so reads are always plain lists.
+
+> The built-in `Ash.Type.Vector` is a different module and is **not** supported by AshNeo4j — use `AshNeo4j.Types.Vector`.
+
+## On-disk shape
+
+The embedding is stored as a single `LIST<FLOAT>` node property at the attribute's translated (camelCase) property name — no companions, no JSON wrapping:
+
+```
+embedding = [0.12, -0.04, 0.98, ...]   (Neo4j LIST<FLOAT>)
+```
+
+This is exactly the shape Neo4j's vector index and `vector.similarity.cosine/2` expect.
+
+## Expression functions
+
+| Function | Returns | Scale | Order |
+|---|---|---|---|
+| `vector_similarity(attr, ^q)` | float — Neo4j-normalised cosine similarity | `[0.0, 1.0]` (`1.0` identical, `0.5` orthogonal, `0.0` opposite) | higher = closer |
+| `vector_cosine_distance(attr, ^q)` | float — pgvector-style cosine distance | `[0.0, 2.0]` (`0.0` identical, `2.0` opposite) | lower = closer |
+
+Neo4j's `vector.similarity.cosine/2` returns a **normalised** similarity `(1 + raw_cosine) / 2` in `[0, 1]` — not the raw `[-1, 1]` cosine. `vector_similarity` exposes that value directly; `vector_cosine_distance` rescales it to pgvector's `<=>` semantics as `2 * (1 - similarity)` (which equals `1 - raw_cosine`).
+
+```elixir
+require Ash.Query
+import Ash.Expr
+
+q = embed("a natural-language query")   # your embedding model → [float()]
+
+# rank by relevance, ash_ai-style (distance: ascending, closest first)
+Note
+|> Ash.Query.filter(vector_cosine_distance(embedding, ^q) < 0.5)
+|> Ash.Query.sort({calc(vector_cosine_distance(embedding, ^q), type: :float), :asc})
+|> Ash.Query.limit(10)
+|> Ash.read!()
+
+# or with similarity (descending, closest first)
+Note
+|> Ash.Query.sort({calc(vector_similarity(embedding, ^q), type: :float), :desc})
+|> Ash.Query.limit(10)
+|> Ash.read!()
+```
+
+Both functions push down to Cypher:
+
+```cypher
+-- vector_similarity(embedding, $q)
+vector.similarity.cosine(s.embedding, $q)
+
+-- vector_cosine_distance(embedding, $q)
+(2.0 * (1.0 - vector.similarity.cosine(s.embedding, $q)))
+```
+
+in both `WHERE` (filter) and `ORDER BY` (sort). The query embedding is bound as a plain `LIST<FLOAT>` parameter.
+
+### Pushdown agrees with in-memory evaluation
+
+The data layer always re-applies a query's filter in Elixir (`Ash.Filter.Runtime`) after the Cypher read, treating the pushdown as an over-selecting prefilter. So `evaluate/1` for both functions computes the **same** value the Cypher does — mirroring Neo4j's `(1 + raw_cosine)/2` normalisation exactly (`AshNeo4j.Functions.VectorMath`). This also means the functions work correctly even with no pushdown (pure in-memory), and a `nil` or wrong-shaped embedding evaluates to `nil` (excluded).
+
+### ash_ai interop
+
+`vector_cosine_distance` deliberately mirrors the name and semantics of AshPostgres/pgvector's `vector_cosine_distance` (`<=>`), so the same `read` action expression composes across data layers:
+
+```elixir
+read :search do
+  argument :query, :string, allow_nil?: false
+
+  prepare before_action(fn query, _ctx ->
+    {:ok, [v]} = MyApp.Embeddings.generate([query.arguments.query], [])
+
+    query
+    |> Ash.Query.filter(vector_cosine_distance(embedding, ^v) < 0.5)
+    |> Ash.Query.sort({calc(vector_cosine_distance(embedding, ^v), type: :float), :asc})
+    |> Ash.Query.limit(10)
+  end)
+end
+```
+
+## Indexes — indexable, not yet indexed in queries
+
+`AshNeo4j.Vector` builds and runs the `CREATE VECTOR INDEX` Cypher from a resource + attribute, so you don't hand-encode the label, translated property name, dimensions, and similarity function:
+
+```elixir
+# Create the HNSW vector index for a vector attribute
+AshNeo4j.Vector.create_index(Note, :embedding)
+
+# Euclidean distance instead of the default cosine
+AshNeo4j.Vector.create_index(Note, :embedding, similarity_function: :euclidean)
+
+# Rebuild after a dimensions / similarity-function change (DROP IF EXISTS + CREATE)
+AshNeo4j.Vector.create_index(Note, :embedding, recreate: true)
+
+# Symmetric remove
+AshNeo4j.Vector.drop_index(Note, :embedding)
+
+# Dry run — the CREATE Cypher without touching the database
+AshNeo4j.Vector.index_statements(Note, :embedding)
+#=> {:ok, "CREATE VECTOR INDEX note_embedding_vector IF NOT EXISTS " <>
+#=>       "FOR (n:Note) ON (n.embedding) " <>
+#=>       "OPTIONS {indexConfig: {`vector.dimensions`: 1536, `vector.similarity_function`: 'cosine'}}"}
+```
+
+`create_index/3` uses `IF NOT EXISTS`, so it's safe to call repeatedly (e.g. from a start-up task). The `:dimensions` constraint is required on the attribute — the index needs the vector size. Consistent with AshNeo4j's no-migrations stance, index lifecycle is a deliberate operator concern; AshNeo4j just doesn't do it *for* you.
+
+> **The index does not yet accelerate queries.** Unlike pgvector — where `ORDER BY embedding <=> $q LIMIT k` transparently uses the HNSW index — Neo4j does **not** consult the vector index for `vector.similarity.cosine` in a `WHERE`/`ORDER BY`. The current pushdown is correct but a **full scan**: every node reached by the `MATCH` is scored. The HNSW index is only consulted by `db.index.vector.queryNodes` / the Cypher 25 `SEARCH` clause, which replace the `MATCH` entirely — tracked as indexed-KNN follow-up [#297](https://github.com/diffo-dev/ash_neo4j/issues/297). Create the index now (so it's ready and populated); query acceleration lands with #297.
+
+## Testing against a Cypher 25 server
+
+The default test pool (`Bolt`) targets a pre-2025.06 server, so vector tests need a Cypher-25-capable pool. AshNeo4j's test suite configures a second `Bolt6` pool (Neo4j 2026.05) and routes to it per-process:
+
+```elixir
+use ExUnit.Case, async: false   # the pool is small and the sandbox holds a connection
+
+@describetag :cypher25          # excluded from the default run
+
+setup do
+  Process.put(:ash_neo4j_pool, Bolt6)   # route this process's queries + capability checks
+  AshNeo4j.Sandbox.checkout()
+  on_exit(&AshNeo4j.Sandbox.rollback/0)
+end
+```
+
+`AshNeo4j.BoltyHelper.with_pool/2` wraps the override for code that runs in a separate process (e.g. an `on_exit` cleanup). Cosine similarity is a plain Cypher function and needs no index, so search tests run inside the sandbox transaction. See `usage-rules/testing.md` for the pool-routing details.
+
+## Limitations
+
+- **Queries are a full scan** — the vector index is not yet used for `vector.similarity.cosine`. Fine for modest vector counts; indexed top-K is [#297](https://github.com/diffo-dev/ash_neo4j/issues/297).
+- **No native `db.index.vector.queryNodes` / `SEARCH` primitive yet** — there is no `vector_near(attr, ^q, top_k: n)`; ranking is expressed as `sort + limit` over the cosine expression (#297).
+- **Cosine only at the expression level** — `vector_similarity` / `vector_cosine_distance` are cosine; euclidean is available at the *index* level (`similarity_function: :euclidean`) but not yet as an expression function.
+- **Storage is `LIST<FLOAT>`** — the native Bolt 6.0 VECTOR type cannot be persisted as a node property, by design here.
+- **Index lifecycle is the operator's responsibility** (no migrations).


### PR DESCRIPTION
Closes #74.

Adds vector embedding support to AshNeo4j: a vector attribute type, cosine similarity/distance query functions (filter + sort), and vector-index lifecycle helpers.

## What's included

**Storage** — `AshNeo4j.Types.Vector`
- Elixir value is `[float()]`; persisted as a Neo4j `LIST<FLOAT>` node property.
- The native Bolt 6.0 `%Bolty.Types.Vector{}` type **cannot** be written as a node property (verified against Neo4j 2026.05 community), so it is never used for storage. `cast_input/2` and `cast_stored/2` still accept it defensively and unwrap to a list.
- Constraints: `:element_type` (`:float32` default / `:float64`), `:dimensions` (validated on cast).

**Query functions**
- `vector_similarity(attr, ^q)` — Neo4j-normalised cosine similarity in `[0,1]` (higher = closer).
- `vector_cosine_distance(attr, ^q)` — ash_ai-compatible pgvector-style distance in `[0,2]` (lower = closer); same name/semantics as AshPostgres so a future ash_ai bridge composes.
- Both push down to `vector.similarity.cosine(...)` in `WHERE` and `ORDER BY` (distance as `2 * (1 - similarity)`), and implement `evaluate/1` (shared `AshNeo4j.Functions.VectorMath`) mirroring Neo4j's `(1 + raw_cosine)/2` normalisation — required because the data layer re-applies filters in-memory via `Ash.Filter.Runtime`.

**Sort pushdown**
- The ORDER BY term contract now carries fully-formed expressions + params, so `sort({calc(vector_*(...), type: :float), :asc|:desc})` pushes the cosine expression down with the query embedding bound as a param.

**Index lifecycle** — `AshNeo4j.Vector`
- `create_index/3`, `drop_index/3`, `index_statements/3` (dry run) for `CREATE VECTOR INDEX`.

**Capability gating + pool routing**
- The gate is **Cypher 25 (Neo4j ≥ 2025.06), not Bolt 6.0** — with list storage and list params, similarity search works over Bolt 5.8.
- `BoltyHelper` gains `current_pool/0` + `with_pool/2` and pool-aware `policy/1` / `cypher25?/1` (cached per pool). The data layer routes through `current_pool()`, letting `:cypher25` tests target the Neo4j 2026.05 pool while the default suite stays on 5.26.26.

## Usage

```elixir
attribute :embedding, AshNeo4j.Types.Vector,
  constraints: [element_type: :float32, dimensions: 1536]

# rank notes by relevance, ash_ai-style
Note
|> Ash.Query.filter(vector_cosine_distance(embedding, ^q) < 0.5)
|> Ash.Query.sort({calc(vector_cosine_distance(embedding, ^q), type: :float), :asc})
|> Ash.Query.limit(10)
|> Ash.read!()
```

## Tests

- Pure unit tests: type cast/constraints, `evaluate/1` maths, `index_statements/3` dry run.
- Live `:cypher25` integration: round-trip, filter, sort (similarity + distance), sort+limit, index create/drop — run against the Neo4j 2026.05 pool, excluded by default.
- Full suite: 581 passing (575 default + 6 `:cypher25`).

## Follow-up

#297 — indexed KNN via `db.index.vector.queryNodes` / `SEARCH` clause. The pushdown here is correct but full-scan (Neo4j does not use the HNSW index for `ORDER BY vector.similarity.cosine`); #297 is the performance path for large vector sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)