### PR TITLE
feat: RequiresCypher25 as a returned {:error}, never raise — closes #350

### DIFF
--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -411,13 +411,17 @@ defmodule AshNeo4j.Cypher do
   end
 
   @doc """
-  Raises `AshNeo4j.Error.RequiresCypher25` when the connected server does not
-  support Cypher 25 (negotiated server version < 2025.06). Call at the top of
-  any function that emits Cypher 25-only syntax.
+  `:ok` when the connected server supports Cypher 25 (negotiated server version
+  ≥ 2025.06), else `{:error, %AshNeo4j.Error.RequiresCypher25{}}`. Use at the top
+  of any function that emits Cypher 25-only syntax and thread the error up — a
+  data layer returns it, never raises.
   """
-  def require_cypher25!() do
-    unless BoltyHelper.cypher25?() do
-      raise AshNeo4j.Error.RequiresCypher25
+  @spec require_cypher25() :: :ok | {:error, struct()}
+  def require_cypher25() do
+    if BoltyHelper.cypher25?() do
+      :ok
+    else
+      {:error, AshNeo4j.Error.RequiresCypher25.exception([])}
     end
   end
 

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -4,10 +4,12 @@
 
 defmodule AshNeo4j.Error.RequiresCypher25 do
   @moduledoc """
-  Raised when a Cypher 25 operation is attempted against a Neo4j server older
-  than 2025.06. Upgrade to Neo4j 2025.06 or later to use this feature.
+  Returned (never raised) when a Cypher 25 operation is attempted against a Neo4j
+  server older than 2025.06. Upgrade to Neo4j 2025.06 or later to use this feature.
   """
-  defexception message: "This operation requires Cypher 25 (Neo4j ≥ 2025.06)"
+  use Splode.Error, fields: [], class: :invalid
+
+  def message(_), do: "This operation requires Cypher 25 (Neo4j ≥ 2025.06)"
 end
 
 defmodule AshNeo4j.Error.GeoDimensionMismatch do

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -31,9 +31,8 @@ defmodule AshNeo4j.QueryHelper do
     # A predicate we couldn't form (e.g. an unresolvable traverse, #342) is an
     # `{:error, _}` that doesn't match `%Query{}` — `with` passes it straight
     # through rather than running a fabricated query.
-    with %Query{} = base <- build_query(ash_query, mapping) do
-      {terms, sort_params} = sort_terms(ash_query, mapping)
-
+    with %Query{} = base <- build_query(ash_query, mapping),
+         {:ok, {terms, sort_params}} <- sort_terms(ash_query, mapping) do
       query =
         base
         |> Query.merge_params(sort_params)
@@ -67,9 +66,8 @@ defmodule AshNeo4j.QueryHelper do
         build_branch_query(branch_dl_query, mapping, "b#{idx}_", :nodes)
       end)
 
-    with nil <- Enum.find(branch_queries, &match?({:error, _}, &1)) do
-      {terms, sort_params} = sort_terms(ash_query, mapping)
-
+    with nil <- Enum.find(branch_queries, &match?({:error, _}, &1)),
+         {:ok, {terms, sort_params}} <- sort_terms(ash_query, mapping) do
       query =
         branch_queries
         |> Query.combination_block(union_type: union_type)
@@ -102,16 +100,16 @@ defmodule AshNeo4j.QueryHelper do
         if keep_ids == [] do
           {:ok, []}
         else
-          {terms, sort_params} = sort_terms(ash_query, mapping)
+          with {:ok, {terms, sort_params}} <- sort_terms(ash_query, mapping) do
+            final =
+              mapping.label_pair
+              |> Query.node_read_by_ids(keep_ids)
+              |> Query.merge_params(sort_params)
+              |> Query.paginate_nodes(terms, ash_query.offset, ash_query.limit)
+              |> Query.add_order_by(terms)
 
-          final =
-            mapping.label_pair
-            |> Query.node_read_by_ids(keep_ids)
-            |> Query.merge_params(sort_params)
-            |> Query.paginate_nodes(terms, ash_query.offset, ash_query.limit)
-            |> Query.add_order_by(terms)
-
-          run_cypher_query(final)
+            run_cypher_query(final)
+          end
         end
 
       {:error, reason} ->
@@ -582,15 +580,15 @@ defmodule AshNeo4j.QueryHelper do
 
       %{operator: op, left: %AshNeo4j.Functions.VectorSimilarity{arguments: [ref, query_vec]}, right: threshold}
       when op in [:<, :<=, :>, :>=, :==, :!=] and is_number(threshold) ->
