### PR TITLE
feat: compose st_dwithin with a traversal — within-distance of a reached node (#330)

### DIFF
--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -392,28 +392,30 @@ defmodule AshNeo4j.Cypher.Query do
   @doc """
   Multi-hop traversal filter (#321) — generalises `relationship_read/7` to a path.
 
-  `MATCH (s:Src)<path>(d) WHERE d.<field> <op> $param WITH DISTINCT s MATCH (s)-[r0]-(d0) RETURN s, r0, d0`
+  `MATCH (s:Src)<path>(d) WHERE <reached conditions> WITH DISTINCT s MATCH (s)-[r0]-(d0) RETURN s, r0, d0`
 
   `path_segments` is `[{edge_label, direction, dest_label}]` (dest_label may be
-  `nil` for an unlabelled hop); the reached node binds as `d`. `WITH DISTINCT s`
-  collapses a source matched via multiple paths to one row before enrichment.
+  `nil` for an unlabelled hop); the reached node binds as `d`. `conditions` are
+  the same `{prop, op, val, ci?}` tuples the property/spatial/vector path uses —
+  rendered against `d` via `build_conditions/3`, so a reached-node field
+  comparison, `st_dwithin`, `st_distance` or vector predicate all compose here.
+  `WITH DISTINCT s` collapses a source matched via multiple paths to one row.
   """
-  @spec traversal_read(atom() | [atom()], [{atom(), atom(), atom() | nil}], String.t(), atom(), any()) :: t()
-  def traversal_read(src_label, path_segments, reached_property, operator, value)
-      when is_list(path_segments) and path_segments != [] and is_binary(reached_property) do
-    param_key = "n_#{reached_property}"
+  @spec traversal_read(atom() | [atom()], [{atom(), atom(), atom() | nil}], [tuple()]) :: t()
+  def traversal_read(src_label, path_segments, conditions)
+      when is_list(path_segments) and path_segments != [] and is_list(conditions) do
+    {where_string, params} = build_conditions(:d, conditions, [])
     match_pattern = Cypher.node(:s, List.wrap(src_label)) <> build_agg_path(path_segments)
-    where_condition = Cypher.expression(:d, reached_property, convert_operator(operator), "$#{param_key}")
 
     %__MODULE__{
       clauses: [
         %Match{pattern: match_pattern},
-        %Where{conditions: [where_condition]},
+        %Where{conditions: [where_string]},
         %With{items: ["DISTINCT s"]},
         %Match{pattern: "(s)-[r0]-(d0)"},
         %Return{items: ["s", "r0", "d0"]}
       ],
-      params: %{param_key => value}
+      params: params
     }
   end
 

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -218,48 +218,80 @@ defmodule AshNeo4j.QueryHelper do
   end
 
   defp build_filtered_query(%ResourceMapping{} = mapping, predicates) do
-    case Enum.find(predicates, &traverse_field_predicate?/1) do
+    case Enum.find(predicates, &traverse_predicate?/1) do
       nil -> build_relationship_or_property_query(mapping, predicates)
       traverse_predicate -> build_traversal_query(mapping, traverse_predicate)
     end
   end
 
-  # A reached-node field comparison: `traverse(^chain, :field) <op> value` (#321).
-  defp traverse_field_predicate?(%{left: %AshNeo4j.Functions.Traverse{arguments: [_chain, field]}})
+  # A reached-node predicate over a traversal: a field comparison (#321), or a
+  # spatial predicate with the traversal as its geometry argument (#330).
+  defp traverse_predicate?(%{left: %AshNeo4j.Functions.Traverse{arguments: [_chain, field]}})
        when is_atom(field),
        do: true
 
-  defp traverse_field_predicate?(_), do: false
+  defp traverse_predicate?(%AshNeo4j.Functions.StDwithin{arguments: [%AshNeo4j.Functions.Traverse{} | _]}), do: true
+  defp traverse_predicate?(_), do: false
 
+  # Reached-node field comparison: `traverse(^chain, :field) <op> value`.
   defp build_traversal_query(%ResourceMapping{} = mapping, %{
          operator: operator,
          left: %AshNeo4j.Functions.Traverse{arguments: [chain, field]},
          right: value
        }) do
-    case resolve_chain(mapping.module, chain) do
-      [] ->
-        Logger.debug("AshNeo4j.QueryHelper: empty traverse chain")
-        Query.node_read(mapping.label_pair)
+    {segments, reached} = resolve_chain(mapping.module, chain)
+    condition = {reached_property(reached, field), operator, to_param_value(value), false}
+    traversal_query(mapping, segments, [condition])
+  end
 
-      segments ->
-        reached_property = field |> AshNeo4j.Util.to_camel_case() |> to_string()
-        Query.traversal_read(mapping.label_pair, segments, reached_property, operator, to_param_value(value))
+  # Composition: `st_dwithin(traverse(^chain, :location), ^point, ^km)` — render the
+  # spatial predicate against the reached node (#330). Needs a resolvable reached
+  # resource (relationship-name chain) for its point property.
+  defp build_traversal_query(%ResourceMapping{} = mapping, %AshNeo4j.Functions.StDwithin{
+         arguments: [%AshNeo4j.Functions.Traverse{arguments: [chain, field]}, test_point, threshold]
+       })
+       when is_number(threshold) do
+    {segments, reached} = resolve_chain(mapping.module, chain)
+
+    case reached && ResourceInfo.mapping(reached) do
+      %ResourceMapping{} = reached_mapping ->
+        condition =
+          {point_property(reached_mapping, field), :st_dwithin,
+           {to_geo_param!(reached_mapping, field, test_point), threshold}, false}
+
+        traversal_query(mapping, segments, [condition])
+
+      _ ->
+        Logger.debug("AshNeo4j.QueryHelper: st_dwithin traversal needs a resolvable reached resource")
+        Query.node_read(mapping.label_pair)
     end
   end
 
-  # Resolves a hop chain to `[{edge_label, direction, dest_label}]`, threading the
-  # current resource so relationship-name hops resolve at each step.
-  defp resolve_chain(resource, chain) when is_list(chain) do
-    {segments, _resource} =
-      Enum.reduce(chain, {[], resource}, fn hop, {acc, current} ->
-        {segment, next} = resolve_hop(current, hop)
-        {acc ++ [segment], next}
-      end)
-
-    segments
+  defp traversal_query(%ResourceMapping{} = mapping, [], _conditions) do
+    Logger.debug("AshNeo4j.QueryHelper: empty traverse chain")
+    Query.node_read(mapping.label_pair)
   end
 
-  defp resolve_chain(_resource, _), do: []
+  defp traversal_query(%ResourceMapping{} = mapping, segments, conditions) do
+    Query.traversal_read(mapping.label_pair, segments, conditions)
+  end
+
+  # The reached node's property name. With a resolved reached resource we honour
+  # its property mapping; for an explicit-edge chain (no resource) we camelCase.
+  defp reached_property(nil, field), do: field |> AshNeo4j.Util.to_camel_case() |> to_string()
+  defp reached_property(resource, field), do: property_name(ResourceInfo.mapping(resource), field)
+
+  # Resolves a hop chain to `{[{edge_label, direction, dest_label}], reached_resource}`,
+  # threading the current resource so relationship-name hops resolve at each step.
+  # `reached_resource` is `nil` once an explicit-edge hop breaks the resource chain.
+  defp resolve_chain(resource, chain) when is_list(chain) do
+    Enum.reduce(chain, {[], resource}, fn hop, {acc, current} ->
+      {segment, next} = resolve_hop(current, hop)
+      {acc ++ [segment], next}
+    end)
+  end
+
+  defp resolve_chain(_resource, _), do: {[], nil}
 
   # Relationship-name hop — resolve via `relate` on the current resource. `:forward`
   # walks the declared edge direction, `:reverse` flips it.

--- a/test/support/resource/party.ex
+++ b/test/support/resource/party.ex
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Test.Resource.Party do
+  @moduledoc false
+  # A source that reaches a Place via a PlaceRef joiner: Party -> PlaceRef -> Place.
+  use Ash.Resource,
+    domain: AshNeo4j.Test.SRM,
+    data_layer: AshNeo4j.DataLayer
+
+  neo4j do
+    label :Party
+    relate [{:place_ref, :HAS_PLACE_REF, :outgoing, :PlaceRef}]
+    skip [:place_ref_id]
+  end
+
+  actions do
+    default_accept :*
+    defaults [:read, :destroy]
+
+    create :create do
+      primary? true
+      argument :via_place_ref, :uuid
+      change manage_relationship(:via_place_ref, :place_ref, type: :append_and_remove)
+    end
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :name, :string, public?: true
+    attribute :place_ref_id, :uuid
+  end
+
+  relationships do
+    belongs_to :place_ref, AshNeo4j.Test.Resource.PlaceRef, public?: true
+  end
+end

--- a/test/support/resource/place_ref.ex
+++ b/test/support/resource/place_ref.ex
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Test.Resource.PlaceRef do
+  @moduledoc false
+  # A joiner node connecting a source to a Place (diffo's PlaceRef shape). The
+  # connection's meaning lives on the node — AshNeo4j has no edge properties.
+  use Ash.Resource,
+    domain: AshNeo4j.Test.SRM,
+    data_layer: AshNeo4j.DataLayer
+
+  neo4j do
+    label :PlaceRef
+    relate [{:place, :REFERS_TO, :outgoing, :Place}]
+    skip [:place_id]
+  end
+
+  actions do
+    default_accept :*
+    defaults [:read, :destroy]
+
+    create :create do
+      primary? true
+      argument :refers_to, :uuid
+      change manage_relationship(:refers_to, :place, type: :append_and_remove)
+    end
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :role, :string, public?: true
+    attribute :place_id, :uuid
+  end
+
+  relationships do
+    belongs_to :place, AshNeo4j.Test.Resource.Place, public?: true
+  end
+end

--- a/test/traverse_spatial_test.exs
+++ b/test/traverse_spatial_test.exs
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.TraverseSpatialTest do
+  @moduledoc false
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.Party
+  alias AshNeo4j.Test.Resource.Place
+  alias AshNeo4j.Test.Resource.PlaceRef
+
+  use ExUnit.Case, async: true
+
+  require Ash.Query
+
+  setup_all do
+    BoltyHelper.start()
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  defp geo(lng, lat), do: %Geo.Point{coordinates: {lng, lat}, srid: 4326}
+
+  defp party_at(name, place) do
+    {:ok, ref} = PlaceRef |> Ash.Changeset.for_create(:create, %{role: "site", refers_to: place.id}) |> Ash.create()
+    {:ok, party} = Party |> Ash.Changeset.for_create(:create, %{name: name, via_place_ref: ref.id}) |> Ash.create()
+    party
+  end
+
+  test "st_dwithin composed with a 2-hop traversal: parties whose site is within 5 km of a point" do
+    sydney = Ash.create!(Place, %{name: "Sydney", location: geo(151.2093, -33.8688)})
+    melbourne = Ash.create!(Place, %{name: "Melbourne", location: geo(144.9631, -37.8136)})
+
+    party_at("Sydney Co", sydney)
+    party_at("Melbourne Co", melbourne)
+
+    customer = geo(151.2, -33.85)
+    # Party -[:HAS_PLACE_REF]-> PlaceRef -[:REFERS_TO]-> Place(location)
+    chain = [{:forward, :place_ref}, {:forward, :place}]
+
+    names =
+      Party
+      |> Ash.Query.filter(st_dwithin(traverse(^chain, :location), ^customer, 5_000))
+      |> Ash.read!()
+      |> Enum.map(& &1.name)
+
+    assert names == ["Sydney Co"]
+  end
+
+  test "a broader threshold catches both parties' sites" do
+    sydney = Ash.create!(Place, %{name: "Sydney", location: geo(151.2093, -33.8688)})
+    melbourne = Ash.create!(Place, %{name: "Melbourne", location: geo(144.9631, -37.8136)})
+    party_at("Sydney Co", sydney)
+    party_at("Melbourne Co", melbourne)
+
+    customer = geo(151.2, -33.85)
+    chain = [{:forward, :place_ref}, {:forward, :place}]
+
+    names =
+      Party
+      |> Ash.Query.filter(st_dwithin(traverse(^chain, :location), ^customer, 1_000_000))
+      |> Ash.read!()
+      |> Enum.map(& &1.name)
+      |> Enum.sort()
+
+    assert names == ["Melbourne Co", "Sydney Co"]
+  end
+end


### PR DESCRIPTION
Closes #330. Builds on #321 (traverse filter).

## What

`st_dwithin(traverse(^chain, :location), ^point, ^km)` — the **"within 5 km of the site"** headline — pushes down to a single Cypher path pattern with the spatial predicate against the **reached** node:

```cypher
MATCH (s:Party)-[:HAS_PLACE_REF]->(:PlaceRef)-[:REFERS_TO]->(d:Place)
WHERE point.distance(d.`location.point`, $p) <= $km
WITH DISTINCT s MATCH (s)-[r0]-(d0) RETURN s, r0, d0
```

## How

- **Unified `traversal_read`** to take `{prop, op, val, ci}` condition tuples rendered against the reached node `d` via `build_conditions/3` — so reached-node **field comparisons** (#321) *and* **st_dwithin / st_distance / vector** predicates all compose through the same path machinery, no bespoke spatial query.
- **`resolve_chain` now returns the reached resource**, so its point property (`location.point`) and geo param resolve against the right mapping.

## Fixture

Mirrors the real diffo shape: `Party -> PlaceRef (joiner) -> Place(location)` — a joiner node carries the connection's meaning (AshNeo4j has no edge properties).

## Tests

`test/traverse_spatial_test.exs` — within-5km (Sydney in, Melbourne out) and a broad-threshold catch-both, over the 2-hop. Full suite green (637).

## Follow-on

`vector_similarity` / `st_distance` composition over a reached node — the machinery is unified, so each is just a detection clause + fixture.
