### PR TITLE
fix: emit the CYPHER 25 selector once, not per-branch inside CALL {…} (#299)

### DIFF
--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -343,8 +343,15 @@ defmodule AshNeo4j.Cypher do
   "CALL { MATCH (s:Place) WHERE s.uuid = $b0_s_uuid_0 RETURN s UNION ALL MATCH (s:Place) WHERE s.uuid = $b1_s_uuid_0 RETURN s } OPTIONAL MATCH (s)-[r]-(d) RETURN s, r, d"
   ```
   """
-  def render(%Query{clauses: clauses, params: params}) do
-    {cypher25_prefix() <> Enum.map_join(clauses, " ", &render_clause/1), params}
+  def render(query, opts \\ [])
+
+  def render(%Query{clauses: clauses, params: params}, opts) do
+    # The CYPHER 25 language selector may appear only once, at the very start of
+    # a query — never inside a subquery. Branches assembled into a `CALL { … }`
+    # block are rendered with `prefix?: false` so only the outer query carries
+    # the prefix (#299).
+    prefix = if Keyword.get(opts, :prefix?, true), do: cypher25_prefix(), else: ""
+    {prefix <> Enum.map_join(clauses, " ", &render_clause/1), params}
   end
 
   defp cypher25_prefix, do: if(BoltyHelper.cypher25?(), do: "CYPHER 25 ", else: "")

--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -345,7 +345,9 @@ defmodule AshNeo4j.Cypher.Query do
 
     {rendered_branches, merged_params} =
       Enum.reduce(branches, {[], %{}}, fn branch, {acc_cyphers, acc_params} ->
-        {cypher, branch_params} = Cypher.render(branch)
+        # prefix?: false — the CYPHER 25 selector belongs only on the outer
+        # query, never on a branch inside the CALL { … } block (#299).
+        {cypher, branch_params} = Cypher.render(branch, prefix?: false)
         {[cypher | acc_cyphers], Map.merge(acc_params, branch_params)}
       end)
 

--- a/test/combination_test.exs
+++ b/test/combination_test.exs
@@ -159,3 +159,63 @@ defmodule AshNeo4j.CombinationTest do
     end
   end
 end
+
+defmodule AshNeo4j.CombinationCypher25Test do
+  @moduledoc """
+  #299 — on a Cypher 25 server the `CYPHER 25` selector must appear only once,
+  at the start of the outer query, never inside the `CALL { … }` block of a
+  native combination query. Tagged `:cypher25` / `async: false` (routes to the
+  Neo4j 2026.05 `Bolt6` pool; excluded by default).
+  """
+  use ExUnit.Case, async: false
+
+  require Ash.Query
+  import Ash.Expr
+
+  alias AshNeo4j.Cypher
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.Author
+
+  @moduletag :cypher25
+
+  setup do
+    Process.put(:ash_neo4j_pool, Bolt6)
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+    :ok
+  end
+
+  test "UNION ALL combination runs end-to-end against a Cypher 25 server" do
+    alice = Author |> Ash.create!(%{name: "Alice"})
+    bob = Author |> Ash.create!(%{name: "Bob"})
+    _charlie = Author |> Ash.create!(%{name: "Charlie"})
+
+    {:ok, results} =
+      Author
+      |> Ash.Query.combination_of([
+        Ash.Query.Combination.base(filter: expr(name == "Alice")),
+        Ash.Query.Combination.union_all(filter: expr(name == "Bob"))
+      ])
+      |> Ash.read()
+
+    ids = Enum.map(results, & &1.id)
+    assert alice.id in ids
+    assert bob.id in ids
+    assert length(results) == 2
+  end
+
+  test "the CYPHER 25 selector appears once, only on the outer query" do
+    b0 = Cypher.Query.branch_node_read(:Place, [{"name", :==, "X", false}], param_prefix: "b0_")
+    b1 = Cypher.Query.branch_node_read(:Place, [{"name", :==, "Y", false}], param_prefix: "b1_")
+
+    {cypher, _} =
+      [b0, b1]
+      |> Cypher.Query.combination_block(union_type: :union_all)
+      |> Cypher.render()
+
+    # prefix is active (we routed to the Cypher 25 pool)
+    assert String.starts_with?(cypher, "CYPHER 25 CALL {")
+    # and it appears exactly once — no embedded prefix inside the CALL block
+    assert length(String.split(cypher, "CYPHER 25 ")) == 2
+  end
+end


### PR DESCRIPTION
Closes #299.

On a Cypher 25 server (Neo4j ≥ 2025.06, `cypher25?/0` true), native combination queries (`:union` / `:union_all` pushdown) generated invalid Cypher — the `CYPHER 25` selector was applied to each branch *inside* the `CALL { … }` block as well as to the outer query:

```
CYPHER 25 CALL { CYPHER 25 MATCH (s:Place) … UNION ALL CYPHER 25 MATCH (s:Place) … } …
```

The selector may appear only once, at the very start of a query — never inside a subquery.

## Cause

`AshNeo4j.Cypher.Query.combination_block/2` rendered each branch with `Cypher.render/1`, which prepends `cypher25_prefix()`. The combined query was then rendered again by the outer run/render, prepending the prefix a second time.

## Fix

`Cypher.render/2` takes a `prefix?:` option (default `true`). `combination_block/2` renders branches with `prefix?: false`, so only the outer query carries the selector:

```
CYPHER 25 CALL { MATCH (s:Place) … UNION ALL MATCH (s:Place) … } …
```

## Tests

New `:cypher25` regression tests (routed to the Neo4j 2026.05 pool, excluded by default):
- a `UNION ALL` combination runs end-to-end against a Cypher 25 server (errored before the fix);
- the rendered combination query starts with `CYPHER 25 CALL {` and contains the selector exactly once.

Found by pointing the test pool at the 2026.05 server and running the suite under active `CYPHER 25` — see the discussion on #299.