### PR TITLE
feat: surface + classify Neo4j server errors instead of flattening (#358)

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -406,7 +406,7 @@ defmodule AshNeo4j.DataLayer do
             convert_node_to_resource(resource, node)
 
           {:error, error} ->
-            {:error, error}
+            {:error, AshNeo4j.Error.Neo4j.from_bolt(error)}
         end
       end
 
@@ -1072,7 +1072,7 @@ defmodule AshNeo4j.DataLayer do
         convert_node_to_resource(mapping.module, node)
 
       {:error, error} ->
-        {:error, error}
+        {:error, AshNeo4j.Error.Neo4j.from_bolt(error)}
     end
   end
 

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -70,3 +70,49 @@ defmodule AshNeo4j.Error.UnresolvableTraversal do
   end
 end
 
+defmodule AshNeo4j.Error.Neo4j do
+  @moduledoc """
+  Wraps a Neo4j server error surfaced from `AshNeo4j.Cypher.run/1` (a
+  `%Bolty.Error{}`), preserving its Neo4j status code and message and classifying
+  it by `:category` (#358) — so a failure surfaces as the actual error, not a
+  generic string. The server-side complement to the returned-error work (#350).
+
+  `:category` is one of `:constraint` (a `ConstraintValidationFailed` — what
+  `identities` / primary-key constraints rely on), `:transient` (retryable, e.g.
+  a deadlock), `:statement` (a syntax/parameter error — our generated Cypher is
+  wrong), `:security`, or `:other`.
+  """
+  use Splode.Error, fields: [:neo4j_code, :neo4j_message, :category], class: :invalid
+
+  def message(%{neo4j_code: nil, neo4j_message: msg}), do: "Neo4j error: #{msg}"
+  def message(%{neo4j_code: code, neo4j_message: nil}), do: "Neo4j #{code}"
+  def message(%{neo4j_code: code, neo4j_message: msg}), do: "Neo4j #{code}: #{msg}"
+
+  @doc """
+  Maps an error surfaced from `Cypher.run/1` to a classified `AshNeo4j.Error.Neo4j`.
+  A `%Bolty.Error{}` with a Neo4j status code is classified by that code; any
+  other error term is wrapped with `category: :other`.
+  """
+  def from_bolt(%{bolt: %{code: code, message: msg}}) when is_binary(code) do
+    exception(neo4j_code: code, neo4j_message: msg, category: category(code))
+  end
+
+  def from_bolt(%{__exception__: true} = error) do
+    exception(neo4j_code: nil, neo4j_message: Exception.message(error), category: :other)
+  end
+
+  def from_bolt(other) do
+    exception(neo4j_code: nil, neo4j_message: if(is_binary(other), do: other, else: inspect(other)), category: :other)
+  end
+
+  @doc "True for a Neo4j constraint-violation error (drives `identities` / PK constraints)."
+  def constraint_violation?(%__MODULE__{category: :constraint}), do: true
+  def constraint_violation?(_), do: false
+
+  defp category("Neo.ClientError.Schema.ConstraintValidationFailed"), do: :constraint
+  defp category("Neo.TransientError." <> _), do: :transient
+  defp category("Neo.ClientError.Statement." <> _), do: :statement
+  defp category("Neo.ClientError.Security." <> _), do: :security
+  defp category(_), do: :other
+end
+

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -139,8 +139,8 @@ defmodule AshNeo4j.QueryHelper do
       {:ok, %Bolty.Response{results: results}} ->
         {:ok, results}
 
-      {:error, _} ->
-        {:error, "Error running cypher query"}
+      {:error, error} ->
+        {:error, AshNeo4j.Error.Neo4j.from_bolt(error)}
     end
   end
 

--- a/test/error/neo4j_test.exs
+++ b/test/error/neo4j_test.exs
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Error.Neo4jTest do
+  @moduledoc """
+  `AshNeo4j.Error.Neo4j.from_bolt/1` (#358) classifies a `%Bolty.Error{}` by its
+  Neo4j status code and preserves code + message, so a server failure surfaces
+  as the real error instead of a generic string (the read/write paths thread it
+  via `run_cypher_query` / `create_node` / `update_node`).
+  """
+  use ExUnit.Case, async: true
+
+  alias AshNeo4j.Error.Neo4j
+
+  defp bolt(code, msg \\ "boom"), do: %Bolty.Error{module: Bolty, code: :error, bolt: %{code: code, message: msg}}
+
+  test "a constraint violation classifies as :constraint" do
+    err = Neo4j.from_bolt(bolt("Neo.ClientError.Schema.ConstraintValidationFailed", "already exists"))
+    assert %Neo4j{category: :constraint, neo4j_code: "Neo.ClientError.Schema.ConstraintValidationFailed"} = err
+    assert Neo4j.constraint_violation?(err)
+  end
+
+  test "a transient error classifies as :transient" do
+    err = Neo4j.from_bolt(bolt("Neo.TransientError.Transaction.DeadlockDetected"))
+    assert %Neo4j{category: :transient} = err
+    refute Neo4j.constraint_violation?(err)
+  end
+
+  test "a statement (syntax) error classifies as :statement" do
+    assert %Neo4j{category: :statement} = Neo4j.from_bolt(bolt("Neo.ClientError.Statement.SyntaxError"))
+  end
+
+  test "a security error classifies as :security" do
+    assert %Neo4j{category: :security} = Neo4j.from_bolt(bolt("Neo.ClientError.Security.Forbidden"))
+  end
+
+  test "an unrecognised code classifies as :other" do
+    assert %Neo4j{category: :other} = Neo4j.from_bolt(bolt("Neo.DatabaseError.General.UnknownError"))
+  end
+
+  test "the message preserves the Neo4j code and message" do
+    msg = Exception.message(Neo4j.from_bolt(bolt("Neo.ClientError.Schema.ConstraintValidationFailed", "already exists")))
+    assert msg =~ "ConstraintValidationFailed"
+    assert msg =~ "already exists"
+  end
+
+  test "a non-Bolty error term is wrapped as :other, code nil" do
+    assert %Neo4j{category: :other, neo4j_code: nil, neo4j_message: "raw failure"} = Neo4j.from_bolt("raw failure")
+  end
+end


### PR DESCRIPTION
Closes #358 (surfacing/classification slice). The server-side complement to #350: there we made *our* errors honest; here we stop discarding Neo4j's.

### The bug
`run_cypher_query` threw away bolty's structured `%Bolty.Error` and returned `"Error running cypher query"` for **every** failure — constraint violation, syntax error, transient deadlock, connection drop all collapsed to one useless string.

### The fix
- **`AshNeo4j.Error.Neo4j`** — a Splode error (class `:invalid`) carrying the Neo4j status code + message, classified by `:category`:
  - `:constraint` (`ConstraintValidationFailed` — what `identities` #20 / PK constraints #32 rely on)
  - `:transient` (retryable, e.g. deadlock)
  - `:statement` (syntax/parameter — our generated Cypher is wrong)
  - `:security`, `:other`
  - `from_bolt/1` maps a `%Bolty.Error{}` by its `bolt.code`, or wraps any other error term; `constraint_violation?/1` helper for #32.
- **Read path:** `run_cypher_query` maps the error (no more flattening).
- **Write path:** `create_node` / `update_node` map the (previously passed-through-raw) `%Bolty.Error`, so a constraint violation surfaces *classified*.

### Not a bolty dependency
bolty already provides the structured error (`%Bolty.Error{code, bolt: %{code, message}}`) — this is entirely consumer-side.

### Tests
7 unit tests for `from_bolt/1` (each category + message preservation + non-bolt wrapping). **End-to-end constraint-violation coverage defers to #32** — it owns constraint creation, and Neo4j rejects `CREATE CONSTRAINT` inside the sandbox's explicit transaction, so there's nothing to violate until then. The read/write wiring is a thin `from_bolt` call at three sites.

### Related follow (noted, out of scope)
The ad-hoc `{:error, "<string>"}` errors we generate ourselves (data_layer/spatial/vector/util) could become Splode errors for consistency — separate from this server-error mapping.

Native 1.20 checker + Dialyzer clean, full suite green (677).
