### PR TITLE
feat: type a traversal's reached node from a known dest label (#336)

### DIFF
--- a/lib/ash_neo4j.ex
+++ b/lib/ash_neo4j.ex
@@ -107,6 +107,27 @@ defmodule AshNeo4j do
     |> MapSet.new()
   end
 
+  @doc """
+  Resolves a node `label` (a resource's module label, e.g. `:Author`) to the
+  loaded `AshNeo4j.DataLayer` resource that owns it, or `nil` when there is no
+  unique match (none loaded, or the label is shared across resources).
+
+  Static `label -> resource`, the build-time counterpart to the read-time
+  `worlds/1` resolver — used to type a traversal's reached node from a known
+  dest label so reached-node access introspects the real mapping.
+  """
+  @spec resource_for_label(atom()) :: module() | nil
+  def resource_for_label(label) when is_atom(label) and not is_nil(label) do
+    case Enum.filter(ashneo4j_resources(), fn {_labels, resource} ->
+           ResourceInfo.module_label(resource) == label
+         end) do
+      [{_labels, resource}] -> resource
+      _ -> nil
+    end
+  end
+
+  def resource_for_label(_), do: nil
+
   # `{label_set, resource}` for every loaded resource using AshNeo4j.DataLayer.
   # Scanned fresh each call — no cache, no global state. worlds/1 is
   # consumer-invoked (never on the read path), so this isn't hot, and a fresh

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -412,8 +412,15 @@ defmodule AshNeo4j.QueryHelper do
     case ResourceInfo.node_relationship(resource, rel_name) do
       {_name, edge_label, edge_direction, dest_label} ->
         cypher_direction = if direction == :reverse, do: flip_direction(edge_direction), else: edge_direction
-        next = relationship_destination(resource, rel_name)
-        dest = if direction == :forward, do: dest_label, else: nil
+
+        # A `relate` edge is declared *out of* this resource, so `:reverse` of it
+        # has no well-defined reached type — the honest typed reverse is the
+        # explicit-edge form. Forward resolves to the relationship's destination.
+        {dest, next} =
+          if direction == :forward,
+            do: {dest_label, relationship_destination(resource, rel_name)},
+            else: {nil, nil}
+
         {{edge_label, cypher_direction, dest}, next}
 
       _ ->
@@ -421,9 +428,12 @@ defmodule AshNeo4j.QueryHelper do
     end
   end
 
-  # Explicit edge hop — `{:edge, label}` or `{:edge, label, dest_label}`.
+  # Explicit edge hop — `{:edge, label}` or `{:edge, label, dest_label}`. A given
+  # dest label resolves to its resource so the reached node is typed.
   defp resolve_hop(_resource, {direction, {:edge, label}}), do: {{label, hop_direction(direction), nil}, nil}
-  defp resolve_hop(_resource, {direction, {:edge, label, dest}}), do: {{label, hop_direction(direction), dest}, nil}
+
+  defp resolve_hop(_resource, {direction, {:edge, label, dest}}),
+    do: {{label, hop_direction(direction), dest}, AshNeo4j.resource_for_label(dest)}
 
   defp relationship_destination(resource, rel_name) do
     case Ash.Resource.Info.relationship(resource, rel_name) do

--- a/test/support/resource/author.ex
+++ b/test/support/resource/author.ex
@@ -29,6 +29,10 @@ defmodule AshNeo4j.Test.Resource.Author do
   attributes do
     uuid_primary_key :id
     attribute :name, :string, public?: true
+    # #336 — a custom-sourced attribute whose property name (`writerAlias`) is
+    # NOT camelCase(:pen_name) (`penName`), so reverse-terminal typing tests can
+    # prove the reached node uses the real mapping, not a camelCase guess.
+    attribute :pen_name, :string, public?: true, source: :writerAlias
     attribute :post_id, :uuid
   end
 

--- a/test/traverse_live_test.exs
+++ b/test/traverse_live_test.exs
@@ -79,4 +79,25 @@ defmodule AshNeo4j.TraverseLiveTest do
 
     assert titles == ["by-alice"]
   end
+
+  test "reverse-terminal field access is typed through the real mapping, not a camelCase guess (#336)" do
+    # Author.pen_name is sourced to the property `writerAlias` (not `penName`),
+    # so this only matches if the reverse-reached node resolves to Author and
+    # uses its mapping. The old camelCase fallback queried `penName` — and the
+    # earlier `:name` reverse test passed only because `:name -> "name"` by luck.
+    ghost = Ash.create!(Author, %{name: "G. Writer", pen_name: "Ghost"})
+    public = Ash.create!(Author, %{name: "P. Writer", pen_name: "Public"})
+    {:ok, _} = Post |> Ash.Changeset.for_create(:create, %{title: "ghosted", written_by: ghost.id}) |> Ash.create()
+    {:ok, _} = Post |> Ash.Changeset.for_create(:create, %{title: "open", written_by: public.id}) |> Ash.create()
+
+    chain = [{:reverse, {:edge, :WROTE, :Author}}]
+
+    titles =
+      Post
+      |> Ash.Query.filter(traverse(^chain, :pen_name) == "Ghost")
+      |> Ash.read!()
+      |> Enum.map(& &1.title)
+
+    assert titles == ["ghosted"]
+  end
 end


### PR DESCRIPTION
Closes #336.

Types a traversal's **reached node from a known dest label** so reached-node access introspects the *real* mapping instead of guessing.

### The fix
- New `AshNeo4j.resource_for_label/1` — a static `module_label -> resource` lookup (reusing the loaded-module scan `worlds/1` uses); the **build-time** counterpart to the read-time `worlds/1` resolver.
- `resolve_hop/2`: an **explicit-edge** hop carrying a dest label (`{:reverse, {:edge, :WROTE, :Author}}`) now yields a typed reached resource. So `traverse(^chain, :field)`, spatial, aggregate, and projection all introspect the reached resource's mapping.

### The latent bug it fixes
The shipped reverse explicit-edge test passed **only by luck** — `Author` translates `:name -> "name"`, so the camelCase fallback happened to be right. A reached field whose property name differs from camelCase silently queried the *wrong* property. New test proves the fix with a custom-sourced `Author.pen_name -> "writerAlias"` (camelCase would be `"penName"`): it matches only because the reached node resolves to `Author` and uses its mapping.

### Premise refinement (vs the ticket)
The ticket asked to "reverse the `relate` lookup" for a reverse *relationship-name* hop. But a `relate` edge is declared *out of* its resource, so `:reverse` of it is contradictory — it reaches "things pointing at me", which the model doesn't type. `resolve_hop` now returns honest `nil` there (it was wrongly reporting the *forward* destination). The **typed reverse is the explicit-edge form**, and the genuinely useful polymorphic reverse (a `Place` reached by `Party`/`Place`/`Instance`) can't be typed at build time anyway — it's already served by the **read-time projection (#344, `worlds/1`)**. (`nil` becomes `Unknown` once #342 lands.)

Native 1.20 checker + Dialyzer clean, full suite green (665).
