### PR TITLE
fix: cap test concurrency to the Bolt pool — stop intermittent queue_timeout flakiness (#304)

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,4 +11,14 @@ AshNeo4j.BoltyHelper.start_bolt6()
 
 # `:cypher25` — needs a Neo4j ≥ 2025.06 server (the Bolt6 pool / 2026.05).
 # `:bolt6` — reserved for tests that genuinely require the Bolt 6.0 protocol.
-ExUnit.start(exclude: [:show_neo4j, :bolt6, :cypher25])
+#
+# Cap test concurrency to the Bolt pool (#304). Each async test holds one sandbox
+# connection (an open transaction) for its whole duration, so concurrency must
+# not exceed the pool — otherwise tests contend for connections and fail in a
+# cluster with DBConnection `:queue_timeout`. ExUnit's default `max_cases` is
+# 2× schedulers, which exceeds the pool on many-core machines; tie it to the Bolt
+# `pool_size` instead (the overflow connections absorb transient, cached
+# `connection_info` checkouts).
+bolt_pool_size = Application.get_env(:bolty, Bolt)[:pool_size] || 15
+
+ExUnit.start(exclude: [:show_neo4j, :bolt6, :cypher25], max_cases: bolt_pool_size)


### PR DESCRIPTION
Closes #304.

## Symptom
The full suite intermittently failed ~20 tests in a cluster and passed on an immediate re-run, with no code change — undermining CI signal (and it would have made the #306 benchmark numbers untrustworthy).

## Root cause
Each async test's `AshNeo4j.Sandbox.checkout/0` holds **one Bolt connection (an open transaction) for the whole test**. ExUnit's default `max_cases` is **2× schedulers** — 20 on a 10-core machine — but the Bolt pool serves **`pool_size` 15 + 3 overflow = 18**. On a busy run, 20 concurrent tests contend for 18 connections and the sandbox transactions fail with `DBConnection` `:queue_timeout` ("connection not available and request was dropped from queue"); a lighter re-run passes. Reproduced on run 2 of 12: 20 failures, all `:queue_timeout`.

## Fix
Cap test concurrency to the Bolt pool in `test_helper.exs`:

```elixir
bolt_pool_size = Application.get_env(:bolty, Bolt)[:pool_size] || 15
ExUnit.start(exclude: [...], max_cases: bolt_pool_size)
```

Tying `max_cases` to `pool_size` (rather than the default core-count multiple) makes it portable — a many-core CI would otherwise demand far more connections than the pool holds. 15 concurrent sandbox holders ≤ 18 pool capacity, with overflow absorbing the transient (cached) `connection_info` checkouts — so the starvation condition is removed, not merely narrowed.

## Verification
- Reproduced at ~1 run in 12 before the change (20 `:queue_timeout` failures).
- **0 failures in 20 consecutive runs** after.

Test-only change (`test/test_helper.exs`).