### PR TITLE
feat: thread GeoDimensionMismatch as a returned {:error}, never raise (#350)

### DIFF
--- a/lib/error.ex
+++ b/lib/error.ex
@@ -12,26 +12,23 @@ end
 
 defmodule AshNeo4j.Error.GeoDimensionMismatch do
   @moduledoc """
-  Raised when a spatial operation combines geometries of different coordinate
-  dimensions (2D vs 3D) — e.g. a 3D `%Geo.PointZ{}` against a 2D attribute, or
-  vice versa. Neo4j silently returns `null` for mixed-CRS operations (which then
-  drops rows in a `WHERE`), so AshNeo4j refuses up front (#270).
+  Returned (never raised) when a spatial operation combines geometries of
+  different coordinate dimensions (2D vs 3D) — e.g. a 3D `%Geo.PointZ{}` against
+  a 2D attribute, or vice versa. Neo4j silently returns `null` for mixed-CRS
+  operations (which then drops rows in a `WHERE`), so AshNeo4j refuses up front
+  (#270) by returning `{:error, error}`.
 
   Bridge worlds explicitly with a downward projection
   (`AshNeo4j.Geo.force_2d/1`) — collapse the 3D operand to its 2D footprint
   and evaluate in 2D. There is no implicit 2D→3D lift (a height cannot be
   fabricated).
   """
-  defexception [:message]
+  use Splode.Error, fields: [:attr_dim, :value_dim], class: :invalid
 
-  @impl true
-  def exception({attr_dim, value_dim}) do
-    %__MODULE__{
-      message:
-        "spatial dimension mismatch: a #{value_dim}D value against a #{attr_dim}D attribute. " <>
-          "Project the 3D operand to 2D with AshNeo4j.Geo.force_2d/1 to evaluate in the 2D world, " <>
-          "or use genuinely matching dimensions."
-    }
+  def message(%{attr_dim: attr_dim, value_dim: value_dim}) do
+    "spatial dimension mismatch: a #{value_dim}D value against a #{attr_dim}D attribute. " <>
+      "Project the 3D operand to 2D with AshNeo4j.Geo.force_2d/1 to evaluate in the 2D world, " <>
+      "or use genuinely matching dimensions."
   end
 end
 

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -67,16 +67,18 @@ defmodule AshNeo4j.QueryHelper do
         build_branch_query(branch_dl_query, mapping, "b#{idx}_", :nodes)
       end)
 
-    {terms, sort_params} = sort_terms(ash_query, mapping)
+    with nil <- Enum.find(branch_queries, &match?({:error, _}, &1)) do
+      {terms, sort_params} = sort_terms(ash_query, mapping)
 
-    query =
-      branch_queries
-      |> Query.combination_block(union_type: union_type)
-      |> Query.merge_params(sort_params)
-      |> Query.paginate_nodes(terms, ash_query.offset, ash_query.limit)
-      |> Query.add_order_by(terms)
+      query =
+        branch_queries
+        |> Query.combination_block(union_type: union_type)
+        |> Query.merge_params(sort_params)
+        |> Query.paginate_nodes(terms, ash_query.offset, ash_query.limit)
+        |> Query.add_order_by(terms)
 
-    run_cypher_query(query)
+      run_cypher_query(query)
+    end
   end
 
   defp run_in_memory_combination(ash_query, mapping, branch_dl_queries, all_types) do
@@ -84,14 +86,9 @@ defmodule AshNeo4j.QueryHelper do
       branch_dl_queries
       |> Enum.with_index()
       |> Enum.map(fn {branch_dl_query, idx} ->
-        query = build_branch_query(branch_dl_query, mapping, "b#{idx}_", :ids)
-
-        case Cypher.run(query) do
-          {:ok, %Bolty.Response{results: results}} ->
-            {:ok, MapSet.new(results, &Map.get(&1, "sid"))}
-
-          {:error, _} = err ->
-            err
+        with %Query{} = query <- build_branch_query(branch_dl_query, mapping, "b#{idx}_", :ids),
+             {:ok, %Bolty.Response{results: results}} <- Cypher.run(query) do
+          {:ok, MapSet.new(results, &Map.get(&1, "sid"))}
         end
       end)
 
