### PR TITLE
fix: make spatial POINT index effective at scale (#311)

### DIFF
--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -33,6 +33,15 @@ defmodule AshNeo4j.Cypher do
     Call
   }
 
+  # World-extent WGS-84 corners, used to rewrite bbox-containment predicates
+  # into index-servable range scans on the indexed companion corners (#311).
+  # `point.withinBBox(indexedCorner, worldSW, p)` reads as `indexedCorner <= p`
+  # and is served by the POINT index (NodeIndexSeekByRange); the natural
+  # `point.withinBBox(p, n.bbSW, n.bbNE)` form has the indexed properties as
+  # the box, not the probe, so it can only be a full scan.
+  @world_sw "point({longitude: -180, latitude: -90})"
+  @world_ne "point({longitude: 180, latitude: 90})"
+
   @spec remove_properties(atom(), maybe_improper_list()) :: binary()
   @doc """
   Converts a list of property names into a remove properties string.
@@ -67,9 +76,9 @@ defmodule AshNeo4j.Cypher do
   iex> AshNeo4j.Cypher.expression(:s, "name", "=", "$s_name_0", case_insensitive?: true)
   "toLower(s.name) = toLower($s_name_0)"
   iex> AshNeo4j.Cypher.expression(:n, "bounds", "within_bbox", "$test_point")
-  "point.withinBBox($test_point, n.`bounds.bbSW`, n.`bounds.bbNE`)"
+  "point.withinBBox(n.`bounds.bbSW`, point({longitude: -180, latitude: -90}), $test_point) AND point.withinBBox(n.`bounds.bbNE`, $test_point, point({longitude: 180, latitude: 90}))"
   iex> AshNeo4j.Cypher.expression(:n, "bounds", "within_bbox_box", {"$inner_sw", "$inner_ne"})
-  "point.withinBBox($inner_sw, n.`bounds.bbSW`, n.`bounds.bbNE`) AND point.withinBBox($inner_ne, n.`bounds.bbSW`, n.`bounds.bbNE`)"
+  "point.withinBBox(n.`bounds.bbSW`, point({longitude: -180, latitude: -90}), $inner_sw) AND point.withinBBox(n.`bounds.bbNE`, $inner_ne, point({longitude: 180, latitude: 90}))"
   iex> AshNeo4j.Cypher.expression(:n, "location", "st_distance", {"<", "$test_point", "$threshold"})
   "point.distance(n.location, $test_point) < $threshold"
   iex> AshNeo4j.Cypher.expression(:n, "location", "dwithin", {"$test_point", "$threshold"})
@@ -95,13 +104,24 @@ defmodule AshNeo4j.Cypher do
         "#{variable}.#{left} IS NOT NULL"
 
       operator == "within_bbox" ->
-        "point.withinBBox(#{right}, #{variable}.`#{left}.bbSW`, #{variable}.`#{left}.bbNE`)"
+        # P ∈ [bbSW, bbNE] ⟺ bbSW ≤ P AND bbNE ≥ P. Probing the indexed corners
+        # against world-extent boxes keeps the indexed properties as the probe,
+        # so the POINT index serves both ranges (#311).
+        bb_sw = "#{variable}.`#{left}.bbSW`"
+        bb_ne = "#{variable}.`#{left}.bbNE`"
+
+        "point.withinBBox(#{bb_sw}, #{@world_sw}, #{right}) AND " <>
+          "point.withinBBox(#{bb_ne}, #{right}, #{@world_ne})"
 
       operator == "within_bbox_box" ->
         {sw_ref, ne_ref} = right
+        # Test box ⊆ attr box ⟺ attr.bbSW ≤ test.sw AND attr.bbNE ≥ test.ne —
+        # again expressed as indexed-corner range scans (#311).
+        bb_sw = "#{variable}.`#{left}.bbSW`"
+        bb_ne = "#{variable}.`#{left}.bbNE`"
 
-        "point.withinBBox(#{sw_ref}, #{variable}.`#{left}.bbSW`, #{variable}.`#{left}.bbNE`) AND " <>
-          "point.withinBBox(#{ne_ref}, #{variable}.`#{left}.bbSW`, #{variable}.`#{left}.bbNE`)"
+        "point.withinBBox(#{bb_sw}, #{@world_sw}, #{sw_ref}) AND " <>
+          "point.withinBBox(#{bb_ne}, #{ne_ref}, #{@world_ne})"
 
       operator == "st_distance" ->
         {comp_op, test_ref, threshold_ref} = right

--- a/lib/spatial.ex
+++ b/lib/spatial.ex
@@ -223,14 +223,17 @@ defmodule AshNeo4j.Spatial do
 
   # --- companion shape -------------------------------------------------
 
-  # `%Geo.Point{}` promotes to a single `.point` companion; every other
+  # Point-shaped geometries (2D `%Geo.Point{}` and 3D `%Geo.PointZ{}`, #270)
+  # promote to a single `.point` companion (a native Neo4j POINT); every other
   # geometry promotes to `.bbSW` / `.bbNE`. A mixed-type attribute
   # (e.g. geo_types: [:point, :polygon]) can store either shape, so we
   # index all companions it could ever produce.
+  @point_geo_types [:point, :point_z, :point_zm]
+
   defp companion_suffixes(geo_types) do
     types = List.wrap(geo_types)
-    point = if :point in types, do: ["point"], else: []
-    bbox = if Enum.any?(types, &(&1 != :point)), do: ["bbSW", "bbNE"], else: []
+    point = if Enum.any?(types, &(&1 in @point_geo_types)), do: ["point"], else: []
+    bbox = if Enum.any?(types, &(&1 not in @point_geo_types)), do: ["bbSW", "bbNE"], else: []
     point ++ bbox
   end
 

--- a/test/show_neo4j_test.exs
+++ b/test/show_neo4j_test.exs
@@ -33,13 +33,20 @@ defmodule AshNeo4j.ShowNeo4jTest do
       MATCH (n:SRM:Place {name: 'Spatial showcase'}) RETURN keys(n) AS props
 
       // Bounding-box prefilter via the indexed scalar companions —
-      // works uniformly for path, bounds, pes, regions
+      // works uniformly for path, bounds, pes, regions. Probing the indexed
+      // corners against world-extent boxes lets the POINT index serve the
+      // ranges (#311) — equivalent to "test point ∈ [bbSW, bbNE]".
       MATCH (n:SRM:Place)
       WHERE n.`path.bbSW` IS NOT NULL
         AND point.withinBBox(
-          point({longitude: 151.25, latitude: -33.7}),
           n.`path.bbSW`,
-          n.`path.bbNE`
+          point({longitude: -180, latitude: -90}),
+          point({longitude: 151.25, latitude: -33.7})
+        )
+        AND point.withinBBox(
+          n.`path.bbNE`,
+          point({longitude: 151.25, latitude: -33.7}),
+          point({longitude: 180, latitude: 90})
         )
       RETURN n.name, n.`path.json`
 

--- a/test/spatial_index_test.exs
+++ b/test/spatial_index_test.exs
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.SpatialIndexTest do
+  @moduledoc """
+  `AshNeo4j.Spatial.index_statements/3` companion selection (dry run, no DB).
+
+  A point-shaped attribute — 2D `:point` or 3D `:point_z` (#270) — indexes its
+  single `.point` companion; an areal/linear geometry indexes `.bbSW`/`.bbNE`.
+  The 3D case is the regression for #306: a `:point_z` attribute was being
+  treated as a bbox geometry, so `create_index` built indexes on
+  `<attr>.bbSW`/`.bbNE` (which a `%Geo.PointZ{}` never writes) instead of the
+  `<attr>.point` it actually stores — leaving 3D distance queries unindexed.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshNeo4j.Spatial
+  alias AshNeo4j.Test.Resource.Place
+
+  test "3D point_z attribute indexes the .point companion, not bbSW/bbNE (#306)" do
+    {:ok, [stmt]} = Spatial.index_statements(Place, :tower)
+    assert stmt =~ "tower.point"
+    refute stmt =~ "bbSW"
+    refute stmt =~ "bbNE"
+  end
+
+  test "2D point attribute indexes the .point companion" do
+    {:ok, [stmt]} = Spatial.index_statements(Place, :location)
+    assert stmt =~ "location.point"
+  end
+
+  test "polygon attribute indexes the bbSW/bbNE companions" do
+    {:ok, stmts} = Spatial.index_statements(Place, :bounds)
+    assert Enum.any?(stmts, &(&1 =~ "bbSW"))
+    assert Enum.any?(stmts, &(&1 =~ "bbNE"))
+  end
+end

--- a/test/thing_test.exs
+++ b/test/thing_test.exs
@@ -11,7 +11,6 @@ defmodule AshNeo4j.ThingTest do
   alias AshNeo4j.Test.Resource.ThingCategory
   alias AshNeo4j.Test.Resource.ThingNote
   alias AshNeo4j.Test.Resource.ThingTag
-  require Ash.Query
 
   setup_all do
     BoltyHelper.start()


### PR DESCRIPTION
Closes #311.

Surfaced while building the #306 geospatial benchmarks: a POINT index existed but neither 3D distance nor bbox containment was accelerated. Two distinct causes:

### 1. 3D `point_z` companion mis-selected
`AshNeo4j.Spatial.companion_suffixes/1` treated a `:point_z` attribute as a bbox geometry, so `create_index` built indexes on `<attr>.bbSW`/`.bbNE` — companions a `%Geo.PointZ{}` never writes — instead of the `<attr>.point` it actually stores. 3D `st_dwithin` therefore had no usable index. Fixed by recognising `:point_z`/`:point_zm` as point-shaped alongside `:point`.

### 2. `withinBBox` containment query form forced a full scan
The natural `point.withinBBox($p, n.bbSW, n.bbNE)` puts the **indexed properties in the box position**, not the probe, so Neo4j plans a `NodeByLabelScan` (proven via `EXPLAIN`). Reformulated `within_bbox` / `within_bbox_box` into range scans on the indexed corners against world-extent boxes:

```
point.withinBBox(n.`bounds.bbSW`, worldSW, $p) AND
point.withinBBox(n.`bounds.bbNE`, $p, worldNE)
```

Logically equivalent — `P ∈ [bbSW, bbNE] ⟺ bbSW ≤ P ≤ bbNE` — but served by the POINT index (`NodeIndexSeekByRange`).

### Tests
- New `test/spatial_index_test.exs`: dry-run regression asserting `index_statements` targets `.point` for 2D/3D points and `.bbSW`/`.bbNE` for areal geometry.
- Updated cypher doctests and the `show_neo4j` exploration snippet to the new form.
- The existing `within_bbox` behavioural tests (inside/outside/corner-inclusive) pass unchanged, confirming equivalence.
- Dropped an unused `require Ash.Query` in `thing_test.exs`.

Full suite: 603 passed, 1 skipped, 9 excluded.

Follow-up: #306 benchmarks re-run against this fix (containment now indexed) before that PR is finalised.