### PR TITLE
feat: traverse exists / count — membership & cardinality pushdown (#334)

### DIFF
--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -420,6 +420,51 @@ defmodule AshNeo4j.Cypher.Query do
   end
 
   @doc """
+  Existence / cardinality of a traversal's reached set (#334) — a `WHERE`
+  predicate on the source, not a field comparison on the reached node.
+
+  `MATCH (s:Src) WHERE EXISTS { MATCH (s)<path>(d) } OPTIONAL MATCH (s)-[r]-(d0) RETURN s, r, d0`
+  `MATCH (s:Src) WHERE COUNT { MATCH (s)<path>(d) RETURN DISTINCT d } > $n OPTIONAL MATCH (s)-[r]-(d0) RETURN s, r, d0`
+
+  `agg` selects the predicate:
+
+    * `{:exists, true}`  → `EXISTS { … }` (short-circuits on first match)
+    * `{:exists, false}` → `NOT EXISTS { … }` (membership exclusion)
+    * `{:count, op, n}`  → `COUNT { … RETURN DISTINCT d } <op> $n` (distinct reached nodes)
+
+  The source is filtered directly (no per-path row fan-out), and enrichment uses
+  `OPTIONAL MATCH` so a `NOT EXISTS` source with no other edges still returns.
+  Needs no reached-resource typing, so it composes over reverse chains too.
+  """
+  @spec traversal_predicate_read(atom() | [atom()], [{atom(), atom(), atom() | nil}], tuple()) :: t()
+  def traversal_predicate_read(src_label, path_segments, agg)
+      when is_list(path_segments) and path_segments != [] do
+    path_pattern = "(s)" <> build_agg_path(path_segments)
+    {where_string, params} = build_traversal_predicate(path_pattern, agg)
+
+    %__MODULE__{
+      clauses: [
+        %Match{pattern: Cypher.node(:s, List.wrap(src_label))},
+        %Where{conditions: [where_string]},
+        %OptionalMatch{pattern: "(s)-[r]-(d0)"},
+        %Return{items: ["s", "r", "d0"]}
+      ],
+      params: params
+    }
+  end
+
+  defp build_traversal_predicate(path_pattern, {:exists, true}),
+    do: {"EXISTS { MATCH #{path_pattern} }", %{}}
+
+  defp build_traversal_predicate(path_pattern, {:exists, false}),
+    do: {"NOT EXISTS { MATCH #{path_pattern} }", %{}}
+
+  defp build_traversal_predicate(path_pattern, {:count, op, value}) do
+    key = "traverse_count_0"
+    {"COUNT { MATCH #{path_pattern} RETURN DISTINCT d } #{convert_operator(op)} $#{key}", %{key => value}}
+  end
+
+  @doc """
   `MATCH (n:L1:L2 {props}) OPTIONAL MATCH (n)-[r]-(d) RETURN n, r, d`
 
   Like `node_read/1` but matches by properties in the MATCH pattern (not a WHERE clause).

--- a/lib/functions/traverse.ex
+++ b/lib/functions/traverse.ex
@@ -20,6 +20,11 @@ defmodule AshNeo4j.Functions.Traverse do
       |> Ash.Query.filter(st_dwithin(traverse(^chain, :location), ^point, 5_000))
       |> Ash.read!()
 
+      # membership / cardinality over the reached set (#334)
+      Service |> Ash.Query.filter(traverse(^chain, :exists) == true)   # reaches a node
+      Service |> Ash.Query.filter(traverse(^chain, :exists) == false)  # reaches none
+      Service |> Ash.Query.filter(traverse(^chain, :count) > 0)        # cardinality
+
   ## Arguments
 
     * `hop_chain` — a list of hops, each `{:forward | :reverse, edge_selector}`.
@@ -27,9 +32,19 @@ defmodule AshNeo4j.Functions.Traverse do
       `edge_selector` is an Ash **relationship name** (atom, resolved on the
       source resource to its edge label + destination label) or an explicit
       `{:edge, label}` / `{:edge, label, dest_label}`.
-    * `projection` (optional, default `:node`) — a field atom on the reached
-      node (the value to compare or feed to `st_dwithin`/`vector_similarity`),
-      or `:node` for the reached node itself.
+    * `projection` (optional, default `:node`) — what to pull from the reached
+      set:
+        * `:node` (default) — the reached node itself
+        * a field atom (e.g. `:status`, `:location`) — a field on the reached
+          node, to compare or feed to `st_dwithin`/`vector_similarity`
+        * `:exists` — membership; renders to `EXISTS {}` / `NOT EXISTS {}`,
+          spelled `== true` / `== false`
+        * `:count` — cardinality of distinct reached nodes; renders to
+          `COUNT { … } <op> n`
+
+  Ash's `count()`/`sum()`/… are inline aggregates welded to a relationship path
+  and expanded at filter hydration, so they can't nest as `traverse(count())`;
+  the aggregate is carried as a projection literal (`:count`) instead.
 
   ## Pushdown only
 

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -239,6 +239,31 @@ defmodule AshNeo4j.QueryHelper do
 
   defp traverse_predicate?(_), do: false
 
+  # Membership over the reached set (#334): `traverse(^chain, :exists) == true|false`.
+  # `:exists` renders to `EXISTS {}` / `NOT EXISTS {}` — no reached-node field, so
+  # no reached-resource typing needed (composes over reverse chains too).
+  defp build_traversal_query(%ResourceMapping{} = mapping, %{
+         operator: operator,
+         left: %AshNeo4j.Functions.Traverse{arguments: [chain, :exists]},
+         right: value
+       })
+       when operator in [:==, :!=] and is_boolean(value) do
+    {segments, _reached} = resolve_chain(mapping.module, chain)
+    exists? = if operator == :==, do: value, else: not value
+    traversal_predicate(mapping, segments, {:exists, exists?})
+  end
+
+  # Cardinality over the reached set (#334): `traverse(^chain, :count) <op> n`.
+  defp build_traversal_query(%ResourceMapping{} = mapping, %{
+         operator: operator,
+         left: %AshNeo4j.Functions.Traverse{arguments: [chain, :count]},
+         right: value
+       })
+       when operator in [:==, :!=, :<, :<=, :>, :>=] and is_integer(value) do
+    {segments, _reached} = resolve_chain(mapping.module, chain)
+    traversal_predicate(mapping, segments, {:count, operator, value})
+  end
+
   # Reached-node field comparison: `traverse(^chain, :field) <op> value`.
   defp build_traversal_query(%ResourceMapping{} = mapping, %{
          operator: operator,
@@ -311,6 +336,15 @@ defmodule AshNeo4j.QueryHelper do
 
   defp traversal_query(%ResourceMapping{} = mapping, segments, conditions) do
     Query.traversal_read(mapping.label_pair, segments, conditions)
+  end
+
+  defp traversal_predicate(%ResourceMapping{} = mapping, [], _agg) do
+    Logger.debug("AshNeo4j.QueryHelper: empty traverse chain")
+    Query.node_read(mapping.label_pair)
+  end
+
+  defp traversal_predicate(%ResourceMapping{} = mapping, segments, agg) do
+    Query.traversal_predicate_read(mapping.label_pair, segments, agg)
   end
 
   # The reached node's property name. With a resolved reached resource we honour

--- a/test/traverse_exists_count_test.exs
+++ b/test/traverse_exists_count_test.exs
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.TraverseExistsCountTest do
+  @moduledoc false
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.Party
+  alias AshNeo4j.Test.Resource.Place
+  alias AshNeo4j.Test.Resource.PlaceRef
+
+  use ExUnit.Case, async: true
+
+  require Ash.Query
+
+  setup_all do
+    BoltyHelper.start()
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  defp party_at(name, place) do
+    {:ok, ref} = PlaceRef |> Ash.Changeset.for_create(:create, %{role: "site", refers_to: place.id}) |> Ash.create()
+    {:ok, party} = Party |> Ash.Changeset.for_create(:create, %{name: name, via_place_ref: ref.id}) |> Ash.create()
+    party
+  end
+
+  # Party -[:HAS_PLACE_REF]-> PlaceRef -[:REFERS_TO]-> Place
+  @chain [{:forward, :place_ref}, {:forward, :place}]
+
+  test "exists == true: parties that reach a place through the chain" do
+    sydney = Ash.create!(Place, %{name: "Sydney"})
+    party_at("Sited Co", sydney)
+    Ash.create!(Party, %{name: "Floating Co"})
+
+    names =
+      Party
+      |> Ash.Query.filter(traverse(^@chain, :exists) == true)
+      |> Ash.read!()
+      |> Enum.map(& &1.name)
+
+    assert names == ["Sited Co"]
+  end
+
+  test "exists == false: parties that reach no place (membership exclusion)" do
+    sydney = Ash.create!(Place, %{name: "Sydney"})
+    party_at("Sited Co", sydney)
+    Ash.create!(Party, %{name: "Floating Co"})
+
+    names =
+      Party
+      |> Ash.Query.filter(traverse(^@chain, :exists) == false)
+      |> Ash.read!()
+      |> Enum.map(& &1.name)
+
+    assert names == ["Floating Co"]
+  end
+
+  test "count > 0: cardinality threshold reaches the sited party only" do
+    sydney = Ash.create!(Place, %{name: "Sydney"})
+    party_at("Sited Co", sydney)
+    Ash.create!(Party, %{name: "Floating Co"})
+
+    names =
+      Party
+      |> Ash.Query.filter(traverse(^@chain, :count) > 0)
+      |> Ash.read!()
+      |> Enum.map(& &1.name)
+
+    assert names == ["Sited Co"]
+  end
+
+  test "count == 0: cardinality zero is the no-reach set" do
+    sydney = Ash.create!(Place, %{name: "Sydney"})
+    party_at("Sited Co", sydney)
+    Ash.create!(Party, %{name: "Floating Co"})
+
+    names =
+      Party
+      |> Ash.Query.filter(traverse(^@chain, :count) == 0)
+      |> Ash.read!()
+      |> Enum.map(& &1.name)
+
+    assert names == ["Floating Co"]
+  end
+end


### PR DESCRIPTION
Closes #334.

Adds `:exists` and `:count` projections to `traverse/2` — membership and cardinality over a traversal's reached set, pushed down to Cypher.

```elixir
traverse(^chain, :exists) == true    # reaches a node        → EXISTS { … }
traverse(^chain, :exists) == false   # reaches none          → NOT EXISTS { … }
traverse(^chain, :count) > 0         # cardinality threshold  → COUNT { … RETURN DISTINCT d } > 0
```

### Why a projection literal, not `traverse(count())`

Ash's `count`/`sum`/`min`/`max`/`avg`/`first`/`list` are **inline aggregates welded to a relationship path**, expanded at filter hydration before any data layer sees the expression. Both nesting directions raise:

```
traverse(^chain, count()) > 0   → RAISES: `count()` invalid, `nil` is not a valid relationship path
count(traverse(^chain)) > 0     → RAISES: `traverse(...)` is not a valid relationship path
```

So the aggregate is carried in the projection slot as a literal (`:count`) that survives hydration — still **one** composable `traverse` function, not a welded `traverse_count`.

### Notes

- `:exists` is not sugar for `:count > 0` — it renders to `EXISTS {}`, which short-circuits, vs `COUNT {}` which counts all then compares.
- `:exists`/`:count` access no reached-node field, so they need no reached-resource typing — they compose over **reverse** chains too (unlike field access, the #336 gap).
- Enrichment uses `OPTIONAL MATCH` so a `NOT EXISTS` source with no other edges still returns.
- Field aggregates (`{:sum, :price}`, `{:min, :opened_at}`) are the same projection slot, deferred to keep this the membership/cardinality slice.

### Tests

4 live tests over the `Party -> PlaceRef -> Place` fixtures (exists true/false, count `> 0` / `== 0`). Full suite green (643 passed), REUSE clean.
