### PR TITLE
fix: root-node aggregates aggregate over s, not unbound d (#291)

### DIFF
--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -601,20 +601,36 @@ defmodule AshNeo4j.Cypher.Query do
         dest_conditions \\ []
       )
       when is_atom(pk_field) and is_list(ids) and is_list(path_segments) and is_atom(kind) do
-    path = build_agg_path(path_segments)
-    expr = aggregate_expr(kind, field, name, uniq?)
     src = labels_string(source_label)
-    {dest_where, dest_params} = build_dest_conditions(dest_conditions)
 
-    %__MODULE__{
-      clauses:
-        [
-          %Match{pattern: "(s:#{src})"},
-          %Where{conditions: ["s.#{pk_field} IN $agg_ids"]},
-          %OptionalMatch{pattern: "(s)#{path}"}
-        ] ++ dest_where ++ [%Return{items: [expr]}],
-      params: Map.merge(%{"agg_ids" => ids}, dest_params)
-    }
+    case path_segments do
+      [] ->
+        # Root-node aggregate (no relationship path, #291) — aggregate over the
+        # source node `s` directly; there is no `d` to bind, so no OPTIONAL MATCH.
+        %__MODULE__{
+          clauses: [
+            %Match{pattern: "(s:#{src})"},
+            %Where{conditions: ["s.#{pk_field} IN $agg_ids"]},
+            %Return{items: [aggregate_expr(kind, field, name, uniq?, "s")]}
+          ],
+          params: %{"agg_ids" => ids}
+        }
+
+      _ ->
+        path = build_agg_path(path_segments)
+        expr = aggregate_expr(kind, field, name, uniq?)
+        {dest_where, dest_params} = build_dest_conditions(dest_conditions)
+
+        %__MODULE__{
+          clauses:
+            [
+              %Match{pattern: "(s:#{src})"},
+              %Where{conditions: ["s.#{pk_field} IN $agg_ids"]},
+              %OptionalMatch{pattern: "(s)#{path}"}
+            ] ++ dest_where ++ [%Return{items: [expr]}],
+          params: Map.merge(%{"agg_ids" => ids}, dest_params)
+        }
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -962,14 +978,16 @@ defmodule AshNeo4j.Cypher.Query do
     end)
   end
 
-  defp aggregate_expr(kind, field, name, uniq?) do
+  # `node_var` is the node the aggregate runs over — `"d"` for a relationship
+  # traversal, `"s"` for a root-node aggregate (empty relationship path, #291).
+  defp aggregate_expr(kind, field, name, uniq?, node_var \\ "d") do
     distinct = if uniq?, do: "DISTINCT ", else: ""
-    field_ref = if field, do: "d.#{field}", else: "d"
+    field_ref = if field, do: "#{node_var}.#{field}", else: node_var
 
     fn_str =
       case kind do
-        :count -> "COUNT(#{distinct}d)"
-        :exists -> "COUNT(d) > 0"
+        :count -> "COUNT(#{distinct}#{node_var})"
+        :exists -> "COUNT(#{node_var}) > 0"
         :sum -> "sum(#{distinct}#{field_ref})"
         :avg -> "avg(#{distinct}#{field_ref})"
         :min -> "min(#{field_ref})"

--- a/test/aggregate_test.exs
+++ b/test/aggregate_test.exs
@@ -11,7 +11,6 @@ defmodule AshNeo4j.AggregateTest do
   alias AshNeo4j.Test.Resource.Post
   alias AshNeo4j.Test.Resource.Comment
   alias AshNeo4j.Test.Type.DogTypedStruct
-  require Ash.Query
   require Ash.Expr
 
   setup_all do
@@ -348,6 +347,36 @@ defmodule AshNeo4j.AggregateTest do
 
       [loaded] = Post |> Ash.read!() |> Ash.load!([:comment_dogs])
       assert loaded.comment_dogs == []
+    end
+  end
+
+  # #291 — aggregates with no relationship path (counting root nodes directly)
+  # must aggregate over the source node `s`, not an unbound `d`.
+  describe "root-node aggregates (no relationship path)" do
+    test "Ash.count/1 counts root nodes" do
+      author = create_author()
+      create_post(author, "p1")
+      create_post(author, "p2")
+      create_post(author, "p3")
+
+      assert {:ok, 3} = Ash.count(Post)
+    end
+
+    test "Ash.count/1 returns 0 when there are no nodes" do
+      assert {:ok, 0} = Ash.count(Post)
+    end
+
+    test "Ash.aggregate/3 :count over root nodes" do
+      author = create_author()
+      create_post(author, "p1")
+      create_post(author, "p2")
+
+      assert {:ok, %{n: 2}} = Ash.aggregate(Post, {:n, :count, []})
+    end
+
+    test "Ash.aggregate/3 :exists over root nodes is true when present" do
+      create_post(create_author(), "p1")
+      assert {:ok, %{any: true}} = Ash.aggregate(Post, {:any, :exists, []})
     end
   end
 end