@@ -174,17 +171,20 @@ defmodule AshNeo4j.QueryHelper do
 
   defp classify_combination(_), do: {:error, "AshNeo4j: combination_of must start with :base"}
 
-  # builder: :nodes | :ids — which branch_node_read variant to use
+  # builder: :nodes | :ids — which branch_node_read variant to use.
+  # Returns the branch Cypher.Query, or `{:error, _}` if a branch predicate
+  # can't be formed (threaded up by the combination runners).
   defp build_branch_query(branch_dl_query, %ResourceMapping{} = mapping, param_prefix, builder) do
-    conditions = extract_branch_conditions(branch_dl_query, mapping)
-    build = if builder == :ids, do: &Query.branch_node_read_ids/3, else: &Query.branch_node_read/3
-    build.(mapping.label_pair, conditions, param_prefix: param_prefix)
+    with {:ok, conditions} <- extract_branch_conditions(branch_dl_query, mapping) do
+      build = if builder == :ids, do: &Query.branch_node_read_ids/3, else: &Query.branch_node_read/3
+      build.(mapping.label_pair, conditions, param_prefix: param_prefix)
+    end
   end
 
   defp extract_branch_conditions(branch_dl_query, %ResourceMapping{} = mapping) do
     case branch_dl_query.filter do
       nil ->
-        []
+        {:ok, []}
 
       filter ->
         simple_filter = Ash.Filter.to_simple_filter(filter, skip_invalid?: true)
@@ -317,7 +317,9 @@ defmodule AshNeo4j.QueryHelper do
        })
        when is_number(threshold) do
     spatial_traversal(mapping, chain, fn reached ->
-      {point_property(reached, field), :st_dwithin, {to_geo_param!(reached, field, test_point), threshold}, false}
+      geo_condition(reached, field, test_point, fn param ->
+        {point_property(reached, field), :st_dwithin, {param, threshold}, false}
+      end)
     end)
   end
 
@@ -328,7 +330,9 @@ defmodule AshNeo4j.QueryHelper do
        })
        when distance in [AshNeo4j.Functions.StDistance, AshNeo4j.Functions.StDistanceInMeters] and is_number(threshold) do
     spatial_traversal(mapping, chain, fn reached ->
-      {point_property(reached, field), :st_distance, {operator, to_geo_param!(reached, field, test_point), threshold}, false}
+      geo_condition(reached, field, test_point, fn param ->
+        {point_property(reached, field), :st_distance, {operator, param, threshold}, false}
+      end)
     end)
   end
 
@@ -358,6 +362,7 @@ defmodule AshNeo4j.QueryHelper do
     else
       case condition_fn.(ResourceInfo.mapping(reached)) do
         nil -> unresolvable(mapping, :unmapped_property, %{reached: reached})
+        {:error, _} = error -> error
         condition -> traversal_query(mapping, segments, [condition])
       end
     end
@@ -482,8 +487,9 @@ defmodule AshNeo4j.QueryHelper do
 
     cond do
       Enum.empty?(relationship_predicates) ->
-        conditions = to_conditions(mapping, property_predicates)
-        Query.node_read_filtered(mapping.label_pair, conditions)
+        with {:ok, conditions} <- to_conditions(mapping, property_predicates) do
+          Query.node_read_filtered(mapping.label_pair, conditions)
+        end
 
       length(relationship_predicates) == 1 ->
         predicate = hd(relationship_predicates)
@@ -524,15 +530,17 @@ defmodule AshNeo4j.QueryHelper do
       %{operator: op, left: %AshNeo4j.Functions.StDistance{arguments: [ref, test_point]}, right: threshold}
       when op in [:<, :<=, :>, :>=, :==, :!=] and is_number(threshold) ->
         if point_attribute?(mapping, ref) do
-          prop = point_property(mapping, ref)
-          {prop, :st_distance, {op, to_geo_param!(mapping, ref, test_point), threshold}, false}
+          geo_condition(mapping, ref, test_point, fn param ->
+            {point_property(mapping, ref), :st_distance, {op, param, threshold}, false}
+          end)
         end
 
       %{operator: op, left: %AshNeo4j.Functions.StDistanceInMeters{arguments: [ref, test_point]}, right: threshold}
       when op in [:<, :<=, :>, :>=, :==, :!=] and is_number(threshold) ->
         if point_attribute?(mapping, ref) do
-          prop = point_property(mapping, ref)
-          {prop, :st_distance, {op, to_geo_param!(mapping, ref, test_point), threshold}, false}
+          geo_condition(mapping, ref, test_point, fn param ->
+            {point_property(mapping, ref), :st_distance, {op, param, threshold}, false}
+          end)
         end
 
       %{operator: op, left: left} = predicate when is_struct(left, Ash.Query.Ref) or is_atom(left) ->
@@ -567,8 +575,9 @@ defmodule AshNeo4j.QueryHelper do
 
       %{name: :st_dwithin, arguments: [ref, test_point, threshold]} when is_number(threshold) ->
         if point_attribute?(mapping, ref) do
-          prop = point_property(mapping, ref)
-          {prop, :st_dwithin, {to_geo_param!(mapping, ref, test_point), threshold}, false}
+          geo_condition(mapping, ref, test_point, fn param ->
+            {point_property(mapping, ref), :st_dwithin, {param, threshold}, false}
+          end)
         end
 
       %{operator: op, left: %AshNeo4j.Functions.VectorSimilarity{arguments: [ref, query_vec]}, right: threshold}
@@ -587,7 +596,26 @@ defmodule AshNeo4j.QueryHelper do
         Logger.debug("AshNeo4j.QueryHelper: predicate #{inspect(predicate)} not handled")
         nil
     end)
-    |> Enum.reject(&is_nil/1)
+    |> finalize_conditions()
+  end
+
+  # The condition list, or the first `{:error, _}` a builder produced (e.g. a
+  # geo dimension mismatch) — so the data layer returns it rather than running a
+  # query missing that predicate (#350).
+  defp finalize_conditions(mapped) do
+    case Enum.find(mapped, &match?({:error, _}, &1)) do
+      {:error, _} = error -> error
+      nil -> {:ok, Enum.reject(mapped, &is_nil/1)}
+    end
+  end
+
+  # Builds a spatial condition from a dimension-checked geo param, or returns the
+  # `{:error, %GeoDimensionMismatch{}}` to thread up.
+  defp geo_condition(mapping, ref, value, builder) do
+    case to_geo_param(mapping, ref, value) do
+      {:error, _} = error -> error
+      {:ok, param} -> builder.(param)
+    end
   end
 
   # True when the referenced attribute is a Point-shaped Geo attribute —
@@ -605,19 +633,19 @@ defmodule AshNeo4j.QueryHelper do
   # silently drops rows) for a 2D/3D mix, so a mismatch raises
   # `AshNeo4j.Error.GeoDimensionMismatch` here instead (#270). Bridge worlds
   # explicitly with `AshNeo4j.Geo.force_2d/1`.
-  defp to_geo_param!(mapping, ref, value) do
+  defp to_geo_param(mapping, ref, value) do
     types = geo_types_of(mapping, ref)
     vd = value_dim(value)
 
     cond do
       vd == 3 and :point in types and :point_z not in types ->
-        raise AshNeo4j.Error.GeoDimensionMismatch, {2, 3}
+        {:error, AshNeo4j.Error.GeoDimensionMismatch.exception(attr_dim: 2, value_dim: 3)}
 
       vd == 2 and :point_z in types and :point not in types ->
-        raise AshNeo4j.Error.GeoDimensionMismatch, {3, 2}
+        {:error, AshNeo4j.Error.GeoDimensionMismatch.exception(attr_dim: 3, value_dim: 2)}
 
       true ->
-        to_param_value(value)
+        {:ok, to_param_value(value)}
     end
   end
 

--- a/test/wgs84_3d_test.exs
+++ b/test/wgs84_3d_test.exs
@@ -41,6 +41,13 @@ defmodule AshNeo4j.Wgs84_3DTest do
     e -> assert Exception.message(e) =~ expected
   end
 
+  # The data layer returns (never raises) a Splode error for an unformable
+  # query (#350) — assert the returned error's message.
+  defp assert_error_message(expected, fun) do
+    assert {:error, error} = fun.()
+    assert Exception.message(error) =~ expected
+  end
+
   describe "GeoJson dimension-aware srid" do
     test "decodes a 3D Point with srid 4979" do
       json = AshNeo4j.GeoJson.encode!(pz(151.0, -33.0, 50.0))
@@ -107,14 +114,14 @@ defmodule AshNeo4j.Wgs84_3DTest do
   end
 
   describe "strict dimension policy (#270)" do
-    test "3D value against a 2D attribute raises GeoDimensionMismatch" do
-      assert_message "dimension mismatch: a 3D value against a 2D attribute", fn ->
+    test "3D value against a 2D attribute returns a GeoDimensionMismatch error" do
+      assert_error_message "dimension mismatch: a 3D value against a 2D attribute", fn ->
         Place |> Ash.Query.filter(st_distance(location, ^pz(151.0, -33.0, 5.0)) < 1000) |> Ash.read()
       end
     end
 
-    test "2D value against a 3D attribute raises GeoDimensionMismatch" do
-      assert_message "dimension mismatch: a 2D value against a 3D attribute", fn ->
+    test "2D value against a 3D attribute returns a GeoDimensionMismatch error" do
+      assert_error_message "dimension mismatch: a 2D value against a 3D attribute", fn ->
         Place |> Ash.Query.filter(st_distance(tower, ^p2(151.0, -33.0)) < 1000) |> Ash.read()
       end
     end


### PR DESCRIPTION
First of #350's three per-error-type conversions: **`GeoDimensionMismatch`** now **returns** `{:error, error}` instead of raising mid-build — the Ash data-layer idiom (per the AGENTS guardrail, #351).

### What changed
- `GeoDimensionMismatch` → a **Splode error** (`use Splode.Error`, class `:invalid`).
- `to_geo_param!/3` (raised) → **`to_geo_param/3`** returning `{:ok, param} | {:error, _}`, routed through a `geo_condition/4` helper at all **five** call sites (direct + traverse spatial).
- Threaded through **both** read paths:
  - **simple:** `to_conditions` → `{:ok, conditions} | {:error}` (via `finalize_conditions/1`); `build_relationship_or_property_query` uses `with {:ok, …} <-`, and `run_simple_query` already passes `{:error}` straight through (from #352).
  - **combination:** `extract_branch_conditions` / `build_branch_query` return `{:error}`; `run_native_combination` and `run_in_memory_combination` propagate a branch error instead of assembling/running a query that silently drops the predicate.

### Tests
The two `wgs84_3d` strict-dimension tests flip from assert-raise to asserting the returned error message (new `assert_error_message/2`). The still-raising `Unsupported3DGeometry` test keeps `assert_message` — it's converted in the next PR.

Combination *happy-path* unwrap is covered by the existing `combination_test`; the branch-error propagation is the idiomatic `with`/`Enum.find` threading shown above.

### #350 progress
1. ✅ **`GeoDimensionMismatch`** (this).
2. ⏭ `Unsupported3DGeometry` (write/dump path).
3. ⏭ `RequiresCypher25` (vector predicates + index lifecycle).

Native 1.20 checker + Dialyzer clean, full suite green (667). Two commits: the Splode error, then the threading.
