### PR TITLE
feat: read-time polymorphic traverse projection — ProjectedTraversal (#329)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,6 +323,14 @@ as a follow-up comment, then leave it with the upstream maintainers.
 
 ## Common agent mistakes
 
+- **Fabricating a definite where a reached/related resource can't be resolved.** When a reached
+  node's labels resolve to no loaded world (`AshNeo4j.worlds/1` returns `[]`), or a property/edge
+  name can't be introspected from `ResourceInfo.mapping/1`, return `AshNeo4j.Unknown` (stamped with
+  the original query's resource as `:world`, a structural `:reason` atom, and diagnostic
+  `:context`) — never synthesise a `nil`/`0`/camelCased guess. A silently-wrong definite is the
+  worst outcome; `Unknown` is the honest "couldn't determine", complementary to `Ash.NotLoaded`'s
+  "not fetched yet". See `AshNeo4j.Calculations.ProjectedTraversal` for the producing path.
+
 - **Not using `mapping.label_pair` for MATCH.** All read, update, delete, and aggregate queries
   must use `mapping.label_pair` (`[domain_label, module_label]`) as the source node pattern.
   Using `mapping.label` alone matches every resource that extends the same fragment. Using

--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ end
 
 The `on_exit` call is optional — the transaction is rolled back automatically when the test process exits — but is recommended for clarity.
 
+### Placing a node in a world
+
+A node's **label set** is what `AshNeo4j.worlds/1` resolves to a `(domain, resource)` world, so polymorphic / open-world tests sometimes need a node whose labels differ from what an Ash create produces. `AshNeo4j.Neo4jHelper.update_node_labels/4` adds and/or removes labels on an existing node — create the node normally via Ash, then mutate its labels:
+
+```elixir
+place = Ash.create!(Place, %{name: "Sydney"})
+# strip the domain label so worlds/1 can no longer resolve this node to a world
+AshNeo4j.Neo4jHelper.update_node_labels(:Place, %{name: "Sydney"}, [], [:SRM])
+```
+
+This is a **test/maintenance** helper — the data layer sets labels at create time and never mutates them on the normal CRUD path — so it lives in `Neo4jHelper` alongside the other raw-Cypher helpers (`create_node/2`, `relate_nodes/6`, …) rather than on a resource action.
+
 ### Parallel tests
 
 Because each test's writes are confined to an uncommitted transaction, tests can run concurrently without interfering:

--- a/lib/calculations/projected_traversal.ex
+++ b/lib/calculations/projected_traversal.ex
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Calculations.ProjectedTraversal do
+  @moduledoc """
+  Read-time projection of a graph traversal (#329): follows a hop `chain` from
+  each record to the reached node and returns it as a value — late-binding the
+  reached node's concrete type at read time via `AshNeo4j.worlds/1`.
+
+  Use it where the reached node's concrete subtype isn't known at the source
+  resource's compile time (open-world refs across a cascade) — the read-time
+  sibling of the `traverse(^chain, …)` filter expression.
+
+  ## Usage
+
+      calculate :site, :struct,
+        {AshNeo4j.Calculations.ProjectedTraversal,
+         chain: [{:forward, :place_ref}, {:forward, :place}]}
+
+  ## Options
+
+    * `:chain` (required) — the hop chain, each hop `{:forward | :reverse,
+      edge_selector}`, same grammar as the `traverse/2` expression.
+
+  ## Result per record
+
+    * the **concrete record** — a node was reached and its labels resolved to a
+      loaded `(domain, resource)` world;
+    * `%AshNeo4j.Unknown{reason: :no_concrete_world}` — a node was reached but
+      its labels resolve to no loaded world (it can't be returned as a typed
+      record);
+    * `nil` — nothing was reached (genuine absence);
+    * `%Ash.NotLoaded{}` — until the calculation is loaded.
+
+  v1 is single-valued (the first reached node) and projects the reached record;
+  list projection and single-field projection are follow-ups.
+  """
+  use Ash.Resource.Calculation
+
+  @impl true
+  def load(_query, _opts, _context), do: []
+
+  @impl true
+  def calculate([], _opts, _context), do: []
+
+  def calculate(records, opts, _context) do
+    chain = Keyword.fetch!(opts, :chain)
+    resource = hd(records).__struct__
+    pk_field = hd(Ash.Resource.Info.primary_key(resource))
+    by_source = AshNeo4j.DataLayer.project_traversal(resource, records, chain)
+
+    Enum.map(records, fn record -> Map.get(by_source, Map.get(record, pk_field)) end)
+  end
+end

