### PR TITLE
fix: nested arrays ({:array, {:array, _}}) round-trip via outer native LIST + inner JSON (#317)

### DIFF
--- a/lib/data_layer/cast.ex
+++ b/lib/data_layer/cast.ex
@@ -19,6 +19,25 @@ defmodule AshNeo4j.DataLayer.Cast do
     {:ok, nil}
   end
 
+  # Nested array: each outer element is a JSON STRING (see `Dump.dump/3`). Decode
+  # it, then cast the inner array back into nested native lists.
+  def cast({:array, {:array, _} = inner_type}, value, constraints) when is_list(value) do
+    item_constraints = TypeClassifier.item_constraints(inner_type, constraints)
+
+    Enum.reduce_while(value, {:ok, []}, fn item, {:ok, acc} ->
+      with {:ok, decoded} <- Util.json_decode(item),
+           {:ok, cast_item} <- cast_nested(inner_type, decoded, item_constraints) do
+        {:cont, {:ok, [cast_item | acc]}}
+      else
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, items} -> {:ok, Enum.reverse(items)}
+      error -> error
+    end
+  end
+
   def cast({:array, inner_type}, value, constraints) when is_list(value) do
     item_constraints = TypeClassifier.item_constraints(inner_type, constraints)
 
@@ -66,6 +85,44 @@ defmodule AshNeo4j.DataLayer.Cast do
 
       _ ->
         {:error, "AshNeo4j.DataLayer: cannot cast value #{inspect(value)} of type #{inspect(type)}"}
+    end
+  end
+
+  # Casts a JSON-decoded nested array back into nested native lists, leaves cast
+  # via the normal path. Mirror of `Dump.dump_nested/3`.
+  defp cast_nested({:array, inner_type}, value, constraints) when is_list(value) do
+    item_constraints = TypeClassifier.item_constraints(inner_type, constraints)
+
+    Enum.reduce_while(value, {:ok, []}, fn item, {:ok, acc} ->
+      case cast_nested(inner_type, item, item_constraints) do
+        {:ok, cast_item} -> {:cont, {:ok, [cast_item | acc]}}
+        error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, items} -> {:ok, Enum.reverse(items)}
+      error -> error
+    end
+  end
+
+  # Native leaves inside the JSON came back as scalars — temporal types as ISO
+  # 8601 strings (see `Util.to_json_safe/1`), so re-cast through the type to
+  # restore the struct; numbers/strings/booleans pass straight through.
+  defp cast_nested(type, value, constraints) do
+    case TypeClassifier.classify(type) do
+      {:ok, :native, native} ->
+        case Ash.Type.cast_stored(native, value, constraints) do
+          {:ok, casted} -> {:ok, casted}
+          _ -> {:ok, value}
+        end
+
+      # JSON leaf: already a decoded map (the whole element was json_decoded),
+      # so cast it straight — no second json_decode.
+      {:ok, :ash_json, ash_type} ->
+        cast_ash_type(ash_type, value, constraints)
+
+      _ ->
+        cast(type, value, constraints)
     end
   end
 

--- a/lib/data_layer/dump.ex
+++ b/lib/data_layer/dump.ex
@@ -18,6 +18,14 @@ defmodule AshNeo4j.DataLayer.Dump do
     nil
   end
 
+  # Nested array. Neo4j has no collection-of-collections, so the outer axis
+  # stays a native LIST and each inner array is encoded as a JSON STRING (any
+  # deeper nesting lives inside that JSON). Symmetric with `Cast.cast/3`.
+  def dump({:array, {:array, _} = inner_type}, value, constraints) when is_list(value) do
+    item_constraints = TypeClassifier.item_constraints(inner_type, constraints)
+    Enum.map(value, fn inner -> inner_type |> dump_nested(inner, item_constraints) |> json_encode() end)
+  end
+
   def dump({:array, inner_type}, value, constraints) when is_list(value) do
     item_constraints = TypeClassifier.item_constraints(inner_type, constraints)
     Enum.map(value, &dump(inner_type, &1, item_constraints))
@@ -58,6 +66,24 @@ defmodule AshNeo4j.DataLayer.Dump do
 
       _ ->
         raise "AshNeo4j.DataLayer Error dumping value #{inspect(value)} of type #{inspect(type)}"
+    end
+  end
+
+  # Dumps a nested array into nested *native* Elixir lists (leaves dumped via the
+  # normal path), so the whole inner structure is JSON-encoded once at the outer
+  # boundary in `dump/3` rather than per level.
+  defp dump_nested({:array, inner_type}, value, constraints) when is_list(value) do
+    item_constraints = TypeClassifier.item_constraints(inner_type, constraints)
+    Enum.map(value, &dump_nested(inner_type, &1, item_constraints))
+  end
+
+  defp dump_nested(type, value, constraints) do
+    case TypeClassifier.classify(type) do
+      # JSON leaves: keep the dumped value json-*safe* (a map), not yet a string,
+      # so the single json_encode at the outer boundary yields clean nested JSON
+      # instead of double-escaped strings.
+      {:ok, :ash_json, ash_type} -> dump_ash_type(ash_type, value, constraints)
+      _ -> dump(type, value, constraints)
     end
   end
 

--- a/lib/data_layer/type_classifier.ex
+++ b/lib/data_layer/type_classifier.ex
@@ -187,4 +187,11 @@ defmodule AshNeo4j.DataLayer.TypeClassifier do
 
     Keyword.merge(subtype, explicit_items)
   end
+
+  # Nested array (`{:array, {:array, _}}`): the constraints for the next level
+  # down live under `:items`. Without this clause an array-of-array raises here
+  # (the `is_atom/1` clause never matches a tuple inner type).
+  def item_constraints({:array, _}, constraints) when is_list(constraints) do
+    constraints[:items] || []
+  end
 end

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -179,6 +179,15 @@ defmodule AshNeo4j.Util do
     |> Jason.encode()
   end
 
+  # Temporal structs serialise to ISO 8601 strings (not their internal fields),
+  # so they survive a JSON round-trip and re-cast cleanly. `Duration` in
+  # particular has no `Jason.Encoder`, so without this it can't be encoded at all.
+  defp to_json_safe(%Date{} = v), do: Date.to_iso8601(v)
+  defp to_json_safe(%Time{} = v), do: Time.to_iso8601(v)
+  defp to_json_safe(%NaiveDateTime{} = v), do: NaiveDateTime.to_iso8601(v)
+  defp to_json_safe(%DateTime{} = v), do: DateTime.to_iso8601(v)
+  defp to_json_safe(%Duration{} = v), do: Duration.to_iso8601(v)
+
   # Geo structs (Geo.Point, Geo.LineString, Geo.Polygon, Geo.MultiPoint,
   # etc.) carry tuple-shaped coordinates that Jason can't encode directly.
   # Route them through AshNeo4j.GeoJson.encode_map/1 to get an RFC 7946

--- a/test/nested_array_test.exs
+++ b/test/nested_array_test.exs
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.NestedArrayTest do
+  @moduledoc false
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Neo4jHelper
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.NestedArray
+
+  use ExUnit.Case, async: true
+
+  setup_all do
+    BoltyHelper.start()
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  # Round-trips a single nested-array attribute and asserts the read value
+  # matches what went in.
+  defp round_trip(attr, value) do
+    created = Ash.create!(NestedArray, %{attr => value})
+    read = Ash.get!(NestedArray, created.uuid)
+    Map.get(read, attr)
+  end
+
+  test "2-level native groups round-trip" do
+    assert round_trip(:aa_integer, [[1, 2], [3, 4]]) == [[1, 2], [3, 4]]
+    assert round_trip(:aa_float, [[1.5, 2.5], [3.5]]) == [[1.5, 2.5], [3.5]]
+    assert round_trip(:aa_boolean, [[true, false], [false]]) == [[true, false], [false]]
+    assert round_trip(:aa_string, [["a", "b"], ["c"]]) == [["a", "b"], ["c"]]
+  end
+
+  test "2-level atom (ash) round-trips" do
+    assert round_trip(:aa_atom, [[:a, :b], [:c]]) == [[:a, :b], [:c]]
+  end
+
+  test "2-level binary (base64) round-trips" do
+    assert round_trip(:aa_binary, [[<<1, 2>>, <<3>>], [<<4, 5, 6>>]]) == [[<<1, 2>>, <<3>>], [<<4, 5, 6>>]]
+  end
+
+  test "2-level embedded-json (map) round-trips" do
+    v = [[%{name: "Henry", age: 8, breed: :groodle}], [%{name: "Kipper", age: 15, breed: :labradoodle}]]
+    assert round_trip(:aa_map, v) == v
+  end
+
+  test "2-level temporal (date) round-trips" do
+    assert round_trip(:aa_date, [[~D[2025-05-11], ~D[2025-05-12]], [~D[2026-01-01]]]) ==
+             [[~D[2025-05-11], ~D[2025-05-12]], [~D[2026-01-01]]]
+  end
+
+  test "2-level temporal (duration) round-trips" do
+    d = %Duration{day: 25, hour: 5, minute: 6, second: 7}
+    assert round_trip(:aa_duration, [[d]]) == [[d]]
+  end
+
+  test "3-level integer round-trips" do
+    v = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
+    assert round_trip(:aaa_integer, v) == v
+  end
+
+  test "on-disk shape: outer native LIST of (clean) JSON strings, not collections-of-collections" do
+    created =
+      Ash.create!(NestedArray, %{
+        aa_integer: [[1, 2], [3, 4]],
+        aa_map: [[%{name: "Henry", age: 8, breed: :groodle}]]
+      })
+
+    assert {:ok, %{records: records}} = Neo4jHelper.read_nodes(:NestedArray, %{uuid: created.uuid})
+    node = records |> List.first() |> List.first()
+
+    # Outer axis is a native Neo4j LIST; each element is a JSON STRING.
+    assert node.properties["aaInteger"] == ["[1,2]", "[3,4]"]
+
+    # The map leaf is clean nested JSON (decodes straight to a map), not a
+    # double-escaped string.
+    assert [json] = node.properties["aaMap"]
+    assert {:ok, [%{"name" => "Henry", "age" => 8, "breed" => "groodle"}]} = Jason.decode(json)
+  end
+end

--- a/test/support/resource/nested_array.ex
+++ b/test/support/resource/nested_array.ex
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Test.Resource.NestedArray do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshNeo4j.Test.SRM,
+    data_layer: AshNeo4j.DataLayer
+
+  alias AshNeo4j.Test.Type.DogMap
+
+  neo4j do
+    label :NestedArray
+  end
+
+  actions do
+    default_accept :*
+    defaults [:read, :create, :destroy]
+  end
+
+  attributes do
+    uuid_primary_key :uuid
+
+    # One representative per TypeClassifier group, two levels deep.
+    attribute :aa_integer, {:array, {:array, :integer}}, public?: true
+    attribute :aa_float, {:array, {:array, :float}}, public?: true
+    attribute :aa_boolean, {:array, {:array, :boolean}}, public?: true
+    attribute :aa_string, {:array, {:array, :string}}, public?: true
+    attribute :aa_atom, {:array, {:array, :atom}}, public?: true
+    attribute :aa_date, {:array, {:array, :date}}, public?: true
+    attribute :aa_duration, {:array, {:array, :duration}}, public?: true
+    attribute :aa_binary, {:array, {:array, :binary}}, public?: true
+    attribute :aa_map, {:array, {:array, DogMap}}, public?: true
+
+    # Three levels deep.
+    attribute :aaa_integer, {:array, {:array, {:array, :integer}}}, public?: true
+  end
+end


### PR DESCRIPTION
Closes #317.

## Problem

`{:array, {:array, _}}` attributes raised on dump — `TypeClassifier.item_constraints/2` only matched an `is_atom` inner type, never a nested `{:array, _}` tuple (the call is in both `Dump.dump/3` and `Cast.cast/3`, so create *and* read blew up). The n-level recursion was intended but never worked. Neo4j also can't store collections-of-collections as a property, so the nested value needs a single-property representation regardless.

## Fix

- **Outer axis → native `LIST`; each element → JSON string** (deeper nesting lives inside the JSON), symmetric on read.
- `item_constraints/2` gains a clause for a tuple (nested) inner type — the actual raise.
- **Temporal leaves serialise to ISO 8601** via `Util.to_json_safe/1` — including `Duration`, which has no `Jason.Encoder` at all — and re-cast on read.
- **JSON-leaf maps store as clean nested JSON**, not double-escaped (the stringify is deferred to the outer boundary).

On disk: `aaInteger → ["[1,2]","[3,4]"]`; map leaves decode straight to a map.

## Coverage

New live sweep (`test/nested_array_test.exs`) round-trips every `TypeClassifier` group — native (incl. `:date`, `:duration`), atom, base64, embedded-json — at **2 and 3 levels deep**, plus an on-disk shape assertion. Full suite green (611).

Note: the `to_json_safe/1` temporal change applies to all JSON encoding (e.g. a struct attribute with a temporal field), a strict improvement — `Duration` previously couldn't encode.