### PR TITLE
feat: compose st_contains / st_distance with a traversal over a reached node (#332)

### DIFF
--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -231,6 +231,12 @@ defmodule AshNeo4j.QueryHelper do
        do: true
 
   defp traverse_predicate?(%AshNeo4j.Functions.StDwithin{arguments: [%AshNeo4j.Functions.Traverse{} | _]}), do: true
+  defp traverse_predicate?(%AshNeo4j.Functions.StContains{arguments: [%AshNeo4j.Functions.Traverse{} | _]}), do: true
+  defp traverse_predicate?(%{left: %AshNeo4j.Functions.StDistance{arguments: [%AshNeo4j.Functions.Traverse{} | _]}}), do: true
+
+  defp traverse_predicate?(%{left: %AshNeo4j.Functions.StDistanceInMeters{arguments: [%AshNeo4j.Functions.Traverse{} | _]}}),
+    do: true
+
   defp traverse_predicate?(_), do: false
 
   # Reached-node field comparison: `traverse(^chain, :field) <op> value`.
@@ -244,25 +250,56 @@ defmodule AshNeo4j.QueryHelper do
     traversal_query(mapping, segments, [condition])
   end
 
-  # Composition: `st_dwithin(traverse(^chain, :location), ^point, ^km)` — render the
-  # spatial predicate against the reached node (#330). Needs a resolvable reached
-  # resource (relationship-name chain) for its point property.
+  # Composition (#330/#332): a spatial predicate with the traversal as its geometry
+  # argument — render it against the reached node. Needs a resolvable reached
+  # resource (relationship-name chain) for the reached geo attribute.
   defp build_traversal_query(%ResourceMapping{} = mapping, %AshNeo4j.Functions.StDwithin{
          arguments: [%AshNeo4j.Functions.Traverse{arguments: [chain, field]}, test_point, threshold]
        })
        when is_number(threshold) do
+    spatial_traversal(mapping, chain, fn reached ->
+      {point_property(reached, field), :st_dwithin, {to_geo_param!(reached, field, test_point), threshold}, false}
+    end)
+  end
+
+  defp build_traversal_query(%ResourceMapping{} = mapping, %{
+         operator: operator,
+         left: %distance{arguments: [%AshNeo4j.Functions.Traverse{arguments: [chain, field]}, test_point]},
+         right: threshold
+       })
+       when distance in [AshNeo4j.Functions.StDistance, AshNeo4j.Functions.StDistanceInMeters] and is_number(threshold) do
+    spatial_traversal(mapping, chain, fn reached ->
+      {point_property(reached, field), :st_distance, {operator, to_geo_param!(reached, field, test_point), threshold}, false}
+    end)
+  end
+
+  defp build_traversal_query(%ResourceMapping{} = mapping, %AshNeo4j.Functions.StContains{
+         arguments: [%AshNeo4j.Functions.Traverse{arguments: [chain, field]}, %Geo.Point{} = point]
+       }) do
+    spatial_traversal(mapping, chain, fn reached ->
+      if polygon_attribute?(reached, field) do
+        {property_name(reached, field), :st_contains, to_param_value(point), false}
+      end
+    end)
+  end
+
+  # Unsupported traverse predicate shape — fall back to an unfiltered read.
+  defp build_traversal_query(%ResourceMapping{} = mapping, _predicate) do
+    Logger.debug("AshNeo4j.QueryHelper: unsupported traverse predicate, falling back to node_read")
+    Query.node_read(mapping.label_pair)
+  end
+
+  # Resolves the chain + reached resource, applies `condition_fn` against the
+  # reached mapping (`nil` = not applicable), then builds the traversal read.
+  defp spatial_traversal(%ResourceMapping{} = mapping, chain, condition_fn) do
     {segments, reached} = resolve_chain(mapping.module, chain)
 
-    case reached && ResourceInfo.mapping(reached) do
-      %ResourceMapping{} = reached_mapping ->
-        condition =
-          {point_property(reached_mapping, field), :st_dwithin,
-           {to_geo_param!(reached_mapping, field, test_point), threshold}, false}
-
-        traversal_query(mapping, segments, [condition])
-
+    with %ResourceMapping{} = reached_mapping <- reached && ResourceInfo.mapping(reached),
+         condition when not is_nil(condition) <- condition_fn.(reached_mapping) do
+      traversal_query(mapping, segments, [condition])
+    else
       _ ->
-        Logger.debug("AshNeo4j.QueryHelper: st_dwithin traversal needs a resolvable reached resource")
+        Logger.debug("AshNeo4j.QueryHelper: spatial traverse needs a resolvable reached geo attribute")
         Query.node_read(mapping.label_pair)
     end
   end

--- a/test/traverse_spatial_test.exs
+++ b/test/traverse_spatial_test.exs
@@ -69,4 +69,50 @@ defmodule AshNeo4j.TraverseSpatialTest do
 
     assert names == ["Melbourne Co", "Sydney Co"]
   end
+
+  test "st_distance composed with a traversal: parties whose site is under an exact distance" do
+    sydney = Ash.create!(Place, %{name: "Sydney", location: geo(151.2093, -33.8688)})
+    melbourne = Ash.create!(Place, %{name: "Melbourne", location: geo(144.9631, -37.8136)})
+    party_at("Sydney Co", sydney)
+    party_at("Melbourne Co", melbourne)
+
+    customer = geo(151.2, -33.85)
+    chain = [{:forward, :place_ref}, {:forward, :place}]
+
+    names =
+      Party
+      |> Ash.Query.filter(st_distance(traverse(^chain, :location), ^customer) < 5_000)
+      |> Ash.read!()
+      |> Enum.map(& &1.name)
+
+    assert names == ["Sydney Co"]
+  end
+
+  test "st_contains composed with a traversal: parties whose site boundary contains a point" do
+    sydney_box = %Geo.Polygon{
+      coordinates: [[{151.0, -34.0}, {151.4, -34.0}, {151.4, -33.7}, {151.0, -33.7}, {151.0, -34.0}]],
+      srid: 4326
+    }
+
+    melbourne_box = %Geo.Polygon{
+      coordinates: [[{144.8, -38.0}, {145.1, -38.0}, {145.1, -37.7}, {144.8, -37.7}, {144.8, -38.0}]],
+      srid: 4326
+    }
+
+    sydney = Ash.create!(Place, %{name: "Sydney", bounds: sydney_box})
+    melbourne = Ash.create!(Place, %{name: "Melbourne", bounds: melbourne_box})
+    party_at("Sydney Co", sydney)
+    party_at("Melbourne Co", melbourne)
+
+    point = geo(151.2, -33.85)
+    chain = [{:forward, :place_ref}, {:forward, :place}]
+
+    names =
+      Party
+      |> Ash.Query.filter(st_contains(traverse(^chain, :bounds), ^point))
+      |> Ash.read!()
+      |> Enum.map(& &1.name)
+
+    assert names == ["Sydney Co"]
+  end
 end


### PR DESCRIPTION
Closes #332. Follows #330 (`st_dwithin` composition).

## What

`st_distance` and `st_contains` now compose with a traversal, pushed to the reached node:

```elixir
# parties whose site is under an exact distance
Party |> Ash.Query.filter(st_distance(traverse(^chain, :location), ^point) < 5_000) |> Ash.read!()

# parties whose site boundary contains a point
Party |> Ash.Query.filter(st_contains(traverse(^chain, :bounds), ^point)) |> Ash.read!()
```

## How

The `traversal_read` + `build_conditions` unification from #330 means each is **one detection clause** in `query_helper`. The spatial composition clauses now share a `spatial_traversal/3` helper: resolve the chain + reached resource, build the `{prop, op, val, ci}` condition against the reached mapping, render against `d`.

- `st_distance` — same point property (`location.point`) as `st_dwithin`.
- `st_contains` — the reached geometry is the container: point-within the reached polygon's bbox companions (`bounds.bbSW`/`bounds.bbNE`), via the existing `within_bbox` rendering.

## Tests

`test/traverse_spatial_test.exs` — `st_distance` and `st_contains` over the 2-hop `Party -> PlaceRef -> Place`. Full suite green (639).

## Out of scope

Vector composition (`vector_similarity` / `vector_cosine_distance`) — by decision: diffo doesn't use vectors, and `Vector` is being reworked under `Nx.Tensor` (#309/#308).