--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -804,6 +804,31 @@ defmodule AshNeo4j.Cypher.Query do
   end
 
   @doc """
+  `MATCH (n:L1:L2 {match_props}) SET n:Add1:Add2 REMOVE n:Rem1:Rem2 RETURN n`
+
+  Adds and/or removes node labels on a matched node. A node's label set drives
+  `AshNeo4j.worlds/1`, so this moves a node between worlds — handy in tests to
+  place a node in (or strip it of) a resolvable world after an Ash create.
+  Handles all combinations of empty/non-empty add and remove lists.
+  """
+  @spec update_node_labels(atom() | [atom()], map(), [atom()], [atom()]) :: t()
+  def update_node_labels(label, match_props, add_labels, remove_labels \\ [])
+      when is_map(match_props) and is_list(add_labels) and is_list(remove_labels) do
+    {match_pattern, params} = Cypher.parameterized_node(:n, List.wrap(label), match_props)
+
+    set_clauses =
+      if add_labels != [], do: [%Set{expression: "n:" <> Enum.map_join(add_labels, ":", &to_string/1)}], else: []
+
+    remove_clauses =
+      if remove_labels != [], do: [%Remove{items: ["n:" <> Enum.map_join(remove_labels, ":", &to_string/1)]}], else: []
+
+    %__MODULE__{
+      clauses: [%Match{pattern: match_pattern}] ++ set_clauses ++ remove_clauses ++ [%Return{items: ["n"]}],
+      params: params
+    }
+  end
+
+  @doc """
   `MATCH (n:L1:L2 {props}) DETACH DELETE n`
   """
   @spec delete_nodes(atom() | [atom()], map()) :: t()

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -1300,6 +1300,61 @@ defmodule AshNeo4j.DataLayer do
     end)
   end
 
+  @doc """
+  Read-time polymorphic projection (#329): for each source record, follows
+  `chain` to the reached node(s) in one query (`related_nodes/4`) and projects
+  each reached node to its concrete world via `AshNeo4j.worlds/1`.
+
+  Returns `%{source_pk_value => projected}` where `projected` is the concrete
+  record, an `AshNeo4j.Unknown` (a node was reached but its labels resolve to no
+  loaded world), or `nil` (genuinely nothing reached). v1 is single-valued.
+  """
+  @spec project_traversal(module(), [Ash.Resource.record()], list()) :: %{optional(any()) => any()}
+  def project_traversal(resource, records, chain) do
+    mapping = ResourceInfo.mapping(resource)
+    pk_field = hd(Ash.Resource.Info.primary_key(resource))
+    neo4j_pk = Keyword.get(mapping.properties, pk_field, pk_field)
+    ids = Enum.map(records, &Map.get(&1, pk_field))
+    {segments, _reached} = AshNeo4j.QueryHelper.resolve_chain(resource, chain)
+
+    if segments == [] do
+      Map.new(ids, &{&1, nil})
+    else
+      query = CypherQuery.related_nodes(mapping.label_pair, neo4j_pk, ids, segments)
+
+      case Cypher.run(query) do
+        {:ok, %Bolty.Response{results: rows}} ->
+          rows
+          |> Enum.group_by(&Map.get(&1, "source_id"), &Map.get(&1, "dest_node"))
+          |> Map.new(fn {source_id, dest_nodes} -> {source_id, project_reached(resource, dest_nodes)} end)
+
+        {:error, reason} ->
+          raise "AshNeo4j: traverse projection query failed: #{inspect(reason)}"
+      end
+    end
+  end
+
+  # v1 single-valued: the first reached node (or nil when none reached).
+  defp project_reached(resource, dest_nodes) do
+    case Enum.reject(dest_nodes, &is_nil/1) do
+      [] -> nil
+      [node | _] -> project_reached_node(resource, node)
+    end
+  end
+
+  defp project_reached_node(resource, node) do
+    case AshNeo4j.worlds(%{__metadata__: %{labels: node.labels}}) do
+      [{_domain, concrete} | _] ->
+        case convert_node_to_resource(concrete, node) do
+          {:ok, record} -> record
+          _ -> AshNeo4j.Unknown.new(resource, :projection_failed, %{labels: node.labels})
+        end
+
+      [] ->
+        AshNeo4j.Unknown.new(resource, :no_concrete_world, %{labels: node.labels})
+    end
+  end
+
   defp apply_calculations_to_records(records, [], _resource), do: {:ok, records}
 
   defp apply_calculations_to_records(records, calculations, resource) do

