### PR TITLE
chore: bump toolchain (elixir 1.20.0-otp-29, erlang 29.0.1) + neo4j 5.26.27 (#318, #320)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.19.5-otp-28
-erlang 28.3.1
+elixir 1.20.0-otp-29
+erlang 29.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@
 # is ephemeral by design.
 services:
   neo4j-bolt5:
-    image: neo4j:5.26
+    image: neo4j:5.26.27
     container_name: neo4j-ash-bolt5
     ports:
       - "7687:7687"


### PR DESCRIPTION
Closes #318, closes #320.

- **#318** — bump `.tool-versions` to match bolty's current toolchain (`elixir 1.20.0-otp-29`, `erlang 29.0.1`); missed in the 0.9.0 release.
- **#320** — pin the Neo4j 5 LTS test image `neo4j:5.26` → `neo4j:5.26.27` (latest patch).

Config-only; full suite green (603) under the running toolchain. Bolt6 image left at `2026.05` — 2026.06 is just the expected monthly calver cadence.