-        AshNeo4j.Cypher.require_cypher25!()
-        prop = property_name(mapping, ref)
-        {prop, :vector_similarity, {op, to_vector_param(query_vec), threshold}, false}
+        with :ok <- AshNeo4j.Cypher.require_cypher25() do
+          {property_name(mapping, ref), :vector_similarity, {op, to_vector_param(query_vec), threshold}, false}
+        end
 
       %{operator: op, left: %AshNeo4j.Functions.VectorCosineDistance{arguments: [ref, query_vec]}, right: threshold}
       when op in [:<, :<=, :>, :>=, :==, :!=] and is_number(threshold) ->
-        AshNeo4j.Cypher.require_cypher25!()
-        prop = property_name(mapping, ref)
-        {prop, :vector_cosine_distance, {op, to_vector_param(query_vec), threshold}, false}
+        with :ok <- AshNeo4j.Cypher.require_cypher25() do
+          {property_name(mapping, ref), :vector_cosine_distance, {op, to_vector_param(query_vec), threshold}, false}
+        end
 
       predicate ->
         Logger.debug("AshNeo4j.QueryHelper: predicate #{inspect(predicate)} not handled")
@@ -726,15 +724,16 @@ defmodule AshNeo4j.QueryHelper do
   defp sort_terms(ash_query, %ResourceMapping{} = mapping) do
     case ash_query.sort do
       sort when sort in [nil, []] ->
-        {[], %{}}
+        {:ok, {[], %{}}}
 
       sort ->
         sort
         |> Enum.with_index()
