### PR TITLE
feat: graph traversal as an Ash expression — traverse(^chain, :field) filter pushdown (#321)

### DIFF
--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -390,6 +390,34 @@ defmodule AshNeo4j.Cypher.Query do
   end
 
   @doc """
+  Multi-hop traversal filter (#321) — generalises `relationship_read/7` to a path.
+
+  `MATCH (s:Src)<path>(d) WHERE d.<field> <op> $param WITH DISTINCT s MATCH (s)-[r0]-(d0) RETURN s, r0, d0`
+
+  `path_segments` is `[{edge_label, direction, dest_label}]` (dest_label may be
+  `nil` for an unlabelled hop); the reached node binds as `d`. `WITH DISTINCT s`
+  collapses a source matched via multiple paths to one row before enrichment.
+  """
+  @spec traversal_read(atom() | [atom()], [{atom(), atom(), atom() | nil}], String.t(), atom(), any()) :: t()
+  def traversal_read(src_label, path_segments, reached_property, operator, value)
+      when is_list(path_segments) and path_segments != [] and is_binary(reached_property) do
+    param_key = "n_#{reached_property}"
+    match_pattern = Cypher.node(:s, List.wrap(src_label)) <> build_agg_path(path_segments)
+    where_condition = Cypher.expression(:d, reached_property, convert_operator(operator), "$#{param_key}")
+
+    %__MODULE__{
+      clauses: [
+        %Match{pattern: match_pattern},
+        %Where{conditions: [where_condition]},
+        %With{items: ["DISTINCT s"]},
+        %Match{pattern: "(s)-[r0]-(d0)"},
+        %Return{items: ["s", "r0", "d0"]}
+      ],
+      params: %{param_key => value}
+    }
+  end
+
+  @doc """
   `MATCH (n:L1:L2 {props}) OPTIONAL MATCH (n)-[r]-(d) RETURN n, r, d`
 
   Like `node_read/1` but matches by properties in the MATCH pattern (not a WHERE clause).
@@ -976,7 +1004,8 @@ defmodule AshNeo4j.Cypher.Query do
           _ -> "-[:#{edge_label}]-"
         end
 
-      acc <> rel <> "(#{node_var}:#{dest_label})"
+      node = if dest_label, do: "(#{node_var}:#{dest_label})", else: "(#{node_var})"
+      acc <> rel <> node
     end)
   end
 

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -71,6 +71,9 @@ defmodule AshNeo4j.DataLayer do
   def can?(_, {:filter_expr, %AshNeo4j.Functions.VectorSimilarity{}}), do: true
   def can?(_, {:filter_expr, %AshNeo4j.Functions.VectorCosineDistance{}}), do: true
 
+  # traversal — traverse(^chain, :field) reached-node filter → Cypher path pushdown (#321)
+  def can?(_, {:filter_expr, %AshNeo4j.Functions.Traverse{}}), do: true
+
   # All other filter expressions are accepted so Ash can hydrate and then evaluate
   # them in-memory via filter_stream / RuntimeExpression. Cypher builder falls
   # back to TRUE for unrecognised predicates; filter_stream corrects the results.
@@ -102,7 +105,8 @@ defmodule AshNeo4j.DataLayer do
       AshNeo4j.Functions.StIntersects,
       AshNeo4j.Functions.StWithin,
       AshNeo4j.Functions.VectorSimilarity,
-      AshNeo4j.Functions.VectorCosineDistance
+      AshNeo4j.Functions.VectorCosineDistance,
+      AshNeo4j.Functions.Traverse
     ]
   end
 
@@ -237,7 +241,7 @@ defmodule AshNeo4j.DataLayer do
               calculations = Map.values(Map.get(query, :calculations) || %{})
 
               with {:ok, records} <- apply_calculations_to_records(records, calculations, resource),
-                   records <- filter_matches(records, query.filter, query.domain),
+                   records <- filter_matches(records, drop_pushdown_only(query.filter), query.domain),
                    {:ok, records} <- apply_aggregates_to_records(records, aggregates, resource) do
                 {:ok, apply_calculation_sort(records, query.sort, query.domain)}
               end
@@ -680,6 +684,46 @@ defmodule AshNeo4j.DataLayer do
   defp filter_matches(records, filter, domain) do
     {:ok, records} = Ash.Filter.Runtime.filter_matches(domain, records, filter)
     records
+  end
+
+  # **Pushdown-only** expressions (#321 `traverse`, and future engine ops) are
+  # graph operations applied *exactly* by the Cypher pushdown and have no
+  # in-memory value. The residual filter for the in-memory correctness pass is
+  # therefore the original filter with every sub-expression containing a
+  # pushdown-only function replaced by `true` — leaving all ordinary predicates
+  # (which the pushdown may over-return on) intact for re-filtering. A function
+  # opts in via `ash_neo4j_pushdown_only?/0`. (Per-predicate residual tracking —
+  # re-applying only what wasn't pushed — is the cleaner end-state, see #327.)
+  defp drop_pushdown_only(nil), do: nil
+
+  defp drop_pushdown_only(%Ash.Filter{expression: expression} = filter),
+    do: %{filter | expression: drop_pushdown_only_expr(expression)}
+
+  defp drop_pushdown_only(filter), do: drop_pushdown_only_expr(filter)
+
+  defp drop_pushdown_only_expr(%Ash.Query.BooleanExpression{left: left, right: right} = boolean) do
+    %{boolean | left: drop_pushdown_only_expr(left), right: drop_pushdown_only_expr(right)}
+  end
+
+  defp drop_pushdown_only_expr(%Ash.Query.Not{expression: expression} = negation) do
+    %{negation | expression: drop_pushdown_only_expr(expression)}
+  end
+
+  defp drop_pushdown_only_expr(expression) do
+    if contains_pushdown_only?(expression), do: true, else: expression
+  end
+
+  defp contains_pushdown_only?(%module{} = struct) do
+    pushdown_only_function?(module) or
+      (struct |> Map.from_struct() |> Map.values() |> Enum.any?(&contains_pushdown_only?/1))
+  end
+
+  defp contains_pushdown_only?(map) when is_map(map), do: map |> Map.values() |> Enum.any?(&contains_pushdown_only?/1)
+  defp contains_pushdown_only?(list) when is_list(list), do: Enum.any?(list, &contains_pushdown_only?/1)
+  defp contains_pushdown_only?(_), do: false
+
+  defp pushdown_only_function?(module) do
+    function_exported?(module, :ash_neo4j_pushdown_only?, 0) and module.ash_neo4j_pushdown_only?()
   end
 
   # Reads the on-disk property value for an attribute, handling the geo

--- a/lib/functions/traverse.ex
+++ b/lib/functions/traverse.ex
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Functions.Traverse do
+  @moduledoc """
+  A multi-hop graph traversal as an `Ash.Expr` value, pushed down to a Cypher
+  path pattern (#321).
+
+  From the queried node, follow a chain of typed/directed edges and reach the
+  node(s) at the far end — then use that reached node inside a `filter`:
+
+      # reached-node field comparison
+      Service
+      |> Ash.Query.filter(traverse(^chain, :status) == "active")
+      |> Ash.read!()
+
+      # compose with spatial — "services whose site is within 5 km of a point"
+      Service
+      |> Ash.Query.filter(st_dwithin(traverse(^chain, :location), ^point, 5_000))
+      |> Ash.read!()
+
+  ## Arguments
+
+    * `hop_chain` — a list of hops, each `{:forward | :reverse, edge_selector}`.
+      `:forward` walks an outgoing edge, `:reverse` an incoming one.
+      `edge_selector` is an Ash **relationship name** (atom, resolved on the
+      source resource to its edge label + destination label) or an explicit
+      `{:edge, label}` / `{:edge, label, dest_label}`.
+    * `projection` (optional, default `:node`) — a field atom on the reached
+      node (the value to compare or feed to `st_dwithin`/`vector_similarity`),
+      or `:node` for the reached node itself.
+
+  ## Pushdown only
+
+  Traversal needs the graph, so it cannot be computed from argument values
+  alone — `evaluate/1` returns `:unknown` and the data layer must push it down
+  to Cypher. In this first slice it is recognised in `filter`; `sort`/
+  `calculate`/policy contexts are a fast-follow.
+  """
+  use Ash.Query.Function, name: :traverse, predicate?: false
+
+  # traverse(hop_chain) | traverse(hop_chain, projection)
+  def args, do: [[:any], [:any, :any]]
+
+  def returns, do: [:any]
+
+  # No argument-only evaluation — traversal is a graph operation, resolved by
+  # pushdown. `:unknown` signals the data layer must handle it (or the query
+  # fails fast in an unsupported context).
+  def evaluate(_), do: :unknown
+
+  @doc false
+  # Marks this as a **pushdown-only** expression: it needs the graph and has no
+  # in-memory value, so the data layer applies it exactly in Cypher and excludes
+  # it from the in-memory correctness re-filter (see `drop_pushdown_only/1`).
+  def ash_neo4j_pushdown_only?, do: true
+end

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -218,6 +218,83 @@ defmodule AshNeo4j.QueryHelper do
   end
 
   defp build_filtered_query(%ResourceMapping{} = mapping, predicates) do
+    case Enum.find(predicates, &traverse_field_predicate?/1) do
+      nil -> build_relationship_or_property_query(mapping, predicates)
+      traverse_predicate -> build_traversal_query(mapping, traverse_predicate)
+    end
+  end
+
+  # A reached-node field comparison: `traverse(^chain, :field) <op> value` (#321).
+  defp traverse_field_predicate?(%{left: %AshNeo4j.Functions.Traverse{arguments: [_chain, field]}})
+       when is_atom(field),
+       do: true
+
+  defp traverse_field_predicate?(_), do: false
+
+  defp build_traversal_query(%ResourceMapping{} = mapping, %{
+         operator: operator,
+         left: %AshNeo4j.Functions.Traverse{arguments: [chain, field]},
+         right: value
+       }) do
+    case resolve_chain(mapping.module, chain) do
+      [] ->
+        Logger.debug("AshNeo4j.QueryHelper: empty traverse chain")
+        Query.node_read(mapping.label_pair)
+
+      segments ->
+        reached_property = field |> AshNeo4j.Util.to_camel_case() |> to_string()
+        Query.traversal_read(mapping.label_pair, segments, reached_property, operator, to_param_value(value))
+    end
+  end
+
+  # Resolves a hop chain to `[{edge_label, direction, dest_label}]`, threading the
+  # current resource so relationship-name hops resolve at each step.
+  defp resolve_chain(resource, chain) when is_list(chain) do
+    {segments, _resource} =
+      Enum.reduce(chain, {[], resource}, fn hop, {acc, current} ->
+        {segment, next} = resolve_hop(current, hop)
+        {acc ++ [segment], next}
+      end)
+
+    segments
+  end
+
+  defp resolve_chain(_resource, _), do: []
+
+  # Relationship-name hop — resolve via `relate` on the current resource. `:forward`
+  # walks the declared edge direction, `:reverse` flips it.
+  defp resolve_hop(resource, {direction, rel_name}) when is_atom(rel_name) and not is_nil(resource) do
+    case ResourceInfo.node_relationship(resource, rel_name) do
+      {_name, edge_label, edge_direction, dest_label} ->
+        cypher_direction = if direction == :reverse, do: flip_direction(edge_direction), else: edge_direction
+        next = relationship_destination(resource, rel_name)
+        dest = if direction == :forward, do: dest_label, else: nil
+        {{edge_label, cypher_direction, dest}, next}
+
+      _ ->
+        {{rel_name, hop_direction(direction), nil}, nil}
+    end
+  end
+
+  # Explicit edge hop — `{:edge, label}` or `{:edge, label, dest_label}`.
+  defp resolve_hop(_resource, {direction, {:edge, label}}), do: {{label, hop_direction(direction), nil}, nil}
+  defp resolve_hop(_resource, {direction, {:edge, label, dest}}), do: {{label, hop_direction(direction), dest}, nil}
+
+  defp relationship_destination(resource, rel_name) do
+    case Ash.Resource.Info.relationship(resource, rel_name) do
+      %{destination: destination} -> destination
+      _ -> nil
+    end
+  end
+
+  defp hop_direction(:forward), do: :outgoing
+  defp hop_direction(:reverse), do: :incoming
+
+  defp flip_direction(:outgoing), do: :incoming
+  defp flip_direction(:incoming), do: :outgoing
+  defp flip_direction(other), do: other
+
+  defp build_relationship_or_property_query(%ResourceMapping{} = mapping, predicates) do
     relationship_predicates =
       Enum.filter(predicates, fn predicate ->
         if Map.has_key?(predicate, :operator) and ref_or_atom?(predicate.left) do

--- a/test/traverse_live_test.exs
+++ b/test/traverse_live_test.exs
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.TraverseLiveTest do
+  @moduledoc false
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.Author
+  alias AshNeo4j.Test.Resource.Comment
+  alias AshNeo4j.Test.Resource.Post
+
+  use ExUnit.Case, async: true
+
+  require Ash.Query
+
+  setup_all do
+    BoltyHelper.start()
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  test "1-hop forward relationship traversal: authors who wrote a post scoring > 50" do
+    alice = Ash.create!(Author, %{name: "Alice"})
+    bob = Ash.create!(Author, %{name: "Bob"})
+    Ash.create!(Post, %{title: "hit", score: 90, written_by: alice.id})
+    Ash.create!(Post, %{title: "miss", score: 10, written_by: bob.id})
+
+    chain = [{:forward, :posts}]
+
+    names =
+      Author
+      |> Ash.Query.filter(traverse(^chain, :score) > 50)
+      |> Ash.read!()
+      |> Enum.map(& &1.name)
+
+    assert names == ["Alice"]
+  end
+
+  test "2-hop forward traversal: authors with a high-scoring comment on one of their posts" do
+    alice = Ash.create!(Author, %{name: "Alice"})
+    bob = Ash.create!(Author, %{name: "Bob"})
+    {:ok, alice_post} = Post |> Ash.Changeset.for_create(:create, %{title: "ap", written_by: alice.id}) |> Ash.create()
+    {:ok, bob_post} = Post |> Ash.Changeset.for_create(:create, %{title: "bp", written_by: bob.id}) |> Ash.create()
+    cold = Ash.create!(Comment, %{title: "cold", score: 5})
+    hot = Ash.create!(Comment, %{title: "hot", score: 100})
+    Ash.update!(Ash.Changeset.for_update(alice_post, :update, add_comments: [cold.id]))
+    Ash.update!(Ash.Changeset.for_update(bob_post, :update, add_comments: [hot.id]))
+
+    # Author -[:WROTE]-> Post <-[:BELONGS_TO]- Comment
+    chain = [{:forward, :posts}, {:forward, :comments}]
+
+    names =
+      Author
+      |> Ash.Query.filter(traverse(^chain, :score) > 50)
+      |> Ash.read!()
+      |> Enum.map(& &1.name)
+
+    assert names == ["Bob"]
+  end
+
+  test "reverse hop with an explicit edge selector: posts written by a given author" do
+    alice = Ash.create!(Author, %{name: "Alice"})
+    bob = Ash.create!(Author, %{name: "Bob"})
+    {:ok, _} = Post |> Ash.Changeset.for_create(:create, %{title: "by-alice", written_by: alice.id}) |> Ash.create()
+    {:ok, _} = Post |> Ash.Changeset.for_create(:create, %{title: "by-bob", written_by: bob.id}) |> Ash.create()
+
+    # Post <-[:WROTE]- Author — walk the WROTE edge in reverse via an explicit selector
+    chain = [{:reverse, {:edge, :WROTE, :Author}}]
+
+    titles =
+      Post
+      |> Ash.Query.filter(traverse(^chain, :name) == "Alice")
+      |> Ash.read!()
+      |> Enum.map(& &1.title)
+
+    assert titles == ["by-alice"]
+  end
+end

--- a/test/traverse_test.exs
+++ b/test/traverse_test.exs
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Functions.TraverseTest do
+  @moduledoc false
+  alias AshNeo4j.Functions.Traverse
+
+  use ExUnit.Case, async: true
+
+  test "is a variadic expression function: traverse(chain) | traverse(chain, projection)" do
+    assert Traverse.name() == :traverse
+    assert [[:any], [:any, :any]] = Traverse.args()
+  end
+
+  test "is pushdown-only — no in-memory value" do
+    # It needs the graph, so it can't be evaluated from argument values alone.
+    assert Traverse.evaluate(%{arguments: [[{:forward, :posts}], :score]}) == :unknown
+    assert Traverse.ash_neo4j_pushdown_only?()
+  end
+
+  test "is registered with the data layer (parseable in expressions, pushdown accepted)" do
+    assert AshNeo4j.Functions.Traverse in AshNeo4j.DataLayer.functions(nil)
+    assert AshNeo4j.DataLayer.can?(nil, {:filter_expr, %Traverse{}})
+  end
+end


### PR DESCRIPTION
First slice of #321 — see the [implementation plan](https://github.com/diffo-dev/ash_neo4j/issues/321#issuecomment-4664167375).

## What

`AshNeo4j.Functions.Traverse` — a `traverse(hop_chain, projection)` Ash expression function that pushes a multi-hop, reached-node **filter** down to a Cypher **path pattern**, instead of an imperative load-time Elixir walk.

- **hop_chain** — `[{:forward | :reverse, selector}]`; `selector` is an Ash **relationship name** (resolved per hop via `relate`, threading the current resource) or an explicit `{:edge, label}` / `{:edge, label, dest}`. `:forward`/`:reverse` set the walk direction.
- **pushdown** — `traverse(^chain, :field) <op> value` → `MATCH (s)<path>(d) WHERE d.field <op> $p WITH DISTINCT s MATCH (s)-[r0]-(d0) RETURN s, r0, d0`. Generalises `relationship_read/7` to multi-hop via `build_agg_path/1`.
- **general filter mechanism** — `traverse` is the first **pushdown-only** expression (exact in Cypher, no in-memory value). The in-memory correctness re-filter now strips any sub-expression declaring `ash_neo4j_pushdown_only?/0` (`drop_pushdown_only/1`), leaving ordinary predicates intact. Extends to future engine ops with no per-op code. (#327 tracks the cleaner per-predicate residual.)

## Tests

`test/traverse_live_test.exs` — 1-hop forward, 2-hop forward, reverse + explicit-edge; `test/traverse_test.exs` — function contract/registration. Full suite green (635).

## Deferred (fast-follow)

`st_dwithin`/`vector_similarity` composition over the reached node (the "within 5 km of the site" headline); `exists`; the **projection** case (returning a reached value) which introduces **`AshNeo4j.Unknown`** (a reached-but-wrong-type or unreachable projection is *unknown*, not `nil`); `sort`/`calculate`/policy contexts; variable-length.