### PR TITLE
feat: CYPHER 5 sunset tripwire; record Cypher 25 dialect posture (#363)

### DIFF
--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -374,7 +374,44 @@ defmodule AshNeo4j.Cypher do
     {prefix <> Enum.map_join(clauses, " ", &render_clause/1), params}
   end
 
-  defp cypher25_prefix, do: if(BoltyHelper.cypher25?(), do: "CYPHER 25 ", else: "")
+  # Dialect posture (#363): Cypher 25 is the target dialect — we emit the
+  # `CYPHER 25 ` selector explicitly on every server that supports it, so our
+  # (audited Cypher-25-clean) output runs under Cypher 25 there. The bare /
+  # no-selector branch is purely the Neo4j 5.26-LTS fallback, which relies on the
+  # server defaulting to CYPHER 5.
+  defp cypher25_prefix do
+    if BoltyHelper.cypher25?() do
+      "CYPHER 25 "
+    else
+      warn_cypher5_sunset()
+      ""
+    end
+  end
+
+  # Sunset tripwire (#363): the bare fallback above assumes the server defaults to
+  # CYPHER 5. CYPHER 5 is feature-capped from Neo4j 2026.06 and slated for removal
+  # (late-2026.x / 2027.x TBD); a server that no longer speaks it reports
+  # `policy.cypher_5 == false`. Reaching this with cypher_5 false means our
+  # unprefixed Cypher now runs under an unknown server default — flag it once per
+  # pool rather than emit silently. (Near-unreachable on real servers, since a
+  # post-CYPHER-5 server is a Cypher 25 server and takes the prefixed branch.)
+  defp warn_cypher5_sunset do
+    pool = BoltyHelper.current_pool()
+
+    with false <- :persistent_term.get({__MODULE__, :cypher5_warned, pool}, false),
+         %{cypher_5: false} <- BoltyHelper.policy(pool) do
+      Logger.warning(
+        "AshNeo4j is emitting unprefixed Cypher (CYPHER 5 fallback) to pool #{inspect(pool)}, " <>
+          "but the server reports no CYPHER 5 support (policy.cypher_5 == false). CYPHER 5 is " <>
+          "being sunset (Neo4j 2026.06 feature-cap; removal TBD) — these queries now run under the " <>
+          "server's default language. See AshNeo4j #363."
+      )
+
+      :persistent_term.put({__MODULE__, :cypher5_warned, pool}, true)
+    end
+
+    :ok
+  end
 
   defp render_clause(%Match{pattern: p}), do: "MATCH #{p}"
   defp render_clause(%OptionalMatch{pattern: p}), do: "OPTIONAL MATCH #{p}"

--- a/test/cypher5_sunset_tripwire_test.exs
+++ b/test/cypher5_sunset_tripwire_test.exs
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Cypher5SunsetTripwireTest do
+  @moduledoc """
+  The CYPHER 5 sunset tripwire (#363): when AshNeo4j emits unprefixed Cypher (the
+  Neo4j 5.26-LTS fallback, taken when the server isn't a Cypher 25 server) against
+  a server that reports no CYPHER 5 support (`policy.cypher_5 == false`), it warns
+  once per pool rather than emit silently. CYPHER 5 is feature-capped from Neo4j
+  2026.06 and slated for removal.
+  """
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Cypher
+  alias AshNeo4j.Cypher.{Match, Query, Return}
+
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  setup_all do
+    BoltyHelper.start()
+    :ok
+  end
+
+  defp simple_query do
+    %Query{clauses: [%Match{pattern: "(s:Place)"}, %Return{items: ["s"]}], params: %{}}
+  end
+
+  describe "a server with no CYPHER 5 and no Cypher 25 (the stranded sunset state)" do
+    setup do
+      pool = :tripwire_fake_pool
+      :persistent_term.put({BoltyHelper, :policy, pool}, %Bolty.Policy{cypher_5: false, cypher_25: false})
+
+      on_exit(fn ->
+        :persistent_term.erase({BoltyHelper, :policy, pool})
+        :persistent_term.erase({Cypher, :cypher5_warned, pool})
+      end)
+
+      %{pool: pool}
+    end
+
+    test "warns on a bare-fallback render", %{pool: pool} do
+      log =
+        capture_log(fn ->
+          BoltyHelper.with_pool(pool, fn -> Cypher.render(simple_query()) end)
+        end)
+
+      assert log =~ "CYPHER 5 fallback"
+      assert log =~ "policy.cypher_5 == false"
+    end
+
+    test "warns at most once per pool", %{pool: pool} do
+      log =
+        capture_log(fn ->
+          BoltyHelper.with_pool(pool, fn ->
+            Cypher.render(simple_query())
+            Cypher.render(simple_query())
+            Cypher.render(simple_query())
+          end)
+        end)
+
+      assert log |> String.split("CYPHER 5 fallback") |> length() == 2
+    end
+  end
+
+  test "no warning on the default 5.26 pool (cypher_5 true)" do
+    log = capture_log(fn -> Cypher.render(simple_query()) end)
+    refute log =~ "CYPHER 5 fallback"
+  end
+end


### PR DESCRIPTION
Closes #363. Finishes the (shrunk) "Cypher 25 dialect posture" scope.

## 1. Cypher 25 cleanliness audit — done, clean
Recorded; no code change. We already emit `CYPHER 25 ` on 2025.06+ servers, so our output runs under Cypher 25 there. Both legs pass:
- **Empirical:** full suite under explicit `CYPHER 25` against live Neo4j 2026.05 green.
- **Analytical:** every construct generated is the modern idiom — `EXISTS { … }` (not the removed `exists()` predicate), `CALL { }`, `point.distance` / `point.withinBBox` (not bare `distance()`), `vector.similarity.cosine`, `head(collect(...))`, `IS NULL` / `IS NOT NULL`, `size()`, `properties()`. No deprecated-in-25 surface.

The posture is now recorded in-code as a comment on `cypher25_prefix/0`.

## 2. cypher_5 sunset tripwire
CYPHER 5 is feature-capped from Neo4j 2026.06 and slated for removal (late-2026.x / 2027.x TBD). Cypher 25 is our target; the bare/no-selector path is the 5.26-LTS fallback only.

`warn_cypher5_sunset/0` warns **once per pool** when we take the bare fallback against a server reporting `policy.cypher_5 == false` — surfacing the stranded state instead of silently running under an unknown default. No `cypher_5`-pinning infrastructure; `cypher_5` stays a tripwire, not a feature.

(Near-unreachable on real servers — a post-CYPHER-5 server is a Cypher 25 server and takes the prefixed branch — which is exactly why a silent slip-through deserves a flag.)

## Verified
- `mix compile --warnings-as-errors` clean.
- Full suite both servers (`--include cypher25 --include bolt6`): **697 passed**.
- New `cypher5_sunset_tripwire_test.exs` covers fire, once-per-pool dedup, and no-warning on the 5.26 pool (where `cypher_5` is true).
