### PR TITLE
refactor: rename AshNeo4j.Types.* → AshNeo4j.Type.* to match Ash.Type (#323)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ lib/
                                  Unsupported3DGeometry}
   spatial.ex                   — AshNeo4j.Spatial: POINT index lifecycle (operator-invoked)
   vector.ex                    — AshNeo4j.Vector: VECTOR index lifecycle (operator-invoked)
-  types/vector.ex              — AshNeo4j.Types.Vector: embedding attribute (LIST<FLOAT>)
+  types/vector.ex              — AshNeo4j.Type.Vector: embedding attribute (LIST<FLOAT>)
   geo.ex                       — AshNeo4j.Geo: haversine_meters/2 + 3D variant (match
                                  Neo4j point.distance), force_2d/1 (3D→2D projection)
   functions/                   — Ash.Query.Function modules pushed down to Cypher:
@@ -383,7 +383,7 @@ as a follow-up comment, then leave it with the upstream maintainers.
 
 - **Storing a native `%Bolty.Types.Vector{}` as a node property.** Neo4j cannot persist the
   Bolt 6.0 VECTOR type as a property — `CREATE (n {embedding: $vector})` errors. Embeddings are
-  stored as `LIST<FLOAT>` (`AshNeo4j.Types.Vector.dump_to_native/2`), which is what
+  stored as `LIST<FLOAT>` (`AshNeo4j.Type.Vector.dump_to_native/2`), which is what
   `vector.similarity.cosine/2` operates on and what the vector index indexes. The native VECTOR
   type is a query-parameter wire type only. Consequently vector search is gated on **Cypher 25
   (≥ 2025.06)**, not Bolt 6.0 — it works over Bolt 5.8.

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ We've made some decisions around how Ash/Elixir types are used to persist attrib
 | :utc_datetime_usec   | Ash.Type.UtcDatetimeUsec             | DateTime           | ~U[2025-05-11 07:45:41.429903Z]                         | 2025-05-11T07:45:41.429903000Z.                        | DATETIME       |
 | :uuid                | Ash.Type.UUID                        | BitString          | "0274972c-161c-4dc9-882f-6851704c2af9"                  | "0274972c-161c-4dc9-882f-6851704c2af9"                 | STRING         |
 | :uuid7               | Ash.Type.UUIDv7                      | BitString          | "019d85f7-8450-7695-9426-4ede74026140"                  | "019d85f7-8450-7695-9426-4ede74026140"                 | STRING         |
-| (vector embedding)   | AshNeo4j.Types.Vector                | List               | [0.12, -0.04, 0.98]                                     | [0.12, -0.04, 0.98]                                    | LIST<FLOAT>    |
+| (vector embedding)   | AshNeo4j.Type.Vector                | List               | [0.12, -0.04, 0.98]                                     | [0.12, -0.04, 0.98]                                    | LIST<FLOAT>    |
 
 Ash :date, :datetime, :time and :naive_datetime are second precision, whereas :utc_datetime_usec and :time_usec are microsecond precision. Neo4j is capable of nanoseconds however Ash/Elixir is not. 
 
@@ -271,7 +271,7 @@ Struct is supported, however must implement Ash.Type. Ash arrays are supported a
 
 Ash.Type.NewType including Ash.TypedStruct are supported, as are embedded resources.
 
-Ash.Type.File and Ash.Type.Term are not supported. The built-in `Ash.Type.Vector` is also not supported — AshNeo4j ships its own `AshNeo4j.Types.Vector` for embeddings (stored as a Neo4j `LIST<FLOAT>`), with `vector_similarity` / `vector_cosine_distance` search expressions. See `usage-rules/vectors.md`.
+Ash.Type.File and Ash.Type.Term are not supported. The built-in `Ash.Type.Vector` is also not supported — AshNeo4j ships its own `AshNeo4j.Type.Vector` for embeddings (stored as a Neo4j `LIST<FLOAT>`), with `vector_similarity` / `vector_cosine_distance` search expressions. See `usage-rules/vectors.md`.
 
 ## Storage Types
 

--- a/lib/type/vector.ex
+++ b/lib/type/vector.ex
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule AshNeo4j.Types.Vector do
+defmodule AshNeo4j.Type.Vector do
   @moduledoc """
   Ash attribute type for vector embeddings, stored as a Neo4j `LIST<FLOAT>`.
 
@@ -25,7 +25,7 @@ defmodule AshNeo4j.Types.Vector do
 
   ## Usage
 
-      attribute :embedding, AshNeo4j.Types.Vector,
+      attribute :embedding, AshNeo4j.Type.Vector,
         constraints: [element_type: :float32, dimensions: 1536]
 
   See `AshNeo4j.Vector` for index creation helpers and `AshNeo4j.Functions.VectorSimilarity`

--- a/lib/vector.ex
+++ b/lib/vector.ex
@@ -5,7 +5,7 @@
 defmodule AshNeo4j.Vector do
   @moduledoc """
   Convenience helpers for creating the Neo4j VECTOR indexes that back
