### PR TITLE
feat: dynamic-label capability + pattern-position render primitive (#339)

### DIFF
--- a/lib/bolty_helper.ex
+++ b/lib/bolty_helper.ex
@@ -117,4 +117,25 @@ defmodule AshNeo4j.BoltyHelper do
       nil -> false
     end
   end
+
+  @doc """
+  Returns `true` when the current pool (see `current_pool/0`) is connected to a
+  Neo4j server that supports dynamic labels/types (`MATCH (n:$(expr))`,
+  `-[r:$(expr)]->`), which landed in Neo4j 5.26.
+
+  This is the **server-feature axis**, distinct from `cypher25?/0`: dynamic
+  labels run under plain `CYPHER 5` and need no `CYPHER 25` selector, so a
+  5.26 server reports `dynamic_labels: true` but `cypher_25: false`. Read from
+  the negotiated `policy().dynamic_labels` flag (bolty ≥ 0.2.0); `false` when the
+  pool is not started.
+  """
+  def dynamic_labels?(), do: dynamic_labels?(current_pool())
+
+  @doc "Dynamic label/type support for an explicit `pool`."
+  def dynamic_labels?(pool) do
+    case policy(pool) do
+      %{dynamic_labels: dynamic_labels} -> dynamic_labels
+      nil -> false
+    end
+  end
 end

--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -426,6 +426,54 @@ defmodule AshNeo4j.Cypher do
   end
 
   @doc """
+  A **dynamic label/type** fragment `:$(expr)` (Neo4j ≥ 5.26) — the runtime-resolved
+  counterpart to a static `:Label` in a node pattern `(n:$(expr))` or a relationship
+  pattern `-[r:$(expr)]->` (#339). `expr` is any Cypher expression yielding the
+  label/type: a parameter token (`"$label"`), a property (`"n.kind"`), or — for
+  multiple labels in `CREATE` — a list-valued parameter (`"$labels"`).
+
+  `expr` must be a server-side Cypher expression, never an interpolated literal —
+  that is the injection-safe form (the value is bound, not string-built). Gate
+  emission with `require_dynamic_labels/0`.
+
+  ## Examples
+  ```
+  iex> AshNeo4j.Cypher.dynamic_label("$label")
+  ":$($label)"
+  iex> AshNeo4j.Cypher.dynamic_label("n.kind")
+  ":$(n.kind)"
+  ```
+  """
+  @spec dynamic_label(binary()) :: binary()
+  def dynamic_label(expr) when is_binary(expr), do: ":$(#{expr})"
+
+  @doc """
+  `:ok` when the connected server supports dynamic labels/types in **pattern
+  position** (`(n:$(expr))`, `-[r:$(expr)]->` in `MATCH`/`CREATE`/`MERGE`;
+  negotiated server version ≥ 5.26), else
+  `{:error, %AshNeo4j.Error.RequiresDynamicLabels{}}`. This is the **server-feature
+  axis** (plain `CYPHER 5`), distinct from `require_cypher25/0`. Use at the top of
+  any function that emits `dynamic_label/1` and thread the error up — a data layer
+  returns it, never raises.
+
+  > #### WHERE-predicate label filtering is a *finer* gate {: .warning}
+  > The `WHERE n:$(expr)` predicate form is **not** covered by this check: it
+  > fails on 5.26 (`dynamic_labels: true`) and only works on later servers
+  > (verified ≥ 2026.05). `dynamic_labels?/0` / `policy().dynamic_labels` guarantee
+  > the pattern form only — matching bolty's flag semantics. A label-filter
+  > consumer must establish its own server gate (#339; capability-granularity
+  > question raised as diffo-dev/bolty#53).
+  """
+  @spec require_dynamic_labels() :: :ok | {:error, struct()}
+  def require_dynamic_labels() do
+    if BoltyHelper.dynamic_labels?() do
+      :ok
+    else
+      {:error, AshNeo4j.Error.RequiresDynamicLabels.exception([])}
+    end
+  end
+
+  @doc """
   Runs some cypher
 
   ## Examples

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -12,6 +12,19 @@ defmodule AshNeo4j.Error.RequiresCypher25 do
   def message(_), do: "This operation requires Cypher 25 (Neo4j ≥ 2025.06)"
 end
 
+defmodule AshNeo4j.Error.RequiresDynamicLabels do
+  @moduledoc """
+  Returned (never raised) when a dynamic label/type operation (`MATCH (n:$(expr))`,
+  `-[r:$(expr)]->`) is attempted against a Neo4j server older than 5.26. This is
+  the **server-feature axis** — dynamic labels run under plain `CYPHER 5` and are
+  unrelated to the `CYPHER 25` selector (`AshNeo4j.Error.RequiresCypher25`).
+  Upgrade to Neo4j 5.26 or later to use this feature.
+  """
+  use Splode.Error, fields: [], class: :invalid
+
+  def message(_), do: "This operation requires dynamic labels (Neo4j ≥ 5.26)"
+end
+
 defmodule AshNeo4j.Error.GeoDimensionMismatch do
   @moduledoc """
   Returned (never raised) when a spatial operation combines geometries of

--- a/test/dynamic_labels_capability_test.exs
+++ b/test/dynamic_labels_capability_test.exs
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.DynamicLabelsCapabilityTest do
+  @moduledoc """
+  `BoltyHelper.dynamic_labels?/1` reflects the negotiated `policy().dynamic_labels`
+  flag (#339). It is the **server-feature axis** (Neo4j ≥ 5.26, plain Cypher 5),
+  distinct from `cypher25?/1` (the `CYPHER 25` language selector, ≥ 2025.06): the
+  default 5.26 pool reports `dynamic_labels: true` but `cypher_25: false`.
+  """
+  alias AshNeo4j.BoltyHelper
+
+  use ExUnit.Case, async: false
+
+  setup_all do
+    BoltyHelper.start()
+    :ok
+  end
+
+  test "default pool (Neo4j 5.26) supports dynamic labels but not Cypher 25" do
+    assert BoltyHelper.dynamic_labels?() == true
+    assert BoltyHelper.cypher25?() == false
+  end
+
+  test "an unstarted pool reports no capability rather than raising" do
+    assert BoltyHelper.dynamic_labels?(:no_such_pool) == false
+  end
+
+  @tag :bolt6
+  test "the Bolt6 pool (Neo4j 2026.05) supports both dynamic labels and Cypher 25" do
+    assert BoltyHelper.dynamic_labels?(Bolt6) == true
+    assert BoltyHelper.cypher25?(Bolt6) == true
+  end
+end

--- a/test/dynamic_labels_render_test.exs
+++ b/test/dynamic_labels_render_test.exs
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.DynamicLabelsRenderTest do
+  @moduledoc """
+  The `:$(expr)` dynamic label/type render primitive (#339), proven on the wire
+  against the default pool (Neo4j 5.26, where `dynamic_labels?` is true). Covers
+  **pattern position** only — node labels and relationship types in
+  `MATCH`/`CREATE` — which is what `dynamic_labels?` guarantees on 5.26. (The
+  `WHERE n:$(expr)` predicate form is a finer, later capability and is not part of
+  this primitive.) The label/type is supplied as a **bound parameter**, never
+  interpolated — the injection-safe form. Self-contained: each probe creates and
+  `DETACH DELETE`s its nodes in one statement, persisting nothing.
+  """
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Cypher
+
+  use ExUnit.Case, async: false
+
+  setup_all do
+    BoltyHelper.start()
+    :ok
+  end
+
+  test "require_dynamic_labels/0 is :ok on the 5.26 default pool" do
+    assert Cypher.require_dynamic_labels() == :ok
+  end
+
+  test "dynamic_label/1 binds a runtime node label in a CREATE pattern" do
+    label_frag = Cypher.dynamic_label("$label")
+
+    cypher =
+      "CREATE (n#{label_frag} {tag: $tag}) " <>
+        "WITH n, labels(n) AS ls " <>
+        "DETACH DELETE n " <>
+        "RETURN ls AS labels"
+
+    response = Bolty.query!(Bolt, cypher, %{"label" => "DynLabelProbe", "tag" => "probe"})
+
+    assert %{"labels" => ["DynLabelProbe"]} = Bolty.Response.first(response)
+  end
+
+  test "dynamic_label/1 binds a runtime relationship type in a CREATE pattern" do
+    type_frag = Cypher.dynamic_label("$type")
+
+    cypher =
+      "CREATE (a)-[r#{type_frag}]->(b) " <>
+        "WITH a, b, type(r) AS t " <>
+        "DETACH DELETE a, b " <>
+        "RETURN t AS type"
+
+    response = Bolty.query!(Bolt, cypher, %{"type" => "DYN_REL_PROBE"})
+
+    assert %{"type" => "DYN_REL_PROBE"} = Bolty.Response.first(response)
+  end
+end


### PR DESCRIPTION
First baby step of #339 — the dynamic-label foundation, scoped to **pattern position** only. Does **not** close #339; consumer sites follow.

## What's here
- **`BoltyHelper.dynamic_labels?/0,1`** — reads the negotiated `policy().dynamic_labels` (bolty 0.2.0), the **server-feature axis** distinct from `cypher25?`: a 5.26 server reports `dynamic_labels: true` / `cypher_25: false`.
- **`Cypher.dynamic_label/1`** — emits the injection-safe `:$(expr)` fragment for node labels `(n:$(expr))` and rel types `-[r:$(expr)]->` in `MATCH`/`CREATE`/`MERGE` (the value is a bound expression, never string-built).
- **`Cypher.require_dynamic_labels/0`** + **`AshNeo4j.Error.RequiresDynamicLabels`** — gate that returns (never raises) below 5.26, mirroring `require_cypher25/0`.

## Verified
- `mix compile --warnings-as-errors` clean.
- Full suite green across both servers (`--include cypher25 --include bolt6`): **694 passed**, incl. the new capability + wire-proof tests.
- Wire-proven: node-label and rel-type pattern emission run against live **5.26.27** and **2026.05**.

## Scope boundary (deliberate)
Pattern position only. The **`WHERE n:$(expr)` predicate** (label filtering) is a finer, later capability — it **fails on 5.26.27** but works on 2026.05 — that `policy().dynamic_labels` does not cover. That consumer is deferred pending the capability-granularity question raised as **diffo-dev/bolty#53**.

| Form | 5.26.27 | 2026.05.0 |
|---|---|---|
| node pattern `(n:$(expr))` | ✅ | ✅ |
| rel pattern `-[r:$(expr)]->` | ✅ | ✅ |
| WHERE predicate `WHERE n:$(expr)` | ❌ | ✅ |

## Follow-ups (still under #339)
- Consumer sites: polymorphic reads, label-filtered `WHERE` (needs the bolty#53 resolution), future n-world label pairs (#329).
