### PR TITLE
feat: atomic update + destroy support (changeset.filter guard, atomics, bulk) (#361)

### DIFF
--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -887,6 +887,49 @@ defmodule AshNeo4j.Cypher.Query do
   end
 
   @doc """
+  Single guarded + filtered destroy (#361): `MATCH (n:L {id}) WHERE <filter> AND NOT
+  <guard…> DETACH DELETE n`. The `changeset.filter` optimistic-lock conditions are
+  ANDed with the preservation guards. Run via `run_expecting_deletions/1`: zero
+  deletions ⇒ the caller disambiguates filter-miss (StaleRecord) from guard
+  (Unavailable) with `node_matching/3`.
+  """
+  @spec delete_node_filtered(atom() | [atom()], map(), list(), list()) :: t()
+  def delete_node_filtered(label, id_props, filter_conditions, guards)
+      when is_map(id_props) and is_list(filter_conditions) and is_list(guards) do
+    {pattern, id_params} = Cypher.parameterized_node(:n, List.wrap(label), id_props)
+    {filter_where, filter_params} = build_conditions(:n, filter_conditions, param_prefix: "f_")
+
+    guard_conditions =
+      Enum.map(guards, fn {edge_label, direction, dest_label} ->
+        guard_condition(:n, edge_label, direction, dest_label)
+      end)
+
+    where_items = if(filter_where == "", do: [], else: [filter_where]) ++ guard_conditions
+
+    %__MODULE__{
+      clauses: [%Match{pattern: pattern}, %Where{conditions: where_items}, %DetachDelete{items: ["n"]}],
+      params: Map.merge(id_params, filter_params)
+    }
+  end
+
+  @doc """
+  `MATCH (n:L {id}) WHERE <filter> RETURN n` — the optimistic-lock existence check
+  (no guard) used to disambiguate a zero-deletion `delete_node_filtered/4` (#361).
+  """
+  @spec node_matching(atom() | [atom()], map(), list()) :: t()
+  def node_matching(label, id_props, filter_conditions)
+      when is_map(id_props) and is_list(filter_conditions) do
+    {pattern, id_params} = Cypher.parameterized_node(:n, List.wrap(label), id_props)
+    {filter_where, filter_params} = build_conditions(:n, filter_conditions, param_prefix: "f_")
+    where_clauses = if filter_where == "", do: [], else: [%Where{conditions: [filter_where]}]
+
+    %__MODULE__{
+      clauses: [%Match{pattern: pattern}] ++ where_clauses ++ [%Return{items: ["n"]}],
+      params: Map.merge(id_params, filter_params)
+    }
+  end
+
+  @doc """
   Bulk destroy (#361): `MATCH (n:L) WHERE <filter> AND NOT <guard…> DETACH DELETE n`.
   Deletes every node matching `conditions` (the pushed-down query filter) that
   isn't protected by a preservation `guard` — guarded nodes are skipped, not

--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -887,6 +887,43 @@ defmodule AshNeo4j.Cypher.Query do
   end
 
   @doc """
+  Bulk destroy (#361): `MATCH (n:L) WHERE <filter> AND NOT <guard…> DETACH DELETE n`.
+  Deletes every node matching `conditions` (the pushed-down query filter) that
+  isn't protected by a preservation `guard` — guarded nodes are skipped, not
+  errored ("delete what is safe"). When `return?`, the node's `properties`/`id`/
+  `labels` are captured in a `WITH` *before* the delete (a returned deleted node
+  has empty properties) and returned for record reconstruction.
+  """
+  @spec bulk_detach_delete(atom() | [atom()], list(), list(), boolean()) :: t()
+  def bulk_detach_delete(label, conditions, guards, return?)
+      when is_list(conditions) and is_list(guards) and is_boolean(return?) do
+    {filter_where, params} = build_conditions(:n, conditions, param_prefix: "f_")
+
+    guard_conditions =
+      Enum.map(guards, fn {edge_label, direction, dest_label} ->
+        guard_condition(:n, edge_label, direction, dest_label)
+      end)
+
+    where_items = if(filter_where == "", do: [], else: [filter_where]) ++ guard_conditions
+    where_clauses = if where_items == [], do: [], else: [%Where{conditions: where_items}]
+
+    {capture_clauses, return_clauses} =
+      if return? do
+        {[%With{items: ["n", "properties(n) AS props", "id(n) AS nid", "labels(n) AS labels"]}],
+         [%Return{items: ["props", "nid", "labels"]}]}
+      else
+        {[], []}
+      end
+
+    %__MODULE__{
+      clauses:
+        [%Match{pattern: Cypher.node(:n, List.wrap(label))}] ++
+          where_clauses ++ capture_clauses ++ [%DetachDelete{items: ["n"]}] ++ return_clauses,
+      params: params
+    }
+  end
+
+  @doc """
   `MATCH (s:SrcLabel {s_props}) OPTIONAL MATCH (d:DestLabel {d_props}) MERGE (s)-[r:EDGE]->(d) RETURN s, r, d`
   """
   @spec relate(atom() | [atom()], map(), atom() | [atom()], map(), atom(), atom()) :: t()

--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -786,10 +786,12 @@ defmodule AshNeo4j.Cypher.Query do
   Handles all combinations of empty/non-empty set_props and remove_props.
   """
   @spec update_node(atom() | [atom()], map(), map(), [atom()]) :: t()
-  def update_node(label, match_props, set_props, remove_props \\ [])
-      when is_map(match_props) and is_map(set_props) and is_list(remove_props) do
+  def update_node(label, match_props, set_props, remove_props \\ [], guard_conditions \\ [])
+      when is_map(match_props) and is_map(set_props) and is_list(remove_props) and
+             is_list(guard_conditions) do
     {match_pattern, match_params} = Cypher.parameterized_node(:n, List.wrap(label), match_props)
     {props_cypher, set_params} = Cypher.parameterized_properties(:n, set_props)
+    {guard_clauses, guard_params} = guard_where(guard_conditions)
 
     set_clauses = if map_size(set_props) > 0, do: [%Set{expression: "n += #{props_cypher}"}], else: []
     remove_clauses =
@@ -798,9 +800,21 @@ defmodule AshNeo4j.Cypher.Query do
         else: []
 
     %__MODULE__{
-      clauses: [%Match{pattern: match_pattern}] ++ set_clauses ++ remove_clauses ++ [%Return{items: ["n"]}],
-      params: Map.merge(match_params, set_params)
+      clauses:
+        [%Match{pattern: match_pattern}] ++
+          guard_clauses ++ set_clauses ++ remove_clauses ++ [%Return{items: ["n"]}],
+      params: match_params |> Map.merge(set_params) |> Map.merge(guard_params)
     }
+  end
+
+  # The `changeset.filter` guard (#361) as a `WHERE` between the `MATCH` and `SET`.
+  # Rendered against the `:n` update alias; params are `g_`-prefixed so they can't
+  # collide with the match/set params on the same alias.
+  defp guard_where([]), do: {[], %{}}
+
+  defp guard_where(conditions) do
+    {where_string, params} = build_conditions(:n, conditions, param_prefix: "g_")
+    {[%Where{conditions: [where_string]}], params}
   end
 
   @doc """

--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -781,19 +781,30 @@ defmodule AshNeo4j.Cypher.Query do
   end
 
   @doc """
-  `MATCH (n:L1:L2 {match_props}) SET n += {set_props} REMOVE n.p1, n.p2 RETURN n`
+  `MATCH (n:L1:L2 {match_props}) [WHERE guard] SET n += {set_props} [, n.x = <expr>]
+  REMOVE n.p1, n.p2 RETURN n`
 
-  Handles all combinations of empty/non-empty set_props and remove_props.
+  Handles all combinations of empty/non-empty set_props and remove_props. `opts`:
+
+    * `:guard` — `changeset.filter` conditions (#361); rendered as a `WHERE`
+      between the `MATCH` and `SET`. Zero matched rows ⇒ the caller raises
+      `StaleRecord`.
+    * `:atomics` — `{set_expressions, params}` for `changeset.atomics` (#361):
+      live-node `SET n.<prop> = <expr>` clauses (already rendered against `:n`).
   """
-  @spec update_node(atom() | [atom()], map(), map(), [atom()]) :: t()
-  def update_node(label, match_props, set_props, remove_props \\ [], guard_conditions \\ [])
-      when is_map(match_props) and is_map(set_props) and is_list(remove_props) and
-             is_list(guard_conditions) do
+  @spec update_node(atom() | [atom()], map(), map(), [atom()], keyword()) :: t()
+  def update_node(label, match_props, set_props, remove_props \\ [], opts \\ [])
+      when is_map(match_props) and is_map(set_props) and is_list(remove_props) and is_list(opts) do
     {match_pattern, match_params} = Cypher.parameterized_node(:n, List.wrap(label), match_props)
     {props_cypher, set_params} = Cypher.parameterized_properties(:n, set_props)
-    {guard_clauses, guard_params} = guard_where(guard_conditions)
+    {guard_clauses, guard_params} = guard_where(Keyword.get(opts, :guard, []))
+    {atomic_exprs, atomic_params} = Keyword.get(opts, :atomics, {[], %{}})
 
-    set_clauses = if map_size(set_props) > 0, do: [%Set{expression: "n += #{props_cypher}"}], else: []
+    set_exprs =
+      (if(map_size(set_props) > 0, do: ["n += #{props_cypher}"], else: [])) ++ atomic_exprs
+
+    set_clauses = if set_exprs != [], do: [%Set{expression: Enum.join(set_exprs, ", ")}], else: []
+
     remove_clauses =
       if remove_props != [],
         do: [%Remove{items: Enum.map(remove_props, &"n.#{Cypher.quote_if_dotted(&1)}")}],
@@ -803,7 +814,7 @@ defmodule AshNeo4j.Cypher.Query do
       clauses:
         [%Match{pattern: match_pattern}] ++
           guard_clauses ++ set_clauses ++ remove_clauses ++ [%Return{items: ["n"]}],
-      params: match_params |> Map.merge(set_params) |> Map.merge(guard_params)
+      params: match_params |> Map.merge(set_params) |> Map.merge(guard_params) |> Map.merge(atomic_params)
     }
   end
 

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -783,22 +783,50 @@ defmodule AshNeo4j.DataLayer do
     """)
 
     mapping = ResourceInfo.mapping(resource)
-    label = mapping.label_pair
-    id_properties = id_properties(mapping, changeset.data)
 
-    # A filtered destroy (#361) is not supported yet — the guarded `destroy_query`
-    # path is deferred. Refuse rather than silently delete unguarded now that we
-    # advertise `:changeset_filter`.
-    with :ok <- refuse_destroy_filter(resource, changeset) do
-      destroy_node(resource, label, id_properties)
+    # Honour a `changeset.filter` "only-destroy-if" guard (optimistic lock, #361):
+    # render it (refuse an un-pushable filter, stance a) and route. `{:ok, []}` is
+    # the unfiltered case.
+    with {:ok, conditions} <- QueryHelper.guard_conditions(mapping, changeset.filter) do
+      destroy_with_conditions(resource, mapping, conditions, changeset)
     end
   end
 
-  defp refuse_destroy_filter(_resource, %{filter: nil}), do: :ok
-  defp refuse_destroy_filter(_resource, %{filter: %Ash.Filter{expression: nil}}), do: :ok
+  defp destroy_with_conditions(resource, %ResourceMapping{} = mapping, [], changeset) do
+    destroy_node(resource, mapping.label_pair, id_properties(mapping, changeset.data))
+  end
 
-  defp refuse_destroy_filter(resource, %{filter: filter}) do
-    {:error, AshNeo4j.Error.UnsupportedChangesetFilter.exception(resource: resource, filter: filter)}
+  defp destroy_with_conditions(resource, %ResourceMapping{} = mapping, conditions, changeset) do
+    label = mapping.label_pair
+    id_properties = id_properties(mapping, changeset.data)
+    guards = ResourceInfo.preserve_node_relationships(resource)
+
+    case Neo4jHelper.delete_node_filtered(label, id_properties, conditions, guards) do
+      {:ok, _} ->
+        :ok
+
+      # Nothing deleted: if the node still matches the filter it was held back by a
+      # guard (Unavailable); otherwise the optimistic lock didn't hold (StaleRecord).
+      {:error, "nothing deleted"} ->
+        case Neo4jHelper.node_matching(label, id_properties, conditions) do
+          {:ok, %Bolty.Response{results: [_ | _]}} ->
+            {:error, unavailable_guarded(resource)}
+
+          _ ->
+            {:error, Ash.Error.Changes.StaleRecord.exception(resource: resource, filter: changeset.filter)}
+        end
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp unavailable_guarded(resource) do
+    Ash.Error.Invalid.Unavailable.exception(
+      resource: resource,
+      source: AshNeo4j.DataLayer,
+      reason: "guarded relationships prevent deletion"
+    )
   end
 
   defp destroy_node(resource, label, id_properties) do
@@ -808,12 +836,7 @@ defmodule AshNeo4j.DataLayer do
           :ok
 
         {:error, "nothing deleted"} ->
-          {:error,
-           Ash.Error.Invalid.Unavailable.exception(
-             resource: resource,
-             source: AshNeo4j.DataLayer,
-             reason: "guarded relationships prevent deletion"
-           )}
+          {:error, unavailable_guarded(resource)}
 
         {:error, error} ->
           {:error, error}

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -29,9 +29,11 @@ defmodule AshNeo4j.DataLayer do
   # Advertise the "only-update-if" guard (#361) so Ash threads `changeset.filter`
   # into update/destroy — without this, `Ash.Changeset.filter/2` silently drops it.
   def can?(_, :changeset_filter), do: true
-  # Atomic updates (#361): render `changeset.atomics` against the live node. Single
-  # record only — the bulk `update_query/4` decision point is deferred.
+  # Atomic updates (#361): render `changeset.atomics` against the live node.
   def can?(_, {:atomic, :update}), do: true
+  # Bulk atomic update (#361): apply the atomics/attributes to every node matching
+  # the query in one statement (`Ash.bulk_update` :atomic strategy).
+  def can?(_, :update_query), do: true
   def can?(_, :upsert), do: true
   def can?(_, :destroy), do: true
   def can?(_, :sort), do: true
@@ -620,6 +622,87 @@ defmodule AshNeo4j.DataLayer do
     """)
 
     result
+  end
+
+  @impl true
+  def update_query(query, changeset, resource, opts) do
+    Logger.debug("""
+    AshNeo4j.DataLayer: update_query(#{inspect(query)}, #{inspect(changeset)}, #{inspect(resource)})
+    """)
+
+    mapping = ResourceInfo.mapping(resource)
+
+    cond do
+      # Relationship management (manage_relationship) is routed here as an atomic
+      # FK set, but in the graph the FK is an *edge*, not a property. Hand it to the
+      # per-record path, which creates the edge (and renders the atomic) (#361).
+      Map.has_key?(changeset.context, :accessing_from) ->
+        single_update_query_result(resource, changeset, mapping, opts)
+
+      true ->
+        bulk_update_query(query, changeset, resource, mapping, opts)
+    end
+  end
+
+  defp single_update_query_result(resource, changeset, mapping, opts) do
+    # Ash atomic-ises the relationship FK set, so the edge key arrives in `atomics`
+    # — as a literal (belongs_to) or a guard expression like
+    # `if is_distinct_from(new, fk), do: new, else: fk` (has_one). The per-record
+    # relationship path reads the FK from `attributes`, so evaluate each atomic
+    # against the live record and fold it back, then delegate (creates the edge).
+    with {:ok, changeset} <- fold_atomics_to_attributes(resource, changeset),
+         {:ok, record} <- do_update(resource, changeset, mapping) do
+      if Map.get(opts, :return_records?), do: {:ok, [record]}, else: :ok
+    end
+  end
+
+  defp fold_atomics_to_attributes(resource, changeset) do
+    Enum.reduce_while(changeset.atomics, {:ok, changeset.attributes}, fn {field, expr}, {:ok, acc} ->
+      case Ash.Expr.eval(expr, record: changeset.data, resource: resource) do
+        {:ok, value} -> {:cont, {:ok, Map.put(acc, field, value)}}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+    |> case do
+      {:ok, attributes} -> {:ok, %{changeset | attributes: attributes, atomics: []}}
+      error -> error
+    end
+  end
+
+  defp bulk_update_query(query, changeset, resource, mapping, opts) do
+    # `query.filter` already folds in any changeset (optimistic-lock) filter via
+    # Ash's add_changeset_filters/2. Stance (a): the scope must push down in full —
+    # we can't post-filter a bulk SET in Elixir — else refuse (#361).
+    with {:ok, conditions} <- QueryHelper.guard_conditions(mapping, query.filter),
+         {:ok, atomic_sets} <- QueryHelper.render_atomic_sets(resource, mapping, changeset.atomics || []) do
+      set_props = dump_properties(mapping, changeset.attributes)
+
+      case Neo4jHelper.update_node(mapping.label_pair, %{}, set_props, [],
+             guard: conditions,
+             atomics: atomic_sets
+           ) do
+        {:ok, %Bolty.Response{results: results}} ->
+          bulk_update_result(resource, results, opts)
+
+        {:error, error} ->
+          {:error, AshNeo4j.Error.Neo4j.from_bolt(error)}
+      end
+    end
+  end
+
+  # `:ok` when records aren't requested, else `{:ok, records}` — short-circuiting
+  # on the first node that fails to convert.
+  defp bulk_update_result(resource, results, opts) do
+    if Map.get(opts, :return_records?) do
+      converted = Enum.map(results, &convert_node_to_resource(resource, Map.get(&1, "n")))
+
+      case Enum.find(converted, &match?({:error, _}, &1)) do
+        nil -> {:ok, Enum.map(converted, fn {:ok, record} -> record end)}
+        {:error, _} = error -> error
+      end
+    else
+      :ok
+    end
   end
 
   @impl true

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -29,6 +29,9 @@ defmodule AshNeo4j.DataLayer do
   # Advertise the "only-update-if" guard (#361) so Ash threads `changeset.filter`
   # into update/destroy — without this, `Ash.Changeset.filter/2` silently drops it.
   def can?(_, :changeset_filter), do: true
+  # Atomic updates (#361): render `changeset.atomics` against the live node. Single
+  # record only — the bulk `update_query/4` decision point is deferred.
+  def can?(_, {:atomic, :update}), do: true
   def can?(_, :upsert), do: true
   def can?(_, :destroy), do: true
   def can?(_, :sort), do: true
@@ -391,15 +394,16 @@ defmodule AshNeo4j.DataLayer do
   end
 
   defp do_update(resource, changeset, %ResourceMapping{} = mapping) do
-    # Honour the `changeset.filter` "only-update-if" guard (#361). Refuse a guard
-    # we can't push down in full rather than apply the update unguarded (stance a).
-    case QueryHelper.guard_conditions(mapping, changeset.filter) do
-      {:error, _} = error -> error
-      {:ok, guard_conditions} -> do_update(resource, changeset, mapping, guard_conditions)
+    # Honour the `changeset.filter` "only-update-if" guard and render
+    # `changeset.atomics` against the live node (#361). Refuse anything we can't
+    # render in full rather than write unguarded / mis-write (stance a).
+    with {:ok, guard_conditions} <- QueryHelper.guard_conditions(mapping, changeset.filter),
+         {:ok, atomic_sets} <- QueryHelper.render_atomic_sets(resource, mapping, changeset.atomics || []) do
+      do_update(resource, changeset, mapping, guard_conditions, atomic_sets)
     end
   end
 
-  defp do_update(resource, changeset, %ResourceMapping{} = mapping, guard_conditions) do
+  defp do_update(resource, changeset, %ResourceMapping{} = mapping, guard_conditions, atomic_sets) do
     subject_id = id_properties(mapping, changeset.data)
     subject_label = mapping.label_pair
 
@@ -408,11 +412,16 @@ defmodule AshNeo4j.DataLayer do
     remove_property_names = stale_property_names(mapping, update_properties, changeset)
 
     guarded? = guard_conditions != []
+    {atomic_exprs, _atomic_params} = atomic_sets
 
     property_update_result =
-      if !Enum.empty?(update_properties) or !Enum.empty?(remove_property_names) or guarded? do
+      if !Enum.empty?(update_properties) or !Enum.empty?(remove_property_names) or guarded? or
+           atomic_exprs != [] do
         case subject_label
-             |> Neo4jHelper.update_node(subject_id, update_properties, remove_property_names, guard_conditions) do
+             |> Neo4jHelper.update_node(subject_id, update_properties, remove_property_names,
+               guard: guard_conditions,
+               atomics: atomic_sets
+             ) do
           # No row matched the id + guard: a present guard ⇒ the row is stale
           # (the predicate no longer holds); otherwise the id itself didn't match.
           {:ok, %Bolty.Response{results: []}} ->

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -34,6 +34,15 @@ defmodule AshNeo4j.DataLayer do
   # Bulk atomic update (#361): apply the atomics/attributes to every node matching
   # the query in one statement (`Ash.bulk_update` :atomic strategy).
   def can?(_, :update_query), do: true
+  # Bulk destroy (#361): delete every node matching the query in one statement,
+  # skipping `guard`-protected nodes ("delete what is safe").
+  def can?(_, :destroy_query), do: true
+  # Ash gates the atomic bulk-destroy strategy on :update_query AND :expr_error
+  # (#361). We don't render inline `error()` expressions — such an atomic refuses
+  # cleanly via %UnsupportedAtomic{} (stance a) rather than mis-write. NB: with
+  # full atomic support advertised, `manage_relationship` actions need
+  # `require_atomic? false` (standard Ash 3), as they can't be done atomically.
+  def can?(_, :expr_error), do: true
   def can?(_, :upsert), do: true
   def can?(_, :destroy), do: true
   def can?(_, :sort), do: true
@@ -702,6 +711,68 @@ defmodule AshNeo4j.DataLayer do
       end
     else
       :ok
+    end
+  end
+
+  @impl true
+  def destroy_query(query, changeset, resource, opts) do
+    Logger.debug("""
+    AshNeo4j.DataLayer: destroy_query(#{inspect(query)}, #{inspect(changeset)}, #{inspect(resource)})
+    """)
+
+    mapping = ResourceInfo.mapping(resource)
+
+    cond do
+      # Relationship-context destroy — hand to the per-record path (which enforces
+      # the guard as an error, the right semantics for a targeted destroy) (#361).
+      Map.has_key?(changeset.context, :accessing_from) ->
+        single_destroy_query_result(resource, changeset, opts)
+
+      true ->
+        bulk_destroy_query(query, resource, mapping, opts)
+    end
+  end
+
+  defp single_destroy_query_result(resource, changeset, opts) do
+    case destroy(resource, changeset) do
+      :ok -> if Map.get(opts, :return_records?), do: {:ok, [changeset.data]}, else: :ok
+      {:error, _} = error -> error
+    end
+  end
+
+  defp bulk_destroy_query(query, resource, mapping, opts) do
+    # Stance (a): scope must push down in full (no Elixir post-filter on a bulk
+    # delete), else refuse. `guard`-protected nodes are skipped, not deleted.
+    with {:ok, conditions} <- QueryHelper.guard_conditions(mapping, query.filter) do
+      return? = Map.get(opts, :return_records?, false)
+      guards = ResourceInfo.preserve_node_relationships(resource)
+
+      case Neo4jHelper.bulk_detach_delete(mapping.label_pair, conditions, guards, return?) do
+        {:ok, %Bolty.Response{results: results}} ->
+          if return?, do: convert_deleted_nodes(resource, results), else: :ok
+
+        {:error, error} ->
+          {:error, AshNeo4j.Error.Neo4j.from_bolt(error)}
+      end
+    end
+  end
+
+  # Rebuild records from the pre-delete node data captured in the `WITH`.
+  defp convert_deleted_nodes(resource, results) do
+    converted =
+      Enum.map(results, fn row ->
+        node = %Bolty.Types.Node{
+          id: Map.get(row, "nid"),
+          properties: Map.get(row, "props"),
+          labels: Map.get(row, "labels")
+        }
+
+        convert_node_to_resource(resource, node)
+      end)
+
+    case Enum.find(converted, &match?({:error, _}, &1)) do
+      nil -> {:ok, Enum.map(converted, fn {:ok, record} -> record end)}
+      {:error, _} = error -> error
     end
   end
 

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -26,6 +26,9 @@ defmodule AshNeo4j.DataLayer do
   def can?(_, :create), do: true
   def can?(_, :composite_primary_key), do: true
   def can?(_, :update), do: true
+  # Advertise the "only-update-if" guard (#361) so Ash threads `changeset.filter`
+  # into update/destroy — without this, `Ash.Changeset.filter/2` silently drops it.
+  def can?(_, :changeset_filter), do: true
   def can?(_, :upsert), do: true
   def can?(_, :destroy), do: true
   def can?(_, :sort), do: true
@@ -388,6 +391,15 @@ defmodule AshNeo4j.DataLayer do
   end
 
   defp do_update(resource, changeset, %ResourceMapping{} = mapping) do
+    # Honour the `changeset.filter` "only-update-if" guard (#361). Refuse a guard
+    # we can't push down in full rather than apply the update unguarded (stance a).
+    case QueryHelper.guard_conditions(mapping, changeset.filter) do
+      {:error, _} = error -> error
+      {:ok, guard_conditions} -> do_update(resource, changeset, mapping, guard_conditions)
+    end
+  end
+
+  defp do_update(resource, changeset, %ResourceMapping{} = mapping, guard_conditions) do
     subject_id = id_properties(mapping, changeset.data)
     subject_label = mapping.label_pair
 
@@ -395,11 +407,18 @@ defmodule AshNeo4j.DataLayer do
 
     remove_property_names = stale_property_names(mapping, update_properties, changeset)
 
+    guarded? = guard_conditions != []
+
     property_update_result =
-      if !Enum.empty?(update_properties) or !Enum.empty?(remove_property_names) do
-        case subject_label |> Neo4jHelper.update_node(subject_id, update_properties, remove_property_names) do
+      if !Enum.empty?(update_properties) or !Enum.empty?(remove_property_names) or guarded? do
+        case subject_label
+             |> Neo4jHelper.update_node(subject_id, update_properties, remove_property_names, guard_conditions) do
+          # No row matched the id + guard: a present guard ⇒ the row is stale
+          # (the predicate no longer holds); otherwise the id itself didn't match.
           {:ok, %Bolty.Response{results: []}} ->
-            {:error, "no result to update node"}
+            if guarded?,
+              do: {:error, Ash.Error.Changes.StaleRecord.exception(resource: resource, filter: changeset.filter)},
+              else: {:error, "no result to update node"}
 
           {:ok, %Bolty.Response{results: [node_map | _]}} ->
             node = Map.get(node_map, "n")
@@ -604,6 +623,22 @@ defmodule AshNeo4j.DataLayer do
     label = mapping.label_pair
     id_properties = id_properties(mapping, changeset.data)
 
+    # A filtered destroy (#361) is not supported yet — the guarded `destroy_query`
+    # path is deferred. Refuse rather than silently delete unguarded now that we
+    # advertise `:changeset_filter`.
+    with :ok <- refuse_destroy_filter(resource, changeset) do
+      destroy_node(resource, label, id_properties)
+    end
+  end
+
+  defp refuse_destroy_filter(_resource, %{filter: nil}), do: :ok
+  defp refuse_destroy_filter(_resource, %{filter: %Ash.Filter{expression: nil}}), do: :ok
+
+  defp refuse_destroy_filter(resource, %{filter: filter}) do
+    {:error, AshNeo4j.Error.UnsupportedChangesetFilter.exception(resource: resource, filter: filter)}
+  end
+
+  defp destroy_node(resource, label, id_properties) do
     result =
       case Neo4jHelper.safe_delete_nodes(label, id_properties, ResourceInfo.preserve_node_relationships(resource)) do
         {:ok, _} ->

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -25,6 +25,29 @@ defmodule AshNeo4j.Error.RequiresDynamicLabels do
   def message(_), do: "This operation requires dynamic labels (Neo4j ≥ 5.26)"
 end
 
+defmodule AshNeo4j.Error.UnsupportedChangesetFilter do
+  @moduledoc """
+  **Returned** (never raised) when a `changeset.filter` guard (the "only-update-if"
+  predicate) can't be honoured (#361). We refuse rather than apply the write
+  **unguarded**: silently dropping the guard would write when the predicate says
+  not to (the write-side analogue of the traverse synthesis leaks, #342).
+
+  Two cases today:
+
+    * **update** — the guard doesn't reduce to a conjunction of supported attribute
+      predicates (e.g. it contains `or`/`not`, a calculation, or a predicate the
+      pushdown doesn't cover). Narrow it, or do the conditional update outside the
+      data layer.
+    * **destroy** — a filtered destroy is not supported yet (the `destroy_query`
+      decision point is deferred); the whole guard is refused.
+  """
+  use Splode.Error, fields: [:resource, :filter], class: :invalid
+
+  def message(%{resource: resource, filter: filter}) do
+    "cannot honour the changeset filter guard on #{inspect(resource)} (#{inspect(filter)})"
+  end
+end
+
 defmodule AshNeo4j.Error.GeoDimensionMismatch do
   @moduledoc """
   Returned (never raised) when a spatial operation combines geometries of

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -51,12 +51,12 @@ end
 defmodule AshNeo4j.Error.UnsupportedAtomic do
   @moduledoc """
   **Returned** (never raised) when a `changeset.atomics` expression can't be
-  rendered into the update Cypher `SET` (#361). The numeric-first cut renders
-  arithmetic (`+ - * /`), comparisons, `if/3` (⇒ `CASE`), attribute refs and
-  scalar literals; anything else — notably string/atom atomics that Ash wraps in
-  cast calls (`string_trim/…`) — is refused rather than mis-written.
+  rendered into the update Cypher `SET` (#361). The renderer covers arithmetic
+  (`+ - * /`), comparisons, `if/3` (⇒ `CASE`), string concat / `string_trim`
+  (Ash's string cast), attribute refs and scalar literals; an expression using any
+  other Ash function is refused rather than mis-written.
 
-  Express the change as a numeric atomic, or perform it outside the data layer.
+  Express the change with supported operations, or perform it outside the data layer.
   """
   use Splode.Error, fields: [:resource, :expression], class: :invalid
 

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -48,6 +48,23 @@ defmodule AshNeo4j.Error.UnsupportedChangesetFilter do
   end
 end
 
+defmodule AshNeo4j.Error.UnsupportedAtomic do
+  @moduledoc """
+  **Returned** (never raised) when a `changeset.atomics` expression can't be
+  rendered into the update Cypher `SET` (#361). The numeric-first cut renders
+  arithmetic (`+ - * /`), comparisons, `if/3` (⇒ `CASE`), attribute refs and
+  scalar literals; anything else — notably string/atom atomics that Ash wraps in
+  cast calls (`string_trim/…`) — is refused rather than mis-written.
+
+  Express the change as a numeric atomic, or perform it outside the data layer.
+  """
+  use Splode.Error, fields: [:resource, :expression], class: :invalid
+
+  def message(%{resource: resource, expression: expression}) do
+    "cannot render atomic update on #{inspect(resource)} into Cypher (#{inspect(expression)})"
+  end
+end
+
 defmodule AshNeo4j.Error.GeoDimensionMismatch do
   @moduledoc """
   Returned (never raised) when a spatial operation combines geometries of

--- a/lib/neo4j_helper.ex
+++ b/lib/neo4j_helper.ex
@@ -89,6 +89,28 @@ defmodule AshNeo4j.Neo4jHelper do
   end
 
   @doc """
+  Single filtered + guarded destroy (#361): deletes the `id`-matched node when it
+  satisfies `filter_conditions` (optimistic lock) and isn't `guard`-protected.
+  `{:ok, _}` when deleted, `{:error, "nothing deleted"}` otherwise.
+  """
+  def delete_node_filtered(label, id_props, filter_conditions, guards)
+      when (is_atom(label) or is_list(label)) and is_map(id_props) and is_list(filter_conditions) and
+             is_list(guards) do
+    Query.delete_node_filtered(label, id_props, filter_conditions, guards)
+    |> Cypher.run_expecting_deletions()
+  end
+
+  @doc """
+  The optimistic-lock existence check (#361): does the `id`-matched node satisfy
+  `filter_conditions`? Returns `{:ok, %Bolty.Response{}}`.
+  """
+  def node_matching(label, id_props, filter_conditions)
+      when (is_atom(label) or is_list(label)) and is_map(id_props) and is_list(filter_conditions) do
+    Query.node_matching(label, id_props, filter_conditions)
+    |> Cypher.run()
+  end
+
+  @doc """
   Bulk destroy (#361): deletes every node of `label` matching `conditions` that
   isn't protected by a preservation `guard`. Returns `{:ok, %Bolty.Response{}}` —
   with captured pre-delete node data when `return?`.

--- a/lib/neo4j_helper.ex
+++ b/lib/neo4j_helper.ex
@@ -88,6 +88,18 @@ defmodule AshNeo4j.Neo4jHelper do
     |> Cypher.run_expecting_deletions()
   end
 
+  @doc """
+  Bulk destroy (#361): deletes every node of `label` matching `conditions` that
+  isn't protected by a preservation `guard`. Returns `{:ok, %Bolty.Response{}}` —
+  with captured pre-delete node data when `return?`.
+  """
+  def bulk_detach_delete(label, conditions, guards, return?)
+      when (is_atom(label) or is_list(label)) and is_list(conditions) and is_list(guards) and
+             is_boolean(return?) do
+    Query.bulk_detach_delete(label, conditions, guards, return?)
+    |> Cypher.run()
+  end
+
   @spec merge_node(atom(), map()) ::
           {:error, %{:__exception__ => true, :__struct__ => atom(), optional(atom()) => any()}}
           | {:ok, any()}

--- a/lib/neo4j_helper.ex
+++ b/lib/neo4j_helper.ex
@@ -120,9 +120,9 @@ defmodule AshNeo4j.Neo4jHelper do
   :ok
   ```
   """
-  def update_node(label, match_properties, set_properties, remove_properties \\ [])
-      when (is_atom(label) or is_list(label)) and is_map(set_properties) do
-    Query.update_node(label, match_properties, set_properties, remove_properties)
+  def update_node(label, match_properties, set_properties, remove_properties \\ [], guard_conditions \\ [])
+      when (is_atom(label) or is_list(label)) and is_map(set_properties) and is_list(guard_conditions) do
+    Query.update_node(label, match_properties, set_properties, remove_properties, guard_conditions)
     |> Cypher.run()
   end
 

--- a/lib/neo4j_helper.ex
+++ b/lib/neo4j_helper.ex
@@ -120,9 +120,9 @@ defmodule AshNeo4j.Neo4jHelper do
   :ok
   ```
   """
-  def update_node(label, match_properties, set_properties, remove_properties \\ [], guard_conditions \\ [])
-      when (is_atom(label) or is_list(label)) and is_map(set_properties) and is_list(guard_conditions) do
-    Query.update_node(label, match_properties, set_properties, remove_properties, guard_conditions)
+  def update_node(label, match_properties, set_properties, remove_properties \\ [], opts \\ [])
+      when (is_atom(label) or is_list(label)) and is_map(set_properties) and is_list(opts) do
+    Query.update_node(label, match_properties, set_properties, remove_properties, opts)
     |> Cypher.run()
   end
 

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -586,11 +586,11 @@ defmodule AshNeo4j.QueryHelper do
   `{:error, %AshNeo4j.Error.UnsupportedAtomic{}}` when an expression can't be
   rendered.
 
-  Numeric-first cut: arithmetic (`+ - * /`), comparisons, `if/3` (⇒ `CASE`),
-  attribute refs (`n.<prop>`) and scalar literals (bound as params). Anything else
-  — notably string/atom atomics Ash wraps in cast calls — is refused rather than
-  mis-written (stance a). Param keys are `am_`-prefixed and threaded across all
-  atomics so they stay unique.
+  Renders: arithmetic (`+ - * /`), comparisons, `if/3` (⇒ `CASE`), string concat
+  (`<>` ⇒ `+`) and `string_trim` (⇒ `trim`, Ash's string cast), attribute refs
+  (`n.<prop>`) and scalar literals (bound as params). An expression node it doesn't
+  cover (e.g. another Ash function) is refused rather than mis-written (stance a).
+  Param keys are `am_`-prefixed and threaded across all atomics so they stay unique.
   """
   @spec render_atomic_sets(module(), ResourceMapping.t(), keyword()) ::
           {:ok, {[binary()], map()}} | {:error, struct()}
@@ -629,6 +629,21 @@ defmodule AshNeo4j.QueryHelper do
          {:ok, t, params} <- render_atomic_node(mapping, then, params),
          {:ok, e, params} <- render_atomic_else(mapping, rest, params) do
       {:ok, "CASE WHEN #{c} THEN #{t} ELSE #{e} END", params}
+    end
+  end
+
+  # String atomics: Ash casts them as `if trim(expr) == "" then null else trim(expr)`
+  # (empty-string ⇒ nil). `string_trim/1` ⇒ Cypher `trim/1`, and string `<>` ⇒ `+`.
+  defp render_atomic_node(mapping, %Ash.Query.Function.StringTrim{arguments: [inner]}, params) do
+    with {:ok, s, params} <- render_atomic_node(mapping, inner, params) do
+      {:ok, "trim(#{s})", params}
+    end
+  end
+
+  defp render_atomic_node(mapping, %Ash.Query.Operator.Basic.Concat{left: left, right: right}, params) do
+    with {:ok, l, params} <- render_atomic_node(mapping, left, params),
+         {:ok, r, params} <- render_atomic_node(mapping, right, params) do
+      {:ok, "(#{l} + #{r})", params}
     end
   end
 

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -579,6 +579,78 @@ defmodule AshNeo4j.QueryHelper do
     AshNeo4j.Error.UnsupportedChangesetFilter.exception(resource: module, filter: filter)
   end
 
+  @doc """
+  Renders `changeset.atomics` (a keyword of `{field, Ash.Expr}`, #361) into
+  `{:ok, {set_expressions, params}}` for the update `SET`, where each entry is
+  `"n.<prop> = <cypher>"` evaluated against the **live** node — or
+  `{:error, %AshNeo4j.Error.UnsupportedAtomic{}}` when an expression can't be
+  rendered.
+
+  Numeric-first cut: arithmetic (`+ - * /`), comparisons, `if/3` (⇒ `CASE`),
+  attribute refs (`n.<prop>`) and scalar literals (bound as params). Anything else
+  — notably string/atom atomics Ash wraps in cast calls — is refused rather than
+  mis-written (stance a). Param keys are `am_`-prefixed and threaded across all
+  atomics so they stay unique.
+  """
+  @spec render_atomic_sets(module(), ResourceMapping.t(), keyword()) ::
+          {:ok, {[binary()], map()}} | {:error, struct()}
+  def render_atomic_sets(_resource, %ResourceMapping{}, []), do: {:ok, {[], %{}}}
+
+  def render_atomic_sets(resource, %ResourceMapping{module: module} = mapping, atomics) do
+    Enum.reduce_while(atomics, {:ok, {[], %{}}}, fn {field, expr}, {:ok, {sets, params}} ->
+      with {:ok, hydrated} <- Ash.Filter.hydrate_refs(expr, %{resource: resource, public?: false}),
+           {:ok, cypher, params} <- render_atomic_node(mapping, hydrated, params) do
+        {:cont, {:ok, {sets ++ ["n.#{property_name(mapping, field)} = #{cypher}"], params}}}
+      else
+        _ -> {:halt, {:error, AshNeo4j.Error.UnsupportedAtomic.exception(resource: module, expression: expr)}}
+      end
+    end)
+  end
+
+  # `+ - * /` (parenthesised) and comparisons, dispatched on the `:operator` atom.
+  @atomic_binary_ops %{
+    +: "+",
+    -: "-",
+    *: "*",
+    /: "/",
+    >: ">",
+    >=: ">=",
+    <: "<",
+    <=: "<=",
+    ==: "=",
+    !=: "<>"
+  }
+
+  defp render_atomic_node(mapping, %Ash.Query.Ref{} = ref, params),
+    do: {:ok, "n.#{property_name(mapping, ref)}", params}
+
+  defp render_atomic_node(mapping, %Ash.Query.Function.If{arguments: [condition, then | rest]}, params) do
+    with {:ok, c, params} <- render_atomic_node(mapping, condition, params),
+         {:ok, t, params} <- render_atomic_node(mapping, then, params),
+         {:ok, e, params} <- render_atomic_else(mapping, rest, params) do
+      {:ok, "CASE WHEN #{c} THEN #{t} ELSE #{e} END", params}
+    end
+  end
+
+  defp render_atomic_node(mapping, %{operator: op, left: left, right: right}, params)
+       when is_map_key(@atomic_binary_ops, op) do
+    with {:ok, l, params} <- render_atomic_node(mapping, left, params),
+         {:ok, r, params} <- render_atomic_node(mapping, right, params) do
+      {:ok, "(#{l} #{@atomic_binary_ops[op]} #{r})", params}
+    end
+  end
+
+  defp render_atomic_node(_mapping, literal, params)
+       when is_number(literal) or is_binary(literal) or is_boolean(literal) or is_nil(literal) do
+    key = "am_#{map_size(params)}"
+    {:ok, "$#{key}", Map.put(params, key, literal)}
+  end
+
+  defp render_atomic_node(_mapping, other, _params), do: {:error, other}
+
+  defp render_atomic_else(_mapping, [], params), do: {:ok, "null", params}
+  defp render_atomic_else(mapping, [else_], params), do: render_atomic_node(mapping, else_, params)
+
   # True when the filter is an `and`-only tree of leaf predicates — no `or`/`not`,
   # so `to_simple_filter`'s flattened predicate list represents it faithfully.
   defp simple_conjunction?(%Ash.Filter{expression: expression}), do: simple_conjunction?(expression)

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -588,9 +588,11 @@ defmodule AshNeo4j.QueryHelper do
 
   Renders: arithmetic (`+ - * /`), comparisons, `if/3` (⇒ `CASE`), string concat
   (`<>` ⇒ `+`) and `string_trim` (⇒ `trim`, Ash's string cast), attribute refs
-  (`n.<prop>`) and scalar literals (bound as params). An expression node it doesn't
-  cover (e.g. another Ash function) is refused rather than mis-written (stance a).
-  Param keys are `am_`-prefixed and threaded across all atomics so they stay unique.
+  (`n.<prop>`) and scalar literals — numbers/strings/booleans/nil, and atoms (e.g.
+  `Ash.Type.Atom` enum values) bound as their stored string form. An expression
+  node it doesn't cover (e.g. another Ash function) is refused rather than
+  mis-written (stance a). Param keys are `am_`-prefixed and threaded across all
+  atomics so they stay unique.
   """
   @spec render_atomic_sets(module(), ResourceMapping.t(), keyword()) ::
           {:ok, {[binary()], map()}} | {:error, struct()}
@@ -653,6 +655,14 @@ defmodule AshNeo4j.QueryHelper do
          {:ok, r, params} <- render_atomic_node(mapping, right, params) do
       {:ok, "(#{l} #{@atomic_binary_ops[op]} #{r})", params}
     end
+  end
+
+  # Atom literal (e.g. an `Ash.Type.Atom` enum value) — stored as its string form,
+  # matching how the data layer writes atom attributes (Neo4j has no atom type).
+  defp render_atomic_node(_mapping, atom, params)
+       when is_atom(atom) and atom not in [nil, true, false] do
+    key = "am_#{map_size(params)}"
+    {:ok, "$#{key}", Map.put(params, key, Atom.to_string(atom))}
   end
 
   defp render_atomic_node(_mapping, literal, params)

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -541,6 +541,60 @@ defmodule AshNeo4j.QueryHelper do
     end
   end
 
+  @doc """
+  Renders an update's `changeset.filter` guard (the "only-update-if" predicate,
+  #361) to `{:ok, conditions}` for the update `WHERE`, or
+  `{:error, %AshNeo4j.Error.UnsupportedUpdateFilter{}}` when it can't be rendered
+  **in full**.
+
+  Stance: never under-guard. The guard is only pushed down when the filter is a
+  conjunction (`and`-only — no `or`/`not`) of supported attribute predicates that
+  each render; a calculation ref or any predicate the pushdown drops makes the
+  whole guard unsupported, so the data layer returns rather than applies the
+  update unguarded. `nil` (no guard) is `{:ok, []}`.
+  """
+  @spec guard_conditions(ResourceMapping.t(), Ash.Filter.t() | nil) ::
+          {:ok, list()} | {:error, struct()}
+  def guard_conditions(%ResourceMapping{}, nil), do: {:ok, []}
+
+  def guard_conditions(%ResourceMapping{module: module} = mapping, filter) do
+    predicates =
+      filter
+      |> Ash.Filter.to_simple_filter(skip_invalid?: true)
+      |> Map.get(:predicates, [])
+
+    if simple_conjunction?(filter) and predicates != [] and not Enum.any?(predicates, &calculation_ref?/1) do
+      case to_conditions(mapping, predicates) do
+        # Every predicate rendered — a `nil` (unhandled) drop shortens the list.
+        {:ok, conditions} when length(conditions) == length(predicates) -> {:ok, conditions}
+        {:ok, _partial} -> {:error, unsupported_changeset_filter(module, filter)}
+        {:error, _} = error -> error
+      end
+    else
+      {:error, unsupported_changeset_filter(module, filter)}
+    end
+  end
+
+  defp unsupported_changeset_filter(module, filter) do
+    AshNeo4j.Error.UnsupportedChangesetFilter.exception(resource: module, filter: filter)
+  end
+
+  # True when the filter is an `and`-only tree of leaf predicates — no `or`/`not`,
+  # so `to_simple_filter`'s flattened predicate list represents it faithfully.
+  defp simple_conjunction?(%Ash.Filter{expression: expression}), do: simple_conjunction?(expression)
+  defp simple_conjunction?(nil), do: true
+
+  defp simple_conjunction?(%Ash.Query.BooleanExpression{op: :and, left: left, right: right}),
+    do: simple_conjunction?(left) and simple_conjunction?(right)
+
+  defp simple_conjunction?(%Ash.Query.BooleanExpression{op: :or}), do: false
+  defp simple_conjunction?(%Ash.Query.Not{}), do: false
+  defp simple_conjunction?(_leaf), do: true
+
+  defp calculation_ref?(predicate) do
+    match?(%Ash.Query.Ref{attribute: %Ash.Query.Calculation{}}, Map.get(predicate, :left))
+  end
+
   defp to_conditions(%ResourceMapping{} = mapping, predicates) do
     predicates
     |> Enum.map(fn

--- a/test/atomic_update_guard_test.exs
+++ b/test/atomic_update_guard_test.exs
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.AtomicUpdateGuardTest do
+  @moduledoc """
+  The `changeset.filter` "only-update-if" guard (#361). An update applies only to a
+  row still matching the filter; a miss returns `Ash.Error.Changes.StaleRecord`
+  rather than silently writing. A guard that can't be pushed down in full is
+  refused with `AshNeo4j.Error.UnsupportedUpdateFilter` — never applied unguarded.
+  """
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Error.UnsupportedChangesetFilter
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.ThingNote
+
+  use ExUnit.Case, async: false
+
+  require Ash.Expr
+
+  setup_all do
+    BoltyHelper.start()
+    :ok
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  defp flatten(%{errors: errors}) when is_list(errors), do: Enum.flat_map(errors, &flatten/1)
+  defp flatten(e), do: [e]
+
+  defp guarded_update(note, attrs, guard) do
+    note
+    |> Ash.Changeset.for_update(:update, attrs)
+    |> Ash.Changeset.filter(guard)
+    |> Ash.update()
+  end
+
+  test "a guard that still holds applies the update" do
+    note = ThingNote |> Ash.create!(%{body: "draft"})
+
+    assert {:ok, updated} = guarded_update(note, %{body: "active"}, Ash.Expr.expr(body == "draft"))
+    assert updated.body == "active"
+  end
+
+  test "a guard that no longer holds returns StaleRecord, not a silent write" do
+    note = ThingNote |> Ash.create!(%{body: "draft"})
+    {:ok, active} = guarded_update(note, %{body: "active"}, Ash.Expr.expr(body == "draft"))
+
+    # `active` is now body: "active"; the same draft guard must miss.
+    assert {:error, error} = guarded_update(active, %{body: "archived"}, Ash.Expr.expr(body == "draft"))
+    assert Enum.any?(flatten(error), &match?(%Ash.Error.Changes.StaleRecord{}, &1))
+
+    # The row was not written.
+    assert ThingNote |> Ash.get!(active.id) |> Map.get(:body) == "active"
+  end
+
+  test "a conjunction of supported predicates pushes down" do
+    note = ThingNote |> Ash.create!(%{body: "draft"})
+
+    guard = Ash.Expr.expr(body == "draft" and id == ^note.id)
+    assert {:ok, updated} = guarded_update(note, %{body: "active"}, guard)
+    assert updated.body == "active"
+  end
+
+  test "an un-pushable guard (or) is refused, not applied unguarded" do
+    note = ThingNote |> Ash.create!(%{body: "draft"})
+
+    guard = Ash.Expr.expr(body == "draft" or body == "review")
+    assert {:error, error} = guarded_update(note, %{body: "active"}, guard)
+    assert Enum.any?(flatten(error), &match?(%UnsupportedChangesetFilter{}, &1))
+
+    # Refused, so the row is unchanged.
+    assert ThingNote |> Ash.get!(note.id) |> Map.get(:body) == "draft"
+  end
+
+  test "a filtered destroy is refused, not silently deleted unguarded" do
+    note = ThingNote |> Ash.create!(%{body: "draft"})
+
+    result =
+      note
+      |> Ash.Changeset.for_destroy(:destroy)
+      |> Ash.Changeset.filter(Ash.Expr.expr(body == "review"))
+      |> Ash.destroy()
+
+    assert {:error, error} = result
+    assert Enum.any?(flatten(error), &match?(%UnsupportedChangesetFilter{}, &1))
+
+    # The guard didn't hold (body is "draft", not "review") and the destroy was
+    # refused — so the row must still exist rather than have been deleted unguarded.
+    assert ThingNote |> Ash.get!(note.id) |> Map.get(:body) == "draft"
+  end
+end

--- a/test/atomic_update_guard_test.exs
+++ b/test/atomic_update_guard_test.exs
@@ -76,7 +76,7 @@ defmodule AshNeo4j.AtomicUpdateGuardTest do
     assert ThingNote |> Ash.get!(note.id) |> Map.get(:body) == "draft"
   end
 
-  test "a filtered destroy is refused, not silently deleted unguarded" do
+  test "a filtered destroy whose lock no longer holds returns StaleRecord, not a delete" do
     note = ThingNote |> Ash.create!(%{body: "draft"})
 
     result =
@@ -86,10 +86,35 @@ defmodule AshNeo4j.AtomicUpdateGuardTest do
       |> Ash.destroy()
 
     assert {:error, error} = result
-    assert Enum.any?(flatten(error), &match?(%UnsupportedChangesetFilter{}, &1))
+    assert Enum.any?(flatten(error), &match?(%Ash.Error.Changes.StaleRecord{}, &1))
 
-    # The guard didn't hold (body is "draft", not "review") and the destroy was
-    # refused — so the row must still exist rather than have been deleted unguarded.
+    # The optimistic lock missed (body is "draft", not "review") — row preserved.
+    assert ThingNote |> Ash.get!(note.id) |> Map.get(:body) == "draft"
+  end
+
+  test "a filtered destroy whose lock holds deletes the row" do
+    note = ThingNote |> Ash.create!(%{body: "draft"})
+
+    assert :ok =
+             note
+             |> Ash.Changeset.for_destroy(:destroy)
+             |> Ash.Changeset.filter(Ash.Expr.expr(body == "draft"))
+             |> Ash.destroy()
+
+    assert {:error, _} = ThingNote |> Ash.get(note.id)
+  end
+
+  test "an un-pushable destroy filter is refused, not applied unguarded" do
+    note = ThingNote |> Ash.create!(%{body: "draft"})
+
+    result =
+      note
+      |> Ash.Changeset.for_destroy(:destroy)
+      |> Ash.Changeset.filter(Ash.Expr.expr(body == "draft" or body == "review"))
+      |> Ash.destroy()
+
+    assert {:error, error} = result
+    assert Enum.any?(flatten(error), &match?(%UnsupportedChangesetFilter{}, &1))
     assert ThingNote |> Ash.get!(note.id) |> Map.get(:body) == "draft"
   end
 end

--- a/test/atomic_update_test.exs
+++ b/test/atomic_update_test.exs
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.AtomicUpdateTest do
+  @moduledoc """
+  Atomic updates (#361): `changeset.atomics` are evaluated against the live node in
+  a single `SET`, no read-decide-in-Elixir round-trip. Numeric-first cut —
+  arithmetic and `if/3 ⇒ CASE`. An atomic we can't render is refused with
+  `AshNeo4j.Error.UnsupportedAtomic` rather than mis-written.
+  """
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Error.UnsupportedAtomic
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.Comment
+
+  use ExUnit.Case, async: false
+
+  require Ash.Expr
+
+  setup_all do
+    BoltyHelper.start()
+    :ok
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  defp flatten(%{errors: errors}) when is_list(errors), do: Enum.flat_map(errors, &flatten/1)
+  defp flatten(e), do: [e]
+
+  defp atomic(comment, field, expr) do
+    comment
+    |> Ash.Changeset.for_update(:update, %{})
+    |> Ash.Changeset.atomic_update(field, expr)
+    |> Ash.update()
+  end
+
+  test "an arithmetic atomic increments against the live value" do
+    comment = Comment |> Ash.create!(%{title: "t", score: 1})
+
+    assert {:ok, updated} = atomic(comment, :score, Ash.Expr.expr(score + 1))
+    assert updated.score == 2
+  end
+
+  test "an if/3 atomic renders to CASE and decrements only when positive" do
+    comment = Comment |> Ash.create!(%{title: "t", score: 1})
+    expr = Ash.Expr.expr(if score > 0, do: score - 1, else: 0)
+
+    assert {:ok, once} = atomic(comment, :score, expr)
+    assert once.score == 0
+
+    assert {:ok, twice} = atomic(once, :score, expr)
+    assert twice.score == 0
+  end
+
+  test "an atomic combines with a changeset.filter guard" do
+    comment = Comment |> Ash.create!(%{title: "t", score: 5})
+
+    result =
+      comment
+      |> Ash.Changeset.for_update(:update, %{})
+      |> Ash.Changeset.atomic_update(:score, Ash.Expr.expr(score + 1))
+      |> Ash.Changeset.filter(Ash.Expr.expr(score == 5))
+      |> Ash.update()
+
+    assert {:ok, updated} = result
+    assert updated.score == 6
+
+    # The same guard now misses (score is 6) ⇒ StaleRecord, no write.
+    stale =
+      updated
+      |> Ash.Changeset.for_update(:update, %{})
+      |> Ash.Changeset.atomic_update(:score, Ash.Expr.expr(score + 1))
+      |> Ash.Changeset.filter(Ash.Expr.expr(score == 5))
+      |> Ash.update()
+
+    assert {:error, error} = stale
+    assert Enum.any?(flatten(error), &match?(%Ash.Error.Changes.StaleRecord{}, &1))
+    assert Comment |> Ash.get!(updated.id) |> Map.get(:score) == 6
+  end
+
+  test "an unrenderable (string) atomic is refused, not mis-written" do
+    comment = Comment |> Ash.create!(%{title: "draft", score: 1})
+
+    assert {:error, error} = atomic(comment, :title, Ash.Expr.expr(title <> "!"))
+    assert Enum.any?(flatten(error), &match?(%UnsupportedAtomic{}, &1))
+    assert Comment |> Ash.get!(comment.id) |> Map.get(:title) == "draft"
+  end
+end

--- a/test/atomic_update_test.exs
+++ b/test/atomic_update_test.exs
@@ -13,6 +13,7 @@ defmodule AshNeo4j.AtomicUpdateTest do
   alias AshNeo4j.Error.UnsupportedAtomic
   alias AshNeo4j.Sandbox
   alias AshNeo4j.Test.Resource.Comment
+  alias AshNeo4j.Test.Resource.Specification
 
   use ExUnit.Case, async: false
 
@@ -95,6 +96,19 @@ defmodule AshNeo4j.AtomicUpdateTest do
 
     assert {:ok, updated} = atomic(comment, :title, expr)
     assert updated.title == "active"
+  end
+
+  test "an atom (enum) if/3 atomic renders to CASE and transitions against the live value" do
+    spec = Specification |> Ash.create!(%{type: :service})
+    expr = Ash.Expr.expr(if type == :service, do: :resource, else: type)
+
+    assert {:ok, updated} = atomic(spec, :type, expr)
+    assert updated.type == :resource
+
+    # Re-running is a no-op: the live value is now :resource, so the else branch
+    # preserves it (the atom round-trips through its stored string form).
+    assert {:ok, again} = atomic(updated, :type, expr)
+    assert again.type == :resource
   end
 
   test "an atomic using an unsupported function is refused, not mis-written" do

--- a/test/atomic_update_test.exs
+++ b/test/atomic_update_test.exs
@@ -5,9 +5,9 @@
 defmodule AshNeo4j.AtomicUpdateTest do
   @moduledoc """
   Atomic updates (#361): `changeset.atomics` are evaluated against the live node in
-  a single `SET`, no read-decide-in-Elixir round-trip. Numeric-first cut —
-  arithmetic and `if/3 ⇒ CASE`. An atomic we can't render is refused with
-  `AshNeo4j.Error.UnsupportedAtomic` rather than mis-written.
+  a single `SET`, no read-decide-in-Elixir round-trip. Renders arithmetic,
+  string concat/`trim` (Ash's string cast), and `if/3 ⇒ CASE`. An atomic we can't
+  render is refused with `AshNeo4j.Error.UnsupportedAtomic` rather than mis-written.
   """
   alias AshNeo4j.BoltyHelper
   alias AshNeo4j.Error.UnsupportedAtomic
@@ -82,11 +82,26 @@ defmodule AshNeo4j.AtomicUpdateTest do
     assert Comment |> Ash.get!(updated.id) |> Map.get(:score) == 6
   end
 
-  test "an unrenderable (string) atomic is refused, not mis-written" do
+  test "a string-concat atomic renders (Ash's trim/empty-⇒-nil cast)" do
     comment = Comment |> Ash.create!(%{title: "draft", score: 1})
 
-    assert {:error, error} = atomic(comment, :title, Ash.Expr.expr(title <> "!"))
+    assert {:ok, updated} = atomic(comment, :title, Ash.Expr.expr(title <> "!"))
+    assert updated.title == "draft!"
+  end
+
+  test "a string if/3 atomic renders to CASE against the live value" do
+    comment = Comment |> Ash.create!(%{title: "draft", score: 1})
+    expr = Ash.Expr.expr(if title == "draft", do: "active", else: title)
+
+    assert {:ok, updated} = atomic(comment, :title, expr)
+    assert updated.title == "active"
+  end
+
+  test "an atomic using an unsupported function is refused, not mis-written" do
+    comment = Comment |> Ash.create!(%{title: "Draft", score: 1})
+
+    assert {:error, error} = atomic(comment, :title, Ash.Expr.expr(string_downcase(title)))
     assert Enum.any?(flatten(error), &match?(%UnsupportedAtomic{}, &1))
-    assert Comment |> Ash.get!(comment.id) |> Map.get(:title) == "draft"
+    assert Comment |> Ash.get!(comment.id) |> Map.get(:title) == "Draft"
   end
 end

--- a/test/bulk_atomic_update_test.exs
+++ b/test/bulk_atomic_update_test.exs
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.BulkAtomicUpdateTest do
+  @moduledoc """
+  Bulk atomic update (#361): `Ash.bulk_update` with the `:atomic` strategy applies
+  the action's `changeset.atomics` to every node matching the query in a single
+  `MATCH (n:L) WHERE <query filter> SET … RETURN n` — via `update_query/4`.
+  """
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.Comment
+
+  use ExUnit.Case, async: false
+
+  require Ash.Query
+
+  setup_all do
+    BoltyHelper.start()
+    :ok
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  test "increments score atomically for every node matching the query filter" do
+    for score <- [1, 5, 50, 200], do: Comment |> Ash.create!(%{title: "t", score: score})
+
+    result =
+      Comment
+      |> Ash.Query.filter(score < 100)
+      |> Ash.bulk_update!(:increment_score, %{},
+        strategy: :atomic,
+        return_records?: true,
+        return_errors?: true
+      )
+
+    assert result.status == :success
+    assert result.records |> Enum.map(& &1.score) |> Enum.sort() == [2, 6, 51]
+
+    # The out-of-scope node (200) is untouched.
+    assert Comment |> Ash.Query.filter(score == 200) |> Ash.read_one!() |> Map.get(:score) == 200
+  end
+
+  test "an unfiltered bulk atomic update touches every node of the label" do
+    for score <- [10, 20, 30], do: Comment |> Ash.create!(%{title: "t", score: score})
+
+    result =
+      Comment
+      |> Ash.bulk_update!(:increment_score, %{}, strategy: :atomic, return_records?: true)
+
+    assert result.records |> Enum.map(& &1.score) |> Enum.sort() == [11, 21, 31]
+  end
+end

--- a/test/bulk_destroy_test.exs
+++ b/test/bulk_destroy_test.exs
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.BulkDestroyTest do
+  @moduledoc """
+  Bulk destroy (#361): `Ash.bulk_destroy` with the `:atomic` strategy deletes every
+  node matching the query in one `MATCH (n:L) WHERE <filter> DETACH DELETE n` — via
+  `destroy_query/4`. A `guard`-protected node is skipped, not deleted ("delete what
+  is safe"); single targeted destroys keep erroring on a guard (separate path).
+  """
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.Comment
+  alias AshNeo4j.Test.Resource.Specification
+
+  use ExUnit.Case, async: false
+
+  require Ash.Query
+
+  setup_all do
+    BoltyHelper.start()
+    :ok
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  test "deletes exactly the nodes matching the query filter, returning them" do
+    for score <- [1, 5, 50, 200], do: Comment |> Ash.create!(%{title: "t", score: score})
+
+    result =
+      Comment
+      |> Ash.Query.filter(score < 100)
+      |> Ash.bulk_destroy!(:destroy, %{}, strategy: :atomic, return_records?: true, return_errors?: true)
+
+    assert result.status == :success
+    assert result.records |> Enum.map(& &1.score) |> Enum.sort() == [1, 5, 50]
+
+    # Only the out-of-scope node survives.
+    assert Comment |> Ash.read!() |> Enum.map(& &1.score) == [200]
+  end
+
+  test "skips a guard-protected node and deletes the rest" do
+    free = Specification |> Ash.create!(%{type: :service})
+    guarded = Specification |> Ash.create!(%{type: :resource})
+
+    # `Specification` guards `SPECIFIES -> :Service`: a spec that specifies a
+    # service must not be deleted. Seed that edge on `guarded` only.
+    Sandbox.run(
+      "MATCH (n:SRM:Specification {uuid: $id}) CREATE (n)-[:SPECIFIES]->(:Service)",
+      %{"id" => guarded.id}
+    )
+
+    result = Ash.bulk_destroy!(Specification, :destroy, %{}, strategy: :atomic, return_records?: true)
+
+    assert result.records |> Enum.map(& &1.id) == [free.id]
+
+    # The guarded spec survives; the free one is gone.
+    assert Specification |> Ash.read!() |> Enum.map(& &1.id) == [guarded.id]
+  end
+end

--- a/test/bulk_destroy_test.exs
+++ b/test/bulk_destroy_test.exs
@@ -17,6 +17,7 @@ defmodule AshNeo4j.BulkDestroyTest do
   use ExUnit.Case, async: false
 
   require Ash.Query
+  require Ash.Expr
 
   setup_all do
     BoltyHelper.start()
@@ -59,6 +60,25 @@ defmodule AshNeo4j.BulkDestroyTest do
     assert result.records |> Enum.map(& &1.id) == [free.id]
 
     # The guarded spec survives; the free one is gone.
+    assert Specification |> Ash.read!() |> Enum.map(& &1.id) == [guarded.id]
+  end
+
+  test "a single filtered destroy distinguishes a guard (Unavailable) from a stale lock" do
+    guarded = Specification |> Ash.create!(%{type: :service})
+
+    Sandbox.run(
+      "MATCH (n:SRM:Specification {uuid: $id}) CREATE (n)-[:SPECIFIES]->(:Service)",
+      %{"id" => guarded.id}
+    )
+
+    # Lock holds (type == :service) but the node is guarded ⇒ Unavailable, not Stale.
+    assert {:error, error} =
+             guarded
+             |> Ash.Changeset.for_destroy(:destroy)
+             |> Ash.Changeset.filter(Ash.Expr.expr(type == :service))
+             |> Ash.destroy()
+
+    assert Enum.any?(List.wrap(error.errors), &match?(%Ash.Error.Invalid.Unavailable{}, &1))
     assert Specification |> Ash.read!() |> Enum.map(& &1.id) == [guarded.id]
   end
 end

--- a/test/support/resource/chain.ex
+++ b/test/support/resource/chain.ex
@@ -36,6 +36,7 @@ defmodule AshNeo4j.Test.Resource.Chain do
 
     update :update do
       primary? true
+      require_atomic? false
       accept [:name]
       argument :head_id, :uuid
       argument :tail_id, :uuid

--- a/test/support/resource/comment.ex
+++ b/test/support/resource/comment.ex
@@ -21,6 +21,11 @@ defmodule AshNeo4j.Test.Resource.Comment do
     update :update do
       primary? true
     end
+
+    update :increment_score do
+      require_atomic? true
+      change atomic_update(:score, expr(score + 1))
+    end
   end
 
   attributes do

--- a/test/support/resource/state_machine.ex
+++ b/test/support/resource/state_machine.ex
@@ -28,10 +28,12 @@ defmodule AshNeo4j.Test.Resource.StateMachine do
     end
 
     update :start do
+      require_atomic? false
       change transition_state(:started)
     end
 
     update :stop do
+      require_atomic? false
       change transition_state(:stopped)
     end
   end


### PR DESCRIPTION
Closes #361. Atomic update support — the conditional-write substrate (split out of #340). 7 commits, each journaled on the issue.

## What's here
**The `changeset.filter` guard (only-update/destroy-if):**
- `can?(:changeset_filter)` — the real fix: without it Ash silently dropped the guard, so `optimistic_lock` was a no-op on this data layer.
- Update: `MATCH (n {id}) WHERE <filter> SET …`; zero rows ⇒ `Ash.Error.Changes.StaleRecord`.
- Destroy: `MATCH (n {id}) WHERE <filter> AND NOT <guard…> DETACH DELETE n`; zero rows disambiguated into `Unavailable` (guard) vs `StaleRecord` (lock miss).

**Atomics — `changeset.atomics` rendered against the live node:**
- `can?({:atomic, :update})` + a recursive `Ash.Expr → Cypher` renderer: arithmetic (`+ - * /`), comparisons, `if/3 ⇒ CASE`, string concat / `string_trim` (Ash's string cast), atom/enum literals (stored string form), attribute refs, scalar literals.

**Bulk via `update_query/4` and `destroy_query/4`:**
- `can?(:update_query)`, `can?(:destroy_query)`, `can?(:expr_error)` — `Ash.bulk_update`/`bulk_destroy` `:atomic` in one statement.
- Bulk destroy skips `guard`-protected nodes ("delete what is safe"); single targeted destroys still error on a guard.
- Relationship-management (`accessing_from`) updates/destroys delegate to the per-record path so FK→edge handling is preserved (atomics evaluated against the live record via `Ash.Expr.eval`).

## Stance: never silently mis-write
Anything we can't render in full is **returned** (never raised), not applied partially:
- un-pushable filter ⇒ `%AshNeo4j.Error.UnsupportedChangesetFilter{}`
- unrenderable atomic (inline `error()`, other Ash functions) ⇒ `%AshNeo4j.Error.UnsupportedAtomic{}`

## Notable findings (worked through in the journal)
- Bulk destroy's atomic strategy is gated on `:update_query` **and** `:expr_error`; advertising `:expr_error` makes Ash treat updates as atomic-by-default, so `manage_relationship` / `transition_state` actions need `require_atomic? false` (standard Ash 3 — `Post` already did; brought `Chain`/`StateMachine` test resources in line).
- A returned deleted node has empty properties, so bulk-destroy `return_records?` captures node data in a `WITH` before the delete.
- `FOREACH (… | DETACH DELETE n)` errors on 5.26 — single filtered destroy uses a two-query disambiguation (second query only on the failure path).

## Verified
- Full suite **716 passed** both servers (Neo4j 5.26.27 + 2026.05), `--warnings-as-errors` + credo clean.
- New tests: update guard, numeric/string/atom atomics, bulk update, bulk destroy + guard-skip, single filtered destroy + guard-vs-stale disambiguation.

## Out of scope / deferred
#340 (Cypher 25 `WHEN/THEN/ELSE` statement control flow) sits on top of this and stays deferred.