-  `AshNeo4j.Types.Vector` attributes.
+  `AshNeo4j.Type.Vector` attributes.
 
   Requires Cypher 25 (Neo4j ≥ 2025.06). Operations against an older server
   raise `AshNeo4j.Error.RequiresCypher25`.
@@ -137,7 +137,7 @@ defmodule AshNeo4j.Vector do
 
   defp resolve_dimensions(attribute, attr) do
     case attribute.type do
-      AshNeo4j.Types.Vector ->
+      AshNeo4j.Type.Vector ->
         case Keyword.get(attribute.constraints || [], :dimensions) do
           nil ->
             {:error,
@@ -150,7 +150,7 @@ defmodule AshNeo4j.Vector do
 
       other ->
         {:error,
-         "AshNeo4j.Vector: attribute #{inspect(attr)} is #{inspect(other)}, not AshNeo4j.Types.Vector"}
+         "AshNeo4j.Vector: attribute #{inspect(attr)} is #{inspect(other)}, not AshNeo4j.Type.Vector"}
     end
   end
 

--- a/test/support/resource/thing_note.ex
+++ b/test/support/resource/thing_note.ex
@@ -24,7 +24,7 @@ defmodule AshNeo4j.Test.Resource.ThingNote do
     attribute :body, :string, public?: true
     attribute :thing_id, :uuid, public?: true
 
-    attribute :embedding, AshNeo4j.Types.Vector,
+    attribute :embedding, AshNeo4j.Type.Vector,
       public?: true,
       constraints: [element_type: :float32, dimensions: 3]
   end

--- a/test/type/vector_test.exs
+++ b/test/type/vector_test.exs
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule AshNeo4j.Types.VectorTest do
+defmodule AshNeo4j.Type.VectorTest do
   @moduledoc """
-  Pure cast/constraint tests for `AshNeo4j.Types.Vector` — no Neo4j connection.
+  Pure cast/constraint tests for `AshNeo4j.Type.Vector` — no Neo4j connection.
 
   `dump_to_native/2`'s wire-format choice (native `%Bolty.Types.Vector{}` vs
   plain float list) depends on the negotiated `policy.vectors` and is exercised
@@ -12,7 +12,7 @@ defmodule AshNeo4j.Types.VectorTest do
   """
   use ExUnit.Case, async: true
 
-  alias AshNeo4j.Types.Vector
+  alias AshNeo4j.Type.Vector
 
   describe "cast_input/2" do
     test "accepts a list of numbers, coercing to floats" do

--- a/test/vector_test.exs
+++ b/test/vector_test.exs
@@ -29,9 +29,9 @@ defmodule AshNeo4j.VectorTest do
       assert cypher =~ "'euclidean'"
     end
 
-    test "errors when the attribute is not AshNeo4j.Types.Vector" do
+    test "errors when the attribute is not AshNeo4j.Type.Vector" do
       assert {:error, msg} = Vector.index_statements(ThingNote, :body)
-      assert msg =~ "not AshNeo4j.Types.Vector"
+      assert msg =~ "not AshNeo4j.Type.Vector"
     end
   end
 end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -154,11 +154,11 @@ On disk, each geometry stores as a canonical RFC 7946 GeoJSON `STRING` at `<attr
 
 ## Vector embeddings and similarity search
 
-AshNeo4j stores vector embeddings with the `AshNeo4j.Types.Vector` attribute type (Elixir `[float()]`, persisted as a Neo4j `LIST<FLOAT>`) and ranks/filters them with the `vector_similarity` and `vector_cosine_distance` expression functions. The requirement is **Cypher 25 (Neo4j ≥ 2025.06), not Bolt 6.0** — with list storage and list params, similarity search works over Bolt 5.8. The built-in `Ash.Type.Vector` is a different module and is not supported; use `AshNeo4j.Types.Vector`.
+AshNeo4j stores vector embeddings with the `AshNeo4j.Type.Vector` attribute type (Elixir `[float()]`, persisted as a Neo4j `LIST<FLOAT>`) and ranks/filters them with the `vector_similarity` and `vector_cosine_distance` expression functions. The requirement is **Cypher 25 (Neo4j ≥ 2025.06), not Bolt 6.0** — with list storage and list params, similarity search works over Bolt 5.8. The built-in `Ash.Type.Vector` is a different module and is not supported; use `AshNeo4j.Type.Vector`.
 
 ```elixir
 attributes do
-  attribute :embedding, AshNeo4j.Types.Vector,
+  attribute :embedding, AshNeo4j.Type.Vector,
     constraints: [element_type: :float32, dimensions: 1536]
 end
 


### PR DESCRIPTION
Closes #323.

Renames the type namespace from plural `AshNeo4j.Types.*` to singular `AshNeo4j.Type.*`, to match `Ash.Type`.

- `lib/types/` → `lib/type/`, `test/types/` → `test/type/` (git tracks both as renames)
- `AshNeo4j.Types.Vector` → `AshNeo4j.Type.Vector`; refs updated in `lib/vector.ex`, the `thing_note` test resource, and docs (README/AGENTS/usage-rules)

**Breaking:** `AshNeo4j.Types.Vector` was shipped API. Clean break — no deprecation shim, Vector is early-days. Worth a breaking-change note in the next release.

Full suite green (611).