### PR TITLE
chore: clear pre-existing test-suite compiler warnings

### DIFF
--- a/test/combination_test.exs
+++ b/test/combination_test.exs
@@ -11,7 +11,6 @@ defmodule AshNeo4j.CombinationTest do
   """
   use ExUnit.Case, async: true
 
-  require Ash.Query
   require Ash.Expr
   import Ash.Expr
 
@@ -169,7 +168,6 @@ defmodule AshNeo4j.CombinationCypher25Test do
   """
   use ExUnit.Case, async: false
 
-  require Ash.Query
   import Ash.Expr
 
   alias AshNeo4j.Cypher

--- a/test/functions/multi_line_string_test.exs
+++ b/test/functions/multi_line_string_test.exs
@@ -74,7 +74,7 @@ defmodule AshNeo4j.Functions.MultiLineStringTest do
     test "finds places whose routes intersect a search polygon via Ash.Query" do
       sydney = Place |> Ash.create!(%{name: "Sydney routes", routes: routes()})
 
-      _perth =
+      perth =
         Place
         |> Ash.create!(%{
           name: "Perth routes",
@@ -93,7 +93,7 @@ defmodule AshNeo4j.Functions.MultiLineStringTest do
 
       ids = Enum.map(results, & &1.id)
       assert sydney.id in ids
-      refute _perth.id in ids
+      refute perth.id in ids
     end
   end
 

--- a/test/functions/vector_functions_test.exs
+++ b/test/functions/vector_functions_test.exs
@@ -23,7 +23,7 @@ defmodule AshNeo4j.Functions.VectorFunctionsTest do
     test "identical → 1.0, orthogonal → 0.5, opposite → 0.0" do
       assert {:known, 1.0} = sim([1.0, 0.0, 0.0], [1.0, 0.0, 0.0])
       assert {:known, 0.5} = sim([1.0, 0.0, 0.0], [0.0, 1.0, 0.0])
-      assert {:known, 0.0} = sim([1.0, 0.0, 0.0], [-1.0, 0.0, 0.0])
+      assert {:known, +0.0} = sim([1.0, 0.0, 0.0], [-1.0, 0.0, 0.0])
     end
 
     test "is magnitude-invariant" do
@@ -39,7 +39,7 @@ defmodule AshNeo4j.Functions.VectorFunctionsTest do
 
   describe "VectorCosineDistance.evaluate/1 (pgvector-style, [0,2], lower = closer)" do
     test "identical → 0.0, orthogonal → 1.0, opposite → 2.0" do
-      assert {:known, 0.0} = dist([1.0, 0.0, 0.0], [1.0, 0.0, 0.0])
+      assert {:known, +0.0} = dist([1.0, 0.0, 0.0], [1.0, 0.0, 0.0])
       assert {:known, 1.0} = dist([1.0, 0.0, 0.0], [0.0, 1.0, 0.0])
       assert {:known, 2.0} = dist([1.0, 0.0, 0.0], [-1.0, 0.0, 0.0])
     end

--- a/test/geo_nil_clear_test.exs
+++ b/test/geo_nil_clear_test.exs
@@ -16,7 +16,6 @@ defmodule AshNeo4j.GeoNilClearTest do
   alias AshNeo4j.Cypher
   alias AshNeo4j.Sandbox
   alias AshNeo4j.Test.Resource.Place
-  require Ash.Query
 
   setup_all do
     BoltyHelper.start()

--- a/test/geo_type_change_test.exs
+++ b/test/geo_type_change_test.exs
@@ -19,7 +19,6 @@ defmodule AshNeo4j.GeoTypeChangeTest do
   alias AshNeo4j.Cypher
   alias AshNeo4j.Sandbox
   alias AshNeo4j.Test.Resource.Place
-  require Ash.Query
 
   setup_all do
     BoltyHelper.start()

--- a/test/state_machine_test.exs
+++ b/test/state_machine_test.exs
@@ -8,7 +8,6 @@ defmodule AshNeo4j.StateMachineTest do
   alias AshNeo4j.BoltyHelper
   alias AshNeo4j.Sandbox
   alias AshNeo4j.Test.Resource.StateMachine
-  require Ash.Query
 
   setup_all do
     BoltyHelper.start()


### PR DESCRIPTION
Chore — clears the pre-existing compiler warnings that scroll past on every suite run. No behaviour change.

- **Unused `require Ash.Query`** removed from `combination_test` (both modules), `state_machine_test`, `geo_nil_clear_test`, `geo_type_change_test`. These files use only `Ash.Query` *functions* (`combination_of`, `Combination.*`) and the `Ash.Expr` import — no `Ash.Query` macros — so the require was dead.
- **`_perth` → `perth`** in `multi_line_string_test` — the variable is used at the `refute`, so the leading underscore was wrong.
- **`+0.0` instead of `0.0`** in `vector_functions_test` patterns — silences "matching on `0.0` is equivalent to `+0.0`"; semantically identical for a function returning positive zero.

Full suite green (664), and **zero** compiler warnings on a forced test recompile.