--- a/lib/neo4j_helper.ex
+++ b/lib/neo4j_helper.ex
@@ -126,6 +126,31 @@ defmodule AshNeo4j.Neo4jHelper do
     |> Cypher.run()
   end
 
+  @spec update_node_labels(atom() | [atom()], map(), [atom()], [atom()]) ::
+          {:error, %{:__exception__ => true, :__struct__ => atom(), optional(atom()) => any()}}
+          | {:ok, any()}
+  @doc """
+  Adds and/or removes labels on an existing node (matched by label + properties).
+
+  A node's label set drives `AshNeo4j.worlds/1`, so this places a node in — or
+  strips it of — a resolvable world. Useful in tests: create a node via Ash,
+  then mutate its labels to set up a chosen world (or an unresolvable one).
+
+  ## Examples
+  ```
+  iex> AshNeo4j.Neo4jHelper.create_node([:SRM, :Place], %{name: "Sydney"})
+  iex> {result, _} = AshNeo4j.Neo4jHelper.update_node_labels(:Place, %{name: "Sydney"}, [], [:SRM])
+  iex> result
+  :ok
+  ```
+  """
+  def update_node_labels(label, match_properties, add_labels, remove_labels \\ [])
+      when (is_atom(label) or is_list(label)) and is_map(match_properties) and
+             is_list(add_labels) and is_list(remove_labels) do
+    Query.update_node_labels(label, match_properties, add_labels, remove_labels)
+    |> Cypher.run()
+  end
+
   @spec relate_nodes(atom(), map(), atom(), map(), atom(), atom()) ::
           {:error, %{:__exception__ => true, :__struct__ => atom(), optional(atom()) => any()}}
           | {:ok, any()}

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -388,17 +388,23 @@ defmodule AshNeo4j.QueryHelper do
   defp reached_property(nil, field), do: field |> AshNeo4j.Util.to_camel_case() |> to_string()
   defp reached_property(resource, field), do: property_name(ResourceInfo.mapping(resource), field)
 
-  # Resolves a hop chain to `{[{edge_label, direction, dest_label}], reached_resource}`,
-  # threading the current resource so relationship-name hops resolve at each step.
-  # `reached_resource` is `nil` once an explicit-edge hop breaks the resource chain.
-  defp resolve_chain(resource, chain) when is_list(chain) do
+  @doc """
+  Resolves a hop chain to `{[{edge_label, direction, dest_label}], reached_resource}`,
+  threading the current resource so relationship-name hops resolve at each step.
+  `reached_resource` is `nil` once an explicit-edge hop breaks the resource chain.
+
+  Public so read-time consumers (e.g. the projection calculation) can turn a
+  `chain` opt into Cypher path segments for `Cypher.Query.related_nodes/4`.
+  """
+  @spec resolve_chain(module(), list()) :: {[{atom(), atom(), atom() | nil}], module() | nil}
+  def resolve_chain(resource, chain) when is_list(chain) do
     Enum.reduce(chain, {[], resource}, fn hop, {acc, current} ->
       {segment, next} = resolve_hop(current, hop)
       {acc ++ [segment], next}
     end)
   end
 