--- a/test/cypher_test.exs
+++ b/test/cypher_test.exs
@@ -401,4 +401,47 @@ defmodule AshNeo4j.CypherTest do
       assert Query.paginate_nodes(base, [], nil, nil) == base
     end
   end
+
+  # #291 — a root-node aggregate has an empty path; it must aggregate over the
+  # source node `s` with no OPTIONAL MATCH, never an unbound `d`.
+  describe "aggregate_total — root-node aggregate (empty path)" do
+    alias AshNeo4j.Cypher.Query
+
+    test "count over root nodes renders COUNT(s) with no OPTIONAL MATCH" do
+      {cypher, params} =
+        Query.aggregate_total([:Nbn, :Nni], :uuid, ["a", "b"], [], :count, nil, :count)
+        |> Cypher.render()
+
+      assert cypher == "MATCH (s:Nbn:Nni) WHERE s.uuid IN $agg_ids RETURN COUNT(s) AS `count`"
+      assert params == %{"agg_ids" => ["a", "b"]}
+      refute cypher =~ "OPTIONAL MATCH"
+      refute cypher =~ ~r/\bd\b/
+    end
+
+    test "exists over root nodes renders COUNT(s) > 0" do
+      {cypher, _} =
+        Query.aggregate_total([:Nbn, :Nni], :uuid, ["a"], [], :exists, nil, :any)
+        |> Cypher.render()
+
+      assert cypher == "MATCH (s:Nbn:Nni) WHERE s.uuid IN $agg_ids RETURN COUNT(s) > 0 AS `any`"
+    end
+
+    test "sum over a root-node property aggregates over s.field" do
+      {cypher, _} =
+        Query.aggregate_total([:Nbn, :Nni], :uuid, ["a"], [], :sum, :score, :total)
+        |> Cypher.render()
+
+      assert cypher == "MATCH (s:Nbn:Nni) WHERE s.uuid IN $agg_ids RETURN sum(s.score) AS `total`"
+    end
+
+    test "a relationship aggregate (non-empty path) still traverses to d" do
+      {cypher, _} =
+        Query.aggregate_total([:Nbn, :Nni], :uuid, ["a"], [{:HAS, :outgoing, :Port}], :count, nil, :count)
+        |> Cypher.render()
+
+      assert cypher ==
+               "MATCH (s:Nbn:Nni) WHERE s.uuid IN $agg_ids " <>
+                 "OPTIONAL MATCH (s)-[:HAS]->(d:Port) RETURN COUNT(d) AS `count`"
+    end
+  end
 end


### PR DESCRIPTION
Closes #291.

`Ash.count/1` on a resource — and any aggregate with an empty `relationship_path` (counting root nodes directly, not traversing a relationship) — produced invalid Cypher referencing an unbound `d`:

```
MATCH (s:Nbn:Nni) WHERE s.uuid IN $agg_ids OPTIONAL MATCH (s) RETURN COUNT(d) AS `count`
                                                                       ^ d never bound
```

## Cause

`build_agg_path([])` returns `""`, so `OPTIONAL MATCH (s)` binds nothing and `aggregate_expr` still references `d`.

## Fix

`AshNeo4j.Cypher.Query.aggregate_total/9` now special-cases an empty path — it aggregates over the source node `s` directly, with no `OPTIONAL MATCH`:

```
MATCH (s:Nbn:Nni) WHERE s.uuid IN $agg_ids RETURN COUNT(s) AS `count`
```

`aggregate_expr` takes the node variable (`"s"` for root-node, `"d"` for a relationship traversal), so the same builder serves both. Relationship aggregates are unchanged.

## Tests

- `Ash.count` / `Ash.aggregate` `:count` / `:exists` over root nodes.
- Cypher-layer assertions: empty-path renders `COUNT(s)` / `sum(s.field)` with no `OPTIONAL MATCH` and no `d`; a relationship aggregate still traverses to `d`.

## Follow-up

`exists` aggregates over an **empty** result still return the (nil) default rather than `false` — a separate empty-default issue (affects relationship exists too), filed separately and not addressed here.