### PR TITLE
feat: reject 3D-areal writes with a returned {:error}, never raise (#350)

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -305,10 +305,12 @@ defmodule AshNeo4j.DataLayer do
     id_attributes = Map.take(changeset.attributes, primary_keys)
 
     result =
-      if Enum.empty?(id_attributes) do
-        {:error, "no values supplied for primary keys #{primary_keys}"}
-      else
-        create_from_attributes(mapping, changeset.attributes)
+      with :ok <- validate_writable_geo(mapping, changeset.attributes) do
+        if Enum.empty?(id_attributes) do
+          {:error, "no values supplied for primary keys #{primary_keys}"}
+        else
+          create_from_attributes(mapping, changeset.attributes)
+        end
       end
 
     Logger.debug("""
@@ -379,6 +381,13 @@ defmodule AshNeo4j.DataLayer do
     """)
 
     mapping = ResourceInfo.mapping(resource)
+
+    with :ok <- validate_writable_geo(mapping, changeset.attributes) do
+      do_update(resource, changeset, mapping)
+    end
+  end
+
+  defp do_update(resource, changeset, %ResourceMapping{} = mapping) do
     subject_id = id_properties(mapping, changeset.data)
     subject_label = mapping.label_pair
 
@@ -1138,6 +1147,30 @@ defmodule AshNeo4j.DataLayer do
     end
   end
 
+  # Rejects a write up front (#350) when an attribute carries a 3D areal/linear
+  # geometry (PolygonZ, LineStringZ, …) — #270 supports 3D points only, and a 2D
+  # bbox companion would silently drop the z. Walks top-level and nested geo via
+  # `geo_walk`; returns `:ok` or `{:error, %Unsupported3DGeometry{}}`.
+  defp validate_writable_geo(%ResourceMapping{} = mapping, attributes) when is_map(attributes) do
+    Enum.find_value(mapping.properties, :ok, fn {key, translated_key} ->
+      case Map.get(attributes, key) do
+        nil ->
+          nil
+
+        value ->
+          value
+          |> geo_walk([translated_key])
+          |> Enum.find_value(fn {_path, geo} -> unsupported_3d_geometry(geo) end)
+      end
+    end)
+  end
+
+  defp unsupported_3d_geometry(%struct{} = geo) do
+    if struct != Geo.PointZ and geo_dim(geo) == 3 do
+      {:error, AshNeo4j.Error.Unsupported3DGeometry.exception(geometry: struct)}
+    end
+  end
+
   defp dump_properties(%ResourceMapping{} = mapping, attributes) when is_map(attributes) do
     mapping.properties
     |> Enum.reduce(%{}, fn {key, translated_key}, acc ->
@@ -1226,7 +1259,11 @@ defmodule AshNeo4j.DataLayer do
       # #270 Phase 2 — silently storing 2D bbox companions would drop the z and
       # mislead spatial queries, so refuse explicitly rather than degrade.
       AshGeo.is_geo(geo.__struct__) and geo_dim(geo) == 3 ->
-        raise AshNeo4j.Error.Unsupported3DGeometry, geo
+        # validate_writable_geo rejects these before write (#350), so this is
+        # unreachable in practice — skip the (unrepresentable in 2D) indexable
+        # sidecar rather than raise or drop the z via a bbox. The full geometry
+        # is still preserved in the `.json` canonical written by promote_geo/3.
+        acc
 
       AshGeo.is_geo(geo.__struct__) ->
         [west, south, east, north] = AshNeo4j.GeoJson.bbox(geo)

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -34,21 +34,17 @@ end
 
 defmodule AshNeo4j.Error.Unsupported3DGeometry do
   @moduledoc """
-  Raised when a 3D areal or linear geometry (`%Geo.PolygonZ{}`,
+  Returned (never raised) when a 3D areal or linear geometry (`%Geo.PolygonZ{}`,
   `%Geo.LineStringZ{}`, …) is written. #270 Phase 1 supports 3D **points**
   (`%Geo.PointZ{}`) only; 3D areal/linear geometries are deferred to Phase 2,
   because exact 3D containment/distance needs a model the 2D `topo` refinement
   cannot provide. Storing 2D bbox companions would silently drop the z.
   """
-  defexception [:message]
+  use Splode.Error, fields: [:geometry], class: :invalid
 
-  @impl true
-  def exception(%mod{}) do
-    %__MODULE__{
-      message:
-        "#{inspect(mod)} (3D areal/linear geometry) is not supported yet — #270 Phase 1 covers " <>
-          "Geo.PointZ only. Use a 2D geometry, or project to 2D, until 3D areal support lands."
-    }
+  def message(%{geometry: geometry}) do
+    "#{inspect(geometry)} (3D areal/linear geometry) is not supported yet — #270 Phase 1 covers " <>
+      "Geo.PointZ only. Use a 2D geometry, or project to 2D, until 3D areal support lands."
   end
 end
 

--- a/test/wgs84_3d_test.exs
+++ b/test/wgs84_3d_test.exs
@@ -32,17 +32,9 @@ defmodule AshNeo4j.Wgs84_3DTest do
   defp pz(lng, lat, h), do: %Geo.PointZ{coordinates: {lng, lat, h}, srid: 4979}
   defp p2(lng, lat), do: %Geo.Point{coordinates: {lng, lat}, srid: 4326}
 
-  # The data layer raises during query-build / dump; Ash wraps it (Ash.Error.*),
-  # but the original message is preserved — assert on that.
-  defp assert_message(expected, fun) do
-    fun.()
-    flunk("expected an exception, got none")
-  rescue
-    e -> assert Exception.message(e) =~ expected
-  end
-
-  # The data layer returns (never raises) a Splode error for an unformable
-  # query (#350) — assert the returned error's message.
+  # The data layer returns (never raises) a Splode error for an unformable query
+  # or unsupported write (#350); Ash wraps it but preserves the message — assert
+  # on the returned error.
   defp assert_error_message(expected, fun) do
     assert {:error, error} = fun.()
     assert Exception.message(error) =~ expected
@@ -143,14 +135,14 @@ defmodule AshNeo4j.Wgs84_3DTest do
   end
 
   describe "3D areal/linear deferred to Phase 2" do
-    test "storing a PolygonZ raises Unsupported3DGeometry" do
+    test "storing a PolygonZ returns an Unsupported3DGeometry error" do
       polyz = %Geo.PolygonZ{
         coordinates: [[{151.0, -34.0, 0.0}, {151.5, -34.0, 0.0}, {151.5, -33.0, 0.0}, {151.0, -34.0, 0.0}]],
         srid: 4979
       }
 
-      assert_message "3D areal/linear geometry) is not supported yet", fn ->
-        Place |> Ash.create!(%{name: "bad", shape: polyz})
+      assert_error_message "3D areal/linear geometry) is not supported yet", fn ->
+        Place |> Ash.create(%{name: "bad", shape: polyz})
       end
     end
   end


### PR DESCRIPTION
Second of #350's three: **`Unsupported3DGeometry`** now **returns** `{:error, error}` instead of raising deep in the property dump.

### Approach: the gate (B), agreed for this path
Threading `dump_properties` through `update`'s ~200-line body wasn't worth it for one rare write guard (only one line in `update` touches geo; the rest is relationship plumbing). So:
- `Unsupported3DGeometry` → a **Splode error** (`use Splode.Error`, class `:invalid`).
- **`validate_writable_geo/2`** runs up front in `create` and `update`, walking top-level *and* nested geo via the existing `geo_walk`, returning `:ok | {:error}`. **No contract change** to `dump_properties` or its three callers.
- `update` gets the gate via a thin `with :ok <- validate_writable_geo(...)` + a `do_update/3` **extract** — its body moves verbatim, unchanged.
- `upsert` is covered transitively (delegates to `create`/`update`).
- `promote_geo_indexable`'s 3D branch drops its `raise` → a **defensive no-op** (skip the 2D-unrepresentable sidecar; the `.json` canonical still preserves the full geometry), unreachable now that the gate rejects these before write.

### Tests
The `PolygonZ` test flips from assert-raise (`Ash.create!`) to asserting the returned error (`Ash.create` + `assert_error_message`); removed the now-dead `assert_message` helper.

> If we end up refactoring `update` for other reasons, the single-source-of-truth thread (A) is the natural follow — noted in the discussion.

### #350 progress
1. ✅ `GeoDimensionMismatch` (PR #353, merged)
2. ✅ **`Unsupported3DGeometry`** (this)
3. ⏭ `RequiresCypher25` (vector predicates + index lifecycle)

Native 1.20 checker + Dialyzer clean, full suite green (667). Two commits: the Splode error, then the gate.