-  defp resolve_chain(_resource, _), do: {[], nil}
+  def resolve_chain(_resource, _), do: {[], nil}
 
   # Relationship-name hop — resolve via `relate` on the current resource. `:forward`
   # walks the declared edge direction, `:reverse` flips it.

--- a/test/support/resource/party.ex
+++ b/test/support/resource/party.ex
@@ -35,4 +35,11 @@ defmodule AshNeo4j.Test.Resource.Party do
   relationships do
     belongs_to :place_ref, AshNeo4j.Test.Resource.PlaceRef, public?: true
   end
+
+  calculations do
+    # Read-time projection of the reached Place (#329) — Party -> PlaceRef -> Place.
+    calculate :projected_place,
+              :struct,
+              {AshNeo4j.Calculations.ProjectedTraversal, chain: [{:forward, :place_ref}, {:forward, :place}]}
+  end
 end

--- a/test/traverse_projection_test.exs
+++ b/test/traverse_projection_test.exs
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.TraverseProjectionTest do
+  @moduledoc """
+  Read-time polymorphic projection (#329): `AshNeo4j.Calculations.ProjectedTraversal`
+  follows `Party -> PlaceRef -> Place` and returns the reached Place — or
+  `AshNeo4j.Unknown` when the reached node resolves to no loaded world, or `nil`
+  when nothing is reached.
+  """
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Neo4jHelper
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.Party
+  alias AshNeo4j.Test.Resource.Place
+  alias AshNeo4j.Test.Resource.PlaceRef
+  alias AshNeo4j.Unknown
+
+  use ExUnit.Case, async: false
+
+  setup_all do
+    BoltyHelper.start()
+    # worlds/1 resolves against loaded modules; force the ones this asserts on.
+    Enum.each([Place], &Code.ensure_loaded!/1)
+    :ok
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  defp party_at(name, place) do
+    {:ok, ref} = PlaceRef |> Ash.Changeset.for_create(:create, %{role: "site", refers_to: place.id}) |> Ash.create()
+    {:ok, party} = Party |> Ash.Changeset.for_create(:create, %{name: name, via_place_ref: ref.id}) |> Ash.create()
+    party
+  end
+
+  defp projected_place(party) do
+    Party |> Ash.get!(party.id) |> Ash.load!(:projected_place) |> Map.get(:projected_place)
+  end
+
+  test "projects the reached Place as a concrete record" do
+    sydney = Ash.create!(Place, %{name: "Sydney", population: 5_300_000})
+    party = party_at("Sydney Co", sydney)
+
+    projected = projected_place(party)
+
+    assert %Place{name: "Sydney", population: 5_300_000} = projected
+  end
+
+  test "nil when nothing is reached" do
+    {:ok, floating} = Party |> Ash.Changeset.for_create(:create, %{name: "Floating Co"}) |> Ash.create()
+    assert projected_place(floating) == nil
+  end
+
+  test "AshNeo4j.Unknown when the reached node resolves to no loaded world" do
+    sydney = Ash.create!(Place, %{name: "Orphan Site"})
+    party = party_at("Orphan Co", sydney)
+
+    # Strip the domain label so the node still matches the (d:Place) hop but its
+    # label set no longer resolves to a world — a real reached-but-unresolvable node.
+    {:ok, _} = Neo4jHelper.update_node_labels(:Place, %{name: "Orphan Site"}, [], [:SRM])
+
+    projected = projected_place(party)
+
+    assert %Unknown{reason: :no_concrete_world, world: Party} = projected
+    assert Unknown.unknown?(projected)
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -208,6 +208,20 @@ record = Ash.get!(SomeBaseInstance, id)
 
 Resolution is dynamic against loaded modules (no registry): a candidate is a loaded `AshNeo4j.DataLayer` resource whose own labels are a subset of the node's; the outermost (most-nuanced) is kept per domain. Labels that don't resolve to a loaded module are left unknown (omitted). Returns `[]` for a record not produced by this data layer. **Pre-1.0 and may change** — shipped to learn its shape from real downstream use.
 
+### Read-time projection — `AshNeo4j.Calculations.ProjectedTraversal` (exploratory, #329)
+
+The read-time companion to `worlds/1`. Declare it to follow a hop `chain` to a reached node and return it as a value, late-binding the reached node's concrete type at read time — useful when the reached node's subtype isn't known at the source resource's compile time:
+
+```elixir
+calculate :site, :struct,
+  {AshNeo4j.Calculations.ProjectedTraversal,
+   chain: [{:forward, :place_ref}, {:forward, :place}]}
+```
+
+Per record it returns one of: the **concrete record** (labels resolved to a loaded world); **`%AshNeo4j.Unknown{}`** (a node was reached but its labels resolve to no loaded world — it can't be returned as a typed record); **`nil`** (nothing reached); or `%Ash.NotLoaded{}` (until loaded).
+
+`AshNeo4j.Unknown` is a first-class value, complementary to `Ash.NotLoaded`: `NotLoaded` means "not fetched **yet**" (ask again); `Unknown` means "reached, but **couldn't be determined** in the current view of the graph". Pattern-match it alongside `nil` and concrete values — never read `nil`-meaning-absent into it. Shape: `%AshNeo4j.Unknown{world: queried_resource, reason: atom_or_nested_unknown, context: map}`.
+
 ## Naming conventions
 
 AshNeo4j enforces Neo4j conventions at compile time:


### PR DESCRIPTION
Part of #329 — the **read-time polymorphic projection** slice (the monomorphic one-query pushdown projection is a separate follow).

Adds `AshNeo4j.Calculations.ProjectedTraversal` — follow a hop chain to a reached node and return it as a value, late-binding the reached node's concrete type at read time via `AshNeo4j.worlds/1`:

```elixir
calculate :site, :struct,
  {AshNeo4j.Calculations.ProjectedTraversal,
   chain: [{:forward, :place_ref}, {:forward, :place}]}
```

### Per-record result — the honest four

- **concrete record** — labels resolved to a loaded world
- **`%AshNeo4j.Unknown{reason: :no_concrete_world}`** — a node was reached but its labels resolve to no loaded world (the honest "couldn't determine" instead of a faked `nil`)
- **`nil`** — genuinely nothing reached
- **`%Ash.NotLoaded{}`** — until loaded

### Mechanism

Reuses the aggregate read path: one `related_nodes/4` query for the reached nodes (with labels), then `worlds/1` + `convert_node_to_resource` per node, or `AshNeo4j.Unknown` where `worlds/1` returns `[]`. v1 single-valued, projects the reached record.

### Also

- Expose `AshNeo4j.QueryHelper.resolve_chain/2` (chain → path segments).
- `AshNeo4j.DataLayer.project_traversal/3` orchestrator.
- **Test helper:** `Neo4jHelper.update_node_labels/4` (+ `Cypher.Query.update_node_labels/4`) — add/remove labels on a node created via Ash, to place it in (or strip it of) a resolvable world. It's a test/maintenance helper (the driver sets labels only at create), documented in the README testing section. This is what lets the `Unknown` case be tested **end-to-end**: create a Place, strip `:SRM`, and the node still matches `(d:Place)` but `worlds/1` can no longer resolve it.
- Docs: `AshNeo4j.Unknown` added to usage-rules (projection) and AGENTS.md (a "don't fabricate a definite" mistake).

3 live projection tests (concrete / `nil` / `Unknown`), full suite green (664), REUSE clean.
