### PR TITLE
feat: traverse field aggregates — {:min|:max|:avg|:sum, :field} (#338)

### DIFF
--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -400,6 +400,8 @@ defmodule AshNeo4j.Cypher do
     "CALL { #{Enum.join(branches, joiner)} }"
   end
 
+  defp render_clause(%AshNeo4j.Cypher.CallSubquery{body: body}), do: "CALL { #{body} }"
+
   defp render_clause(%OrderBy{terms: terms}) do
     "ORDER BY " <>
       Enum.map_join(terms, ", ", fn

--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -104,6 +104,16 @@ defmodule AshNeo4j.Cypher.Limit do
   defstruct [:value]
 end
 
+defmodule AshNeo4j.Cypher.CallSubquery do
+  @moduledoc """
+  `CALL { … }` subquery block holding a pre-rendered inner query body, e.g. a
+  scoped aggregate `CALL { WITH s MATCH (s)<path>(d) RETURN min(d.p) AS agg_v }`.
+  Distinct from `Call`, which joins branches with `UNION`/`UNION ALL`.
+  """
+  @type t :: %__MODULE__{body: String.t()}
+  defstruct [:body]
+end
+
 defmodule AshNeo4j.Cypher.Query do
   @moduledoc """
   Typed representation of a Cypher query, and builders for constructing common patterns.
@@ -135,7 +145,8 @@ defmodule AshNeo4j.Cypher.Query do
     OrderBy,
     Skip,
     Limit,
-    Call
+    Call,
+    CallSubquery
   }
 
   @type clause ::
@@ -154,6 +165,7 @@ defmodule AshNeo4j.Cypher.Query do
           | Skip.t()
           | Limit.t()
           | Call.t()
+          | CallSubquery.t()
 
   @type t :: %__MODULE__{clauses: [clause()], params: map()}
 
@@ -462,6 +474,42 @@ defmodule AshNeo4j.Cypher.Query do
   defp build_traversal_predicate(path_pattern, {:count, op, value}) do
     key = "traverse_count_0"
     {"COUNT { MATCH #{path_pattern} RETURN DISTINCT d } #{convert_operator(op)} $#{key}", %{key => value}}
+  end
+
+  @doc """
+  Field aggregate over a traversal's reached set (#338) compared against a value.
+
+  No native `MIN {}`/`MAX {}`/`AVG {}`/`SUM {}` subquery expression exists, so
+  this uses a scoped `CALL` that aggregates the reached field, then filters the
+  scalar — plain Cypher 5 (the `WITH s` import form, not `CALL (s) {}`):
+
+  `MATCH (s:Src) CALL { WITH s MATCH (s)<path>(d) RETURN min(d.p) AS agg_v } WITH s, agg_v WHERE agg_v <op> $v OPTIONAL MATCH (s)-[r]-(d0) RETURN s, r, d0`
+
+  `agg` is `{agg_fn, prop, op, value}` where `agg_fn ∈ [:min, :max, :avg, :sum]`
+  and `prop` is the already-resolved reached-node property name.
+
+  Empty-set semantics follow Neo4j's aggregating functions and differ by `agg_fn`:
+  `min`/`max`/`avg` over a no-reach source yield `null` (so `null <op> $v` drops
+  it), while `sum` yields `0` (like `count`) and can still match a comparison.
+  """
+  @spec traversal_aggregate_read(atom() | [atom()], [{atom(), atom(), atom() | nil}], tuple()) :: t()
+  def traversal_aggregate_read(src_label, path_segments, {agg_fn, prop, op, value})
+      when is_list(path_segments) and path_segments != [] and agg_fn in [:min, :max, :avg, :sum] do
+    path = "(s)" <> build_agg_path(path_segments)
+    key = "traverse_agg_0"
+    body = "WITH s MATCH #{path} RETURN #{agg_fn}(d.#{prop}) AS agg_v"
+
+    %__MODULE__{
+      clauses: [
+        %Match{pattern: Cypher.node(:s, List.wrap(src_label))},
+        %CallSubquery{body: body},
+        %With{items: ["s", "agg_v"]},
+        %Where{conditions: ["agg_v #{convert_operator(op)} $#{key}"]},
+        %OptionalMatch{pattern: "(s)-[r]-(d0)"},
+        %Return{items: ["s", "r", "d0"]}
+      ],
+      params: %{key => value}
+    }
   end
 
   @doc """

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -224,8 +224,13 @@ defmodule AshNeo4j.QueryHelper do
     end
   end
 
-  # A reached-node predicate over a traversal: a field comparison (#321), or a
-  # spatial predicate with the traversal as its geometry argument (#330).
+  # A reached-node predicate over a traversal: a field comparison (#321), a
+  # field aggregate (#338), or a spatial predicate with the traversal as its
+  # geometry argument (#330).
+  defp traverse_predicate?(%{left: %AshNeo4j.Functions.Traverse{arguments: [_chain, {agg, field}]}})
+       when agg in [:min, :max, :avg, :sum] and is_atom(field),
+       do: true
+
   defp traverse_predicate?(%{left: %AshNeo4j.Functions.Traverse{arguments: [_chain, field]}})
        when is_atom(field),
        do: true
@@ -262,6 +267,20 @@ defmodule AshNeo4j.QueryHelper do
        when operator in [:==, :!=, :<, :<=, :>, :>=] and is_integer(value) do
     {segments, _reached} = resolve_chain(mapping.module, chain)
     traversal_predicate(mapping, segments, {:count, operator, value})
+  end
+
+  # Field aggregate over the reached set (#338): `traverse(^chain, {:min, :field}) <op> value`.
+  # Reads `d.field`, so it needs the reached resource's property mapping — a
+  # forward relationship-name chain resolves it; a reverse-terminal chain (#336)
+  # gives `reached = nil` and falls back to an unfiltered read.
+  defp build_traversal_query(%ResourceMapping{} = mapping, %{
+         operator: operator,
+         left: %AshNeo4j.Functions.Traverse{arguments: [chain, {agg, field}]},
+         right: value
+       })
+       when agg in [:min, :max, :avg, :sum] and operator in [:==, :!=, :<, :<=, :>, :>=] do
+    {segments, reached} = resolve_chain(mapping.module, chain)
+    traversal_aggregate(mapping, segments, reached, agg, field, operator, value)
   end
 
   # Reached-node field comparison: `traverse(^chain, :field) <op> value`.
@@ -345,6 +364,23 @@ defmodule AshNeo4j.QueryHelper do
 
   defp traversal_predicate(%ResourceMapping{} = mapping, segments, agg) do
     Query.traversal_predicate_read(mapping.label_pair, segments, agg)
+  end
+
+  defp traversal_aggregate(%ResourceMapping{} = mapping, [], _reached, _agg, _field, _op, _value) do
+    Logger.debug("AshNeo4j.QueryHelper: empty traverse chain")
+    Query.node_read(mapping.label_pair)
+  end
+
+  # No resolved reached resource (e.g. reverse-terminal chain, #336) — can't map
+  # the reached field to a property. Fall back to an unfiltered read.
+  defp traversal_aggregate(%ResourceMapping{} = mapping, _segments, nil, _agg, _field, _op, _value) do
+    Logger.debug("AshNeo4j.QueryHelper: traverse aggregate needs a resolvable reached field (forward chain)")
+    Query.node_read(mapping.label_pair)
+  end
+
+  defp traversal_aggregate(%ResourceMapping{} = mapping, segments, reached, agg, field, op, value) do
+    prop = property_name(ResourceInfo.mapping(reached), field)
+    Query.traversal_aggregate_read(mapping.label_pair, segments, {agg, prop, op, to_param_value(value)})
   end
 
   # The reached node's property name. With a resolved reached resource we honour

--- a/test/support/resource/place.ex
+++ b/test/support/resource/place.ex
@@ -16,6 +16,9 @@ defmodule AshNeo4j.Test.Resource.Place do
   attributes do
     uuid_primary_key :id
     attribute :name, :string, public?: true
+    # #338 — a plain numeric attribute so traverse field aggregates
+    # ({:min|:max|:avg|:sum, :population}) have something to aggregate.
+    attribute :population, :integer, public?: true
 
     attribute :location, AshGeo.GeoJson,
       public?: true,

--- a/test/traverse_aggregate_test.exs
+++ b/test/traverse_aggregate_test.exs
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.TraverseAggregateTest do
+  @moduledoc """
+  Field aggregates in the `traverse/2` projection (#338): `{:min|:max|:avg|:sum, :field}`.
+
+  The `Party -> PlaceRef -> Place` fixtures reach a single `Place` per `Party`,
+  so the aggregate runs over a one-node set (its value is that node's) — enough
+  to exercise the pushdown render, the scalar comparison, and the empty-set/null
+  exclusion. Aggregation over many reached nodes is Neo4j-native behaviour.
+  """
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.Party
+  alias AshNeo4j.Test.Resource.Place
+  alias AshNeo4j.Test.Resource.PlaceRef
+
+  use ExUnit.Case, async: true
+
+  require Ash.Query
+
+  setup_all do
+    BoltyHelper.start()
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  defp party_at(name, place) do
+    {:ok, ref} = PlaceRef |> Ash.Changeset.for_create(:create, %{role: "site", refers_to: place.id}) |> Ash.create()
+    {:ok, party} = Party |> Ash.Changeset.for_create(:create, %{name: name, via_place_ref: ref.id}) |> Ash.create()
+    party
+  end
+
+  # Party -[:HAS_PLACE_REF]-> PlaceRef -[:REFERS_TO]-> Place
+  @chain [{:forward, :place_ref}, {:forward, :place}]
+
+  setup do
+    sydney = Ash.create!(Place, %{name: "Sydney", population: 5_300_000})
+    melbourne = Ash.create!(Place, %{name: "Melbourne", population: 5_100_000})
+    party_at("Sydney Co", sydney)
+    party_at("Melbourne Co", melbourne)
+    Ash.create!(Party, %{name: "Floating Co"})
+    :ok
+  end
+
+  defp names(filtered), do: filtered |> Ash.read!() |> Enum.map(& &1.name) |> Enum.sort()
+
+  test "min: parties whose site population exceeds a threshold" do
+    assert names(Ash.Query.filter(Party, traverse(^@chain, {:min, :population}) > 5_200_000)) == ["Sydney Co"]
+  end
+
+  test "max: same field, max aggregate" do
+    assert names(Ash.Query.filter(Party, traverse(^@chain, {:max, :population}) <= 5_200_000)) == ["Melbourne Co"]
+  end
+
+  test "avg: average reached population over (single-node) set" do
+    assert names(Ash.Query.filter(Party, traverse(^@chain, {:avg, :population}) >= 5_200_000)) == ["Sydney Co"]
+  end
+
+  test "sum: summed reached population" do
+    assert names(Ash.Query.filter(Party, traverse(^@chain, {:sum, :population}) > 5_200_000)) == ["Sydney Co"]
+  end
+
+  test "empty-set null: min/max/avg over a no-reach source is null and is excluded" do
+    # Floating Co reaches no Place → min(population) is null → null > 0 drops it.
+    assert names(Ash.Query.filter(Party, traverse(^@chain, {:min, :population}) > 0)) == ["Melbourne Co", "Sydney Co"]
+  end
+
+  test "empty-set zero: sum over a no-reach source is 0 (not null), so it can match" do
+    # Neo4j's sum() (like count()) returns 0 over an empty set — Floating Co's
+    # sum is 0, which satisfies `< 1` where the sited parties' sums do not.
+    assert names(Ash.Query.filter(Party, traverse(^@chain, {:sum, :population}) < 1)) == ["Floating Co"]
+  end
+end


### PR DESCRIPTION
Closes #338.

Extends the `traverse/2` projection slot with field aggregates over the reached set — `{:min, :field}`, `{:max, :field}`, `{:avg, :field}`, `{:sum, :field}` — pushed down to Cypher. Sibling to #334 (`:exists` / `:count`).

```elixir
traverse(^chain, {:max, :opened_at}) > ^cutoff
traverse(^chain, {:avg, :population}) >= 5_200_000
```

### Cypher shape — CALL aggregate, not a subquery expression

Neo4j has `COUNT {}` / `EXISTS {}` (what #334 used) but **no** `MIN {}`/`MAX {}`/`AVG {}`/`SUM {}` subquery expression. So this uses a scoped `CALL` that aggregates, then filters the scalar — **plain Cypher 5** (the `WITH s` import form, no gate):

```cypher
MATCH (s:Src)
CALL { WITH s MATCH (s)<path>(d) RETURN min(d.p) AS agg_v }
WITH s, agg_v WHERE agg_v <op> $v
OPTIONAL MATCH (s)-[r]-(d0) RETURN s, r, d0
```

### Empty-set semantics differ by aggregate (pinned with tests)

Following Neo4j's aggregating functions:
- `min` / `max` / `avg` over a no-reach source → **null** → the comparison drops it
- `sum` over a no-reach source → **0** (like `count`) → can still match

Both cases have a test (`min(:population) > 0` excludes the no-reach party; `sum(:population) < 1` matches it).

### Notes

- Field aggregates read `d.field`, so they need the reached resource's property mapping — forward relationship-name chains resolve it; a **reverse-terminal** chain (#336) gives `reached = nil` and falls back to an unfiltered read.
- Adds a `CallSubquery` clause (`CALL { <body> }`), distinct from the UNION-only `Call`.
- Test fixture adds a numeric `population` attribute to `Place`; the `Party -> PlaceRef -> Place` chain reaches a single node per source, so these tests exercise render + comparison + empty-set semantics (multi-node aggregation is Neo4j-native).

Full suite green (649 passed), REUSE clean.