-        |> Enum.reduce({[], %{}}, fn {{name, order}, index}, {terms, params} ->
+        |> Enum.reduce_while({:ok, {[], %{}}}, fn {{name, order}, index}, {:ok, {terms, params}} ->
           case sort_term(mapping, name, order, index) do
-            nil -> {terms, params}
-            {term, term_params} -> {terms ++ [term], Map.merge(params, term_params)}
+            nil -> {:cont, {:ok, {terms, params}}}
+            {:error, _} = error -> {:halt, error}
+            {term, term_params} -> {:cont, {:ok, {terms ++ [term], Map.merge(params, term_params)}}}
           end
         end)
     end
@@ -745,11 +744,12 @@ defmodule AshNeo4j.QueryHelper do
   defp sort_term(mapping, %Ash.Query.Calculation{module: Ash.Resource.Calculation.Expression, opts: opts}, order, index) do
     case Keyword.get(opts, :expr) do
       %Ash.Query.Call{name: fname, args: [ref, query_vec]} when fname in [:vector_similarity, :vector_cosine_distance] ->
-        AshNeo4j.Cypher.require_cypher25!()
-        prop = property_name(mapping, ref)
-        key = "sort_#{Cypher.sanitize_param(prop)}_#{index}_vec"
-        expr = Cypher.vector_scalar(fname, :s, prop, "$#{key}")
-        {{expr, order}, %{key => to_vector_param(query_vec)}}
+        with :ok <- AshNeo4j.Cypher.require_cypher25() do
+          prop = property_name(mapping, ref)
+          key = "sort_#{Cypher.sanitize_param(prop)}_#{index}_vec"
+          expr = Cypher.vector_scalar(fname, :s, prop, "$#{key}")
+          {{expr, order}, %{key => to_vector_param(query_vec)}}
+        end
 
       _ ->
         nil

--- a/lib/type/vector.ex
+++ b/lib/type/vector.ex
@@ -16,7 +16,7 @@ defmodule AshNeo4j.Type.Vector do
   > #### Cypher 25 required {: .warning}
   > Vector operations require Cypher 25 (Neo4j ≥ 2025.06) — not Bolt 6.0. With
   > list storage and list query params, similarity search works over Bolt 5.8.
-  > This is an AshNeo4j-level requirement — see `AshNeo4j.Cypher.require_cypher25!/0`.
+  > This is an AshNeo4j-level requirement — see `AshNeo4j.Cypher.require_cypher25/0`.
 
   ## Constraints
 

--- a/lib/vector.ex
+++ b/lib/vector.ex
@@ -8,7 +8,7 @@ defmodule AshNeo4j.Vector do
   `AshNeo4j.Type.Vector` attributes.
 
   Requires Cypher 25 (Neo4j ≥ 2025.06). Operations against an older server
-  raise `AshNeo4j.Error.RequiresCypher25`.
+  return `{:error, %AshNeo4j.Error.RequiresCypher25{}}`.
 
       # Create the index for a vector attribute
       AshNeo4j.Vector.create_index(Item, :embedding)
@@ -53,9 +53,8 @@ defmodule AshNeo4j.Vector do
   @spec create_index(Ash.Resource.t(), atom(), keyword()) ::
           {:ok, Bolty.Response.t()} | {:error, term()}
   def create_index(resource, attr, opts \\ []) do
-    Cypher.require_cypher25!()
-
-    with {:ok, spec} <- resolve_spec(resource, attr, opts) do
+    with :ok <- Cypher.require_cypher25(),
+         {:ok, spec} <- resolve_spec(resource, attr, opts) do
       if Keyword.get(opts, :recreate, false) do
         with {:ok, _} <- Cypher.run(drop_cypher(spec)), do: Cypher.run(create_cypher(spec))
       else
@@ -70,9 +69,8 @@ defmodule AshNeo4j.Vector do
   @spec drop_index(Ash.Resource.t(), atom(), keyword()) ::
           {:ok, Bolty.Response.t()} | {:error, term()}
   def drop_index(resource, attr, opts \\ []) do
-    Cypher.require_cypher25!()
-
-    with {:ok, spec} <- resolve_spec(resource, attr, opts) do
+    with :ok <- Cypher.require_cypher25(),
+         {:ok, spec} <- resolve_spec(resource, attr, opts) do
       Cypher.run(drop_cypher(spec))
     end
   end

--- a/test/vector_requires_cypher25_test.exs
+++ b/test/vector_requires_cypher25_test.exs
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.VectorRequiresCypher25Test do
+  @moduledoc """
+  Vector operations against a non-Cypher-25 server return (never raise)
+  `{:error, %AshNeo4j.Error.RequiresCypher25{}}` (#350). These run on the
+  **default** pool (Neo4j 5.x, no Cypher 25), so the requirement is unmet.
+  """
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Error.RequiresCypher25
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.ThingNote
+  alias AshNeo4j.Vector
+
+  use ExUnit.Case, async: false
+
+  require Ash.Query
+
+  setup_all do
+    BoltyHelper.start()
+    :ok
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  defp flatten(%{errors: errors} = e) when is_list(errors), do: [e | Enum.flat_map(errors, &flatten/1)]
+  defp flatten(e), do: [e]
+
+  defp requires_cypher25?(error), do: error |> flatten() |> Enum.any?(&match?(%RequiresCypher25{}, &1))
+
+  test "a vector_similarity filter returns RequiresCypher25, not a raise" do
+    {:error, error} =
+      ThingNote
+      |> Ash.Query.filter(vector_similarity(embedding, ^[1.0, 0.0, 0.0]) > 0.5)
+      |> Ash.read()
+
+    assert requires_cypher25?(error)
+  end
+
+  test "create_index returns {:error, RequiresCypher25}" do
+    assert {:error, %RequiresCypher25{}} = Vector.create_index(ThingNote, :embedding)
+  end
+
+  test "drop_index returns {:error, RequiresCypher25}" do
+    assert {:error, %RequiresCypher25{}} = Vector.drop_index(ThingNote, :embedding)
+  end
+end


### PR DESCRIPTION
Last of #350's three: **`RequiresCypher25`** now **returns** `{:error, error}` instead of raising — completing the conversion of the data-layer raises that crept in with the Geo / Cypher-25 work.

### What changed
- `RequiresCypher25` → a **Splode error** (`use Splode.Error`, class `:invalid`).
- `require_cypher25!/0` (raised) → **`require_cypher25/0`** returning `:ok | {:error, %RequiresCypher25{}}`, threaded through all five sites across three sub-paths:
  - **filter** vector predicates (`vector_similarity` / `vector_cosine_distance` in `to_conditions`) — `with :ok <- require_cypher25()`; the `{:error}` threads up via `finalize_conditions` (reusing #353).
  - **sort** vector term — `sort_term` returns `{:error}`; `sort_terms` now returns `{:ok, {terms, params}} | {:error}`, threaded through `run_simple_query` and both combination runners.
  - **index lifecycle** (`Vector.create_index` / `drop_index`) — `with :ok <- …`, returned to the operator caller.
- Doc references updated (raise → return) in `vector.ex` and `type/vector.ex`.

### Tests
Three tests on the **default** (non-Cypher-25) pool assert the returned error for a `vector_similarity` filter, `create_index`, and `drop_index`. The existing `:cypher25`-tagged live vector tests run on the Bolt6 (2026.05) pool where the requirement is met, so they're unaffected.

### #350 complete
1. ✅ `GeoDimensionMismatch` (PR #353)
2. ✅ `Unsupported3DGeometry` (PR #354)
3. ✅ **`RequiresCypher25`** (this)

Closes #350. The AGENTS guardrail (#351) — "data layer returns `{:error}`, never raises" — now holds across the whole data layer. Native 1.20 checker + Dialyzer clean, full suite green (670).
