### PR TITLE
fix: exists aggregate over an empty result is false, not nil (#301)

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -1260,6 +1260,13 @@ defmodule AshNeo4j.DataLayer do
     end
   end
 
+  # No source nodes — return the empty value for the aggregate. `exists` over an
+  # empty set is `false` (not the nil default Ash carries for it, #301); other
+  # kinds use their declared default (`count` is 0).
+  defp run_aggregate_for_ids(_mapping, _neo4j_pk, [], %{kind: :exists}, _mode) do
+    {:ok, false}
+  end
+
   defp run_aggregate_for_ids(_mapping, _neo4j_pk, [], aggregate, _mode) do
     {:ok, aggregate.default_value}
   end

--- a/test/aggregate_test.exs
+++ b/test/aggregate_test.exs
@@ -379,4 +379,19 @@ defmodule AshNeo4j.AggregateTest do
       assert {:ok, %{any: true}} = Ash.aggregate(Post, {:any, :exists, []})
     end
   end
+
+  # #301 — an exists aggregate over an empty result must be false, not nil.
+  describe "exists over an empty result (#301)" do
+    test "root-node exists is false when there are no nodes" do
+      assert {:ok, %{any: false}} = Ash.aggregate(Post, {:any, :exists, []})
+    end
+
+    test "relationship exists is false when there are no source nodes" do
+      assert {:ok, %{has: false}} = Ash.aggregate(Post, {:has, :exists, [path: [:comments]]})
+    end
+
+    test "Ash.exists?/1 is false on an empty resource" do
+      assert Ash.exists?(Post) == false
+    end
+  end
 end


### PR DESCRIPTION
Closes #301.

An `exists` aggregate whose source set is empty returned `nil` rather than `false`:

```elixir
# empty database
Ash.aggregate(Post, {:any, :exists, []})   #=> {:ok, %{any: nil}}   (expected false)
Ash.exists?(Post)                            #=> nil                  (expected false)
```

`count` was correct in the same situation (`0`) because its default is `0`.

## Cause

When the base read yields no source ids, `run_aggregate_for_ids/5` short-circuits to `{:ok, aggregate.default_value}`. For `exists`, Ash carries a `nil` default, so the empty case returned `nil`.

## Fix

Special-case the `:exists` kind in the empty-ids clause to return `false`. Applies to both root-node and relationship `exists` aggregates with no source nodes; other kinds keep their declared default.

## Tests

- root-node `exists` over an empty resource is `false`;
- relationship `exists` with no source nodes is `false`;
- `Ash.exists?/1` is `false` on an empty resource.

Full suite green across seeds 0–2 (587 passed).