### PR TITLE
fix: honour changeset.filter on relationship attach/detach; StaleRecord on miss (#368)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,10 @@ services:
       retries: 30
 
   neo4j-bolt6:
-    image: neo4j:2026.05
+    # Pin to the UBI build: the floating neo4j:2026.05 tag drifted to a
+    # Temurin-based build that exits 3 on boot (Apple Silicon); the *.0-community-ubi10
+    # build boots cleanly. Pinning also keeps the :cypher25 suite reproducible.
+    image: neo4j:2026.05.0-community-ubi10
     container_name: neo4j-ash-bolt6
     ports:
       - "7689:7687"

--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -967,22 +967,28 @@ defmodule AshNeo4j.Cypher.Query do
   end
 
   @doc """
-  `MATCH (s:SrcLabel {s_props}) OPTIONAL MATCH (d:DestLabel {d_props}) MERGE (s)-[r:EDGE]->(d) RETURN s, r, d`
+  `MATCH (s:SrcLabel {s_props}) [WHERE guard] OPTIONAL MATCH (d:DestLabel {d_props}) MERGE (s)-[r:EDGE]->(d) RETURN s, r, d`
+
+  `opts[:guard]` is a `changeset.filter` condition list (#368) gating the attach on
+  the live source node; a guard miss yields zero rows ⇒ the caller raises `StaleRecord`.
   """
-  @spec relate(atom() | [atom()], map(), atom() | [atom()], map(), atom(), atom()) :: t()
-  def relate(src_label, src_props, dest_label, dest_props, edge_label, direction)
-      when is_atom(edge_label) and is_atom(direction) do
+  @spec relate(atom() | [atom()], map(), atom() | [atom()], map(), atom(), atom(), keyword()) :: t()
+  def relate(src_label, src_props, dest_label, dest_props, edge_label, direction, opts \\ [])
+      when is_atom(edge_label) and is_atom(direction) and is_list(opts) do
     {src_pattern, src_params} = Cypher.parameterized_node(:s, List.wrap(src_label), src_props)
     {dest_pattern, dest_params} = Cypher.parameterized_node(:d, List.wrap(dest_label), dest_props)
+    {guard_clauses, guard_params} = source_guard_where(Keyword.get(opts, :guard, []))
 
     %__MODULE__{
-      clauses: [
-        %Match{pattern: src_pattern},
-        %OptionalMatch{pattern: dest_pattern},
-        %Merge{pattern: "(s)" <> Cypher.relationship(:r, edge_label, direction) <> "(d)"},
-        %Return{items: ["s", "r", "d"]}
-      ],
-      params: Map.merge(src_params, dest_params)
+      clauses:
+        [%Match{pattern: src_pattern}] ++
+          guard_clauses ++
+          [
+            %OptionalMatch{pattern: dest_pattern},
+            %Merge{pattern: "(s)" <> Cypher.relationship(:r, edge_label, direction) <> "(d)"},
+            %Return{items: ["s", "r", "d"]}
+          ],
+      params: src_params |> Map.merge(dest_params) |> Map.merge(guard_params)
     }
   end
 
@@ -994,15 +1000,18 @@ defmodule AshNeo4j.Cypher.Query do
       DELETE r0 WITH s MATCH (d:DestLabel {d_props})
       MERGE (s)-[r:EDGE]->(d) RETURN s, r, d
   """
-  @spec relate_unrelating_source(atom() | [atom()], map(), atom(), map(), atom(), atom()) :: t()
-  def relate_unrelating_source(src_label, src_props, dest_label, dest_props, edge_label, direction)
-      when is_atom(dest_label) and is_atom(edge_label) and is_atom(direction) do
+  @spec relate_unrelating_source(atom() | [atom()], map(), atom(), map(), atom(), atom(), keyword()) :: t()
+  def relate_unrelating_source(src_label, src_props, dest_label, dest_props, edge_label, direction, opts \\ [])
+      when is_atom(dest_label) and is_atom(edge_label) and is_atom(direction) and is_list(opts) do
     {src_pattern, src_params} = Cypher.parameterized_node(:s, List.wrap(src_label), src_props)
     {dest_pattern, dest_params} = Cypher.parameterized_node(:d, [dest_label], dest_props)
+    {guard_clauses, guard_params} = source_guard_where(Keyword.get(opts, :guard, []))
 
     %__MODULE__{
-      clauses: [
-        %Match{pattern: src_pattern},
+      clauses:
+        [%Match{pattern: src_pattern}] ++
+          guard_clauses ++
+          [
         %With{items: ["s"]},
         %OptionalMatch{
           pattern: "(s)" <> Cypher.relationship(:r0, edge_label, direction) <> Cypher.node(:d0, [dest_label])
@@ -1013,7 +1022,7 @@ defmodule AshNeo4j.Cypher.Query do
         %Merge{pattern: "(s)" <> Cypher.relationship(:r, edge_label, direction) <> "(d)"},
         %Return{items: ["s", "r", "d"]}
       ],
-      params: Map.merge(src_params, dest_params)
+      params: src_params |> Map.merge(dest_params) |> Map.merge(guard_params)
     }
   end
 
@@ -1024,16 +1033,19 @@ defmodule AshNeo4j.Cypher.Query do
       WITH s, d OPTIONAL MATCH (s0:SrcLabel)-[r0:EDGE]->(d) WHERE s0 <> s
       DELETE r0 WITH s, d MERGE (s)-[r:EDGE]->(d) RETURN s, r, d
   """
-  @spec relate_unrelating_destination(atom() | [atom()], map(), atom(), map(), atom(), atom()) :: t()
-  def relate_unrelating_destination(src_label, src_props, dest_label, dest_props, edge_label, direction)
-      when is_atom(dest_label) and is_atom(edge_label) and is_atom(direction) do
+  @spec relate_unrelating_destination(atom() | [atom()], map(), atom(), map(), atom(), atom(), keyword()) :: t()
+  def relate_unrelating_destination(src_label, src_props, dest_label, dest_props, edge_label, direction, opts \\ [])
+      when is_atom(dest_label) and is_atom(edge_label) and is_atom(direction) and is_list(opts) do
     src_labels = List.wrap(src_label)
     {src_pattern, src_params} = Cypher.parameterized_node(:s, src_labels, src_props)
     {dest_pattern, dest_params} = Cypher.parameterized_node(:d, [dest_label], dest_props)
+    {guard_clauses, guard_params} = source_guard_where(Keyword.get(opts, :guard, []))
 
     %__MODULE__{
-      clauses: [
-        %Match{pattern: src_pattern},
+      clauses:
+        [%Match{pattern: src_pattern}] ++
+          guard_clauses ++
+          [
         %OptionalMatch{pattern: dest_pattern},
         %With{items: ["s", "d"]},
         %OptionalMatch{
@@ -1045,7 +1057,7 @@ defmodule AshNeo4j.Cypher.Query do
         %Merge{pattern: "(s)" <> Cypher.relationship(:r, edge_label, direction) <> "(d)"},
         %Return{items: ["s", "r", "d"]}
       ],
-      params: Map.merge(src_params, dest_params)
+      params: src_params |> Map.merge(dest_params) |> Map.merge(guard_params)
     }
   end
 
@@ -1058,16 +1070,19 @@ defmodule AshNeo4j.Cypher.Query do
       OPTIONAL MATCH (s0:SrcLabel)-[r0:EDGE]->(d) WHERE s0 <> s DELETE r0
       WITH s, d MERGE (s)-[r:EDGE]->(d) RETURN s, r, d
   """
-  @spec relate_unrelating_both(atom() | [atom()], map(), atom(), map(), atom(), atom()) :: t()
-  def relate_unrelating_both(src_label, src_props, dest_label, dest_props, edge_label, direction)
-      when is_atom(dest_label) and is_atom(edge_label) and is_atom(direction) do
+  @spec relate_unrelating_both(atom() | [atom()], map(), atom(), map(), atom(), atom(), keyword()) :: t()
+  def relate_unrelating_both(src_label, src_props, dest_label, dest_props, edge_label, direction, opts \\ [])
+      when is_atom(dest_label) and is_atom(edge_label) and is_atom(direction) and is_list(opts) do
     src_labels = List.wrap(src_label)
     {src_pattern, src_params} = Cypher.parameterized_node(:s, src_labels, src_props)
     {dest_pattern, dest_params} = Cypher.parameterized_node(:d, [dest_label], dest_props)
+    {guard_clauses, guard_params} = source_guard_where(Keyword.get(opts, :guard, []))
 
     %__MODULE__{
-      clauses: [
-        %Match{pattern: src_pattern},
+      clauses:
+        [%Match{pattern: src_pattern}] ++
+          guard_clauses ++
+          [
         %With{items: ["s"]},
         %OptionalMatch{pattern: "(s)" <> Cypher.relationship(:r0, edge_label, direction) <> dest_pattern},
         %Delete{items: ["r0"]},
@@ -1083,28 +1098,34 @@ defmodule AshNeo4j.Cypher.Query do
         %Merge{pattern: "(s)" <> Cypher.relationship(:r, edge_label, direction) <> "(d)"},
         %Return{items: ["s", "r", "d"]}
       ],
-      params: Map.merge(src_params, dest_params)
+      params: src_params |> Map.merge(dest_params) |> Map.merge(guard_params)
     }
   end
 
   @doc """
-  `MATCH (s:SrcLabel {s_props})-[r:EDGE]->(d:DestLabel {d_props}) DELETE r RETURN s, d`
+  `MATCH (s:SrcLabel {s_props})-[r:EDGE]->(d:DestLabel {d_props}) [WHERE guard] DELETE r RETURN s, d`
+
+  `opts[:guard]` is a `changeset.filter` condition list (#368) gating the detach on
+  the live source node; a guard miss yields zero rows ⇒ the caller raises `StaleRecord`.
   """
-  @spec unrelate(atom() | [atom()], map(), atom(), map(), atom(), atom()) :: t()
-  def unrelate(src_label, src_props, dest_label, dest_props, edge_label, direction)
-      when is_atom(dest_label) and is_atom(edge_label) and is_atom(direction) do
+  @spec unrelate(atom() | [atom()], map(), atom(), map(), atom(), atom(), keyword()) :: t()
+  def unrelate(src_label, src_props, dest_label, dest_props, edge_label, direction, opts \\ [])
+      when is_atom(dest_label) and is_atom(edge_label) and is_atom(direction) and is_list(opts) do
     {src_pattern, src_params} = Cypher.parameterized_node(:s, List.wrap(src_label), src_props)
     {dest_pattern, dest_params} = Cypher.parameterized_node(:d, [dest_label], dest_props)
+    {guard_clauses, guard_params} = source_guard_where(Keyword.get(opts, :guard, []))
 
     path_pattern = src_pattern <> Cypher.relationship(:r, edge_label, direction) <> dest_pattern
 
     %__MODULE__{
-      clauses: [
-        %Match{pattern: path_pattern},
-        %Delete{items: ["r"]},
-        %Return{items: ["s", "d"]}
-      ],
-      params: Map.merge(src_params, dest_params)
+      clauses:
+        [%Match{pattern: path_pattern}] ++
+          guard_clauses ++
+          [
+            %Delete{items: ["r"]},
+            %Return{items: ["s", "d"]}
+          ],
+      params: src_params |> Map.merge(dest_params) |> Map.merge(guard_params)
     }
   end
 
@@ -1123,6 +1144,17 @@ defmodule AshNeo4j.Cypher.Query do
       end
 
     "NOT (#{variable})#{rel}(:#{dest_label})"
+  end
+
+  # A `changeset.filter` guard (#368) on the source alias `:s` of a relate/unrelate
+  # render — a `WHERE` placed immediately after the source `MATCH`, so a guard miss
+  # yields zero rows (no MERGE/DELETE) and the caller raises `StaleRecord`. Params
+  # are `g_`-prefixed so they can't collide with the `s_`/`d_` pattern params.
+  defp source_guard_where([]), do: {[], %{}}
+
+  defp source_guard_where(conditions) do
+    {where_string, params} = build_conditions(:s, conditions, param_prefix: "g_")
+    {[%Where{conditions: [where_string]}], params}
   end
 
   defp build_dest_conditions([]), do: {[], %{}}

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -414,6 +414,12 @@ defmodule AshNeo4j.DataLayer do
     end
   end
 
+  # The optimistic-lock failure raised when a `changeset.filter`-guarded write
+  # matches zero rows — the live node no longer satisfies the guard (#361/#368).
+  defp stale_record(resource, changeset) do
+    Ash.Error.Changes.StaleRecord.exception(resource: resource, filter: changeset.filter)
+  end
+
   defp do_update(resource, changeset, %ResourceMapping{} = mapping, guard_conditions, atomic_sets) do
     subject_id = id_properties(mapping, changeset.data)
     subject_label = mapping.label_pair
@@ -437,7 +443,7 @@ defmodule AshNeo4j.DataLayer do
           # (the predicate no longer holds); otherwise the id itself didn't match.
           {:ok, %Bolty.Response{results: []}} ->
             if guarded?,
-              do: {:error, Ash.Error.Changes.StaleRecord.exception(resource: resource, filter: changeset.filter)},
+              do: {:error, stale_record(resource, changeset)},
               else: {:error, "no result to update node"}
 
           {:ok, %Bolty.Response{results: [node_map | _]}} ->
@@ -474,10 +480,11 @@ defmodule AshNeo4j.DataLayer do
                      object_label,
                      object_id,
                      edge_label,
-                     Util.reverse(object_to_subject_direction)
+                     Util.reverse(object_to_subject_direction),
+                     guard_conditions
                    ) do
                 {:ok, %Bolty.Response{results: []}} ->
-                  {:error, "no result to unrelate nodes"}
+                  if guarded?, do: {:error, stale_record(resource, changeset)}, else: {:error, "no result to unrelate nodes"}
 
                 {:ok, %Bolty.Response{results: [node_map | _]}} ->
                   node = Map.get(node_map, "s")
@@ -503,10 +510,11 @@ defmodule AshNeo4j.DataLayer do
                      object_label,
                      object_id,
                      edge_label,
-                     Util.reverse(object_to_subject_direction)
+                     Util.reverse(object_to_subject_direction),
+                     guard: guard_conditions
                    ) do
                 {:ok, %Bolty.Response{results: []}} ->
-                  {:error, "no result to relate nodes"}
+                  if guarded?, do: {:error, stale_record(resource, changeset)}, else: {:error, "no result to relate nodes"}
 
                 {:ok, %Bolty.Response{results: [node_map | _]}} ->
                   node = Map.get(node_map, "s")
@@ -553,10 +561,13 @@ defmodule AshNeo4j.DataLayer do
                            object_label,
                            object_id,
                            subject_edge.label,
-                           subject_edge.direction
+                           subject_edge.direction,
+                           guard_conditions
                          ) do
                       {:ok, %Bolty.Response{results: []}} ->
-                        {:halt, {:error, "no result to unrelate nodes"}}
+                        if guarded?,
+                          do: {:halt, {:error, stale_record(resource, changeset)}},
+                          else: {:halt, {:error, "no result to unrelate nodes"}}
 
                       {:ok, %Bolty.Response{results: [node_map | _]}} ->
                         node = Map.get(node_map, "s")
@@ -591,10 +602,16 @@ defmodule AshNeo4j.DataLayer do
                                object_id,
                                subject_edge.label,
                                subject_edge.direction,
-                               {subject_exclusive?, object_exclusive?}
+                               exclusive: {subject_exclusive?, object_exclusive?},
+                               guard: guard_conditions
                              ) do
+                          # With a `changeset.filter` guard (#368), zero rows means the
+                          # live source no longer satisfies it ⇒ StaleRecord (as #361);
+                          # without a guard it's an unmatched id/dest as before.
                           {:ok, %Bolty.Response{results: []}} ->
-                            {:halt, {:error, "no result to relate nodes"}}
+                            if guarded?,
+                              do: {:halt, {:error, stale_record(resource, changeset)}},
+                              else: {:halt, {:error, "no result to relate nodes"}}
 
                           {:ok, %Bolty.Response{results: [node_map | _]}} ->
                             node = Map.get(node_map, "s")

--- a/lib/neo4j_helper.ex
+++ b/lib/neo4j_helper.ex
@@ -207,7 +207,7 @@ defmodule AshNeo4j.Neo4jHelper do
     |> Cypher.run()
   end
 
-  @spec unrelate_nodes(atom() | [atom()], map(), atom() | [atom()], map(), atom(), atom()) ::
+  @spec unrelate_nodes(atom() | [atom()], map(), atom() | [atom()], map(), atom(), atom(), list()) ::
           {:error, %{:__exception__ => true, :__struct__ => atom(), optional(atom()) => any()}}
           | {:ok, any()}
   @doc """
@@ -222,15 +222,15 @@ defmodule AshNeo4j.Neo4jHelper do
   :ok
   ```
   """
-  def unrelate_nodes(source_label, source_properties, dest_label, dest_properties, edge_label, edge_direction)
+  def unrelate_nodes(source_label, source_properties, dest_label, dest_properties, edge_label, edge_direction, guard \\ [])
       when (is_atom(source_label) or is_list(source_label)) and is_map(source_properties) and
              is_atom(dest_label) and is_map(dest_properties) and
-             is_atom(edge_label) and is_atom(edge_direction) do
-    Query.unrelate(source_label, source_properties, dest_label, dest_properties, edge_label, edge_direction)
+             is_atom(edge_label) and is_atom(edge_direction) and is_list(guard) do
+    Query.unrelate(source_label, source_properties, dest_label, dest_properties, edge_label, edge_direction, guard: guard)
     |> Cypher.run()
   end
 
-  @spec relate_nodes_unrelating_source(atom(), map(), atom(), map(), atom(), atom()) ::
+  @spec relate_nodes_unrelating_source(atom(), map(), atom(), map(), atom(), atom(), list()) ::
           {:error, %{:__exception__ => true, :__struct__ => atom(), optional(atom()) => any()}}
           | {:ok, any()}
   @doc """
@@ -252,23 +252,25 @@ defmodule AshNeo4j.Neo4jHelper do
         dest_label,
         dest_properties,
         edge_label,
-        edge_direction
+        edge_direction,
+        guard \\ []
       )
       when (is_atom(source_label) or is_list(source_label)) and is_map(source_properties) and
              is_atom(dest_label) and is_map(dest_properties) and
-             is_atom(edge_label) and is_atom(edge_direction) do
+             is_atom(edge_label) and is_atom(edge_direction) and is_list(guard) do
     Query.relate_unrelating_source(
       source_label,
       source_properties,
       dest_label,
       dest_properties,
       edge_label,
-      edge_direction
+      edge_direction,
+      guard: guard
     )
     |> Cypher.run()
   end
 
-  @spec relate_nodes_unrelating_destination(atom(), map(), atom(), map(), atom(), atom()) ::
+  @spec relate_nodes_unrelating_destination(atom(), map(), atom(), map(), atom(), atom(), list()) ::
           {:error, %{:__exception__ => true, :__struct__ => atom(), optional(atom()) => any()}}
           | {:ok, any()}
   @doc """
@@ -290,23 +292,25 @@ defmodule AshNeo4j.Neo4jHelper do
         dest_label,
         dest_properties,
         edge_label,
-        edge_direction
+        edge_direction,
+        guard \\ []
       )
       when (is_atom(source_label) or is_list(source_label)) and is_map(source_properties) and
              is_atom(dest_label) and is_map(dest_properties) and
-             is_atom(edge_label) and is_atom(edge_direction) do
+             is_atom(edge_label) and is_atom(edge_direction) and is_list(guard) do
     Query.relate_unrelating_destination(
       source_label,
       source_properties,
       dest_label,
       dest_properties,
       edge_label,
-      edge_direction
+      edge_direction,
+      guard: guard
     )
     |> Cypher.run()
   end
 
-  @spec relate_nodes_unrelating_source_and_destination(atom(), map(), atom(), map(), atom(), atom()) ::
+  @spec relate_nodes_unrelating_source_and_destination(atom(), map(), atom(), map(), atom(), atom(), list()) ::
           {:error, %{:__exception__ => true, :__struct__ => atom(), optional(atom()) => any()}}
           | {:ok, any()}
   @doc """
@@ -330,29 +334,46 @@ defmodule AshNeo4j.Neo4jHelper do
         dest_label,
         dest_properties,
         edge_label,
-        edge_direction
+        edge_direction,
+        guard \\ []
       )
       when (is_atom(source_label) or is_list(source_label)) and is_map(source_properties) and
              is_atom(dest_label) and is_map(dest_properties) and
-             is_atom(edge_label) and is_atom(edge_direction) do
+             is_atom(edge_label) and is_atom(edge_direction) and is_list(guard) do
     Query.relate_unrelating_both(
       source_label,
       source_properties,
       dest_label,
       dest_properties,
       edge_label,
-      edge_direction
+      edge_direction,
+      guard: guard
     )
     |> Cypher.run()
   end
 
-  def relate_nodes(source_label, source_properties, dest_label, dest_properties, edge_label, edge_direction, options)
+  @doc """
+  Relates two nodes, honouring exclusivity and an optional `changeset.filter` guard.
+
+  `opts`:
+    * `:exclusive` — `{source_exclusive?, destination_exclusive?}` (default `{false, false}`),
+      selecting the plain / unrelate-source / unrelate-destination / unrelate-both render.
+    * `:guard` — a `changeset.filter` condition list (#368) gating the attach on the
+      live source node; a guard miss yields zero rows ⇒ the caller raises `StaleRecord`.
+  """
+  @spec relate_nodes(atom() | [atom()], map(), atom() | [atom()], map(), atom(), atom(), keyword()) ::
+          {:error, %{:__exception__ => true, :__struct__ => atom(), optional(atom()) => any()}}
+          | {:ok, any()}
+  def relate_nodes(source_label, source_properties, dest_label, dest_properties, edge_label, edge_direction, opts)
       when (is_atom(source_label) or is_list(source_label)) and is_map(source_properties) and
              (is_atom(dest_label) or is_list(dest_label)) and is_map(dest_properties) and
-             is_atom(edge_label) and is_atom(edge_direction) and is_tuple(options) do
-    case options do
+             is_atom(edge_label) and is_atom(edge_direction) and is_list(opts) do
+    guard = Keyword.get(opts, :guard, [])
+
+    case Keyword.get(opts, :exclusive, {false, false}) do
       {false, false} ->
-        relate_nodes(source_label, source_properties, dest_label, dest_properties, edge_label, edge_direction)
+        Query.relate(source_label, source_properties, dest_label, dest_properties, edge_label, edge_direction, guard: guard)
+        |> Cypher.run()
 
       {true, false} ->
         relate_nodes_unrelating_source(
@@ -361,7 +382,8 @@ defmodule AshNeo4j.Neo4jHelper do
           dest_label,
           dest_properties,
           edge_label,
-          edge_direction
+          edge_direction,
+          guard
         )
 
       {false, true} ->
@@ -371,7 +393,8 @@ defmodule AshNeo4j.Neo4jHelper do
           dest_label,
           dest_properties,
           edge_label,
-          edge_direction
+          edge_direction,
+          guard
         )
 
       {true, true} ->
@@ -381,7 +404,8 @@ defmodule AshNeo4j.Neo4jHelper do
           dest_label,
           dest_properties,
           edge_label,
-          edge_direction
+          edge_direction,
+          guard
         )
     end
   end

--- a/test/guarded_relate_test.exs
+++ b/test/guarded_relate_test.exs
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.GuardedRelateTest do
+  @moduledoc """
+  The `changeset.filter` guard threaded into the relationship write path (#368): a
+  to-one `manage_relationship` attach/detach is gated by an optimistic-lock
+  predicate against the live source node, in one statement
+  (`MATCH (s) WHERE <filter> … MERGE/DELETE`). A guard miss yields zero rows ⇒
+  `Ash.Error.Changes.StaleRecord`, never a silent (un)relate. A guard that can't
+  push down in full is refused with `AshNeo4j.Error.UnsupportedChangesetFilter` —
+  never applied unguarded. Plain Cypher 5, no gate (sibling of #361).
+
+  `Chain` is a to-one (`belongs_to :head`/`:tail`, FK on the subject), so Ash routes
+  the FK edge write through this data layer's own update — where the guard threads.
+  has_many appends are delegated by Ash to the related side under a parent
+  filter-read, so they keep the same lock semantics without reaching the relate
+  render; covered by Ash's own behaviour, not here.
+  """
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Error.UnsupportedChangesetFilter
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.Chain
+
+  use ExUnit.Case, async: false
+
+  require Ash.Expr
+
+  setup_all do
+    BoltyHelper.start()
+    :ok
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+    :ok
+  end
+
+  defp flatten(%{errors: errors}) when is_list(errors), do: Enum.flat_map(errors, &flatten/1)
+  defp flatten(e), do: [e]
+
+  defp chain(name), do: Chain |> Ash.Changeset.for_create(:create, %{name: name}) |> Ash.create!()
+
+  defp head_id(chain), do: Chain |> Ash.get!(chain.id) |> Ash.load!(:head_id) |> Map.get(:head_id)
+
+  describe "render: guard lands as a WHERE on the source match" do
+    test "relate threads guard right after MATCH (s), g_-prefixed params" do
+      query =
+        AshNeo4j.Cypher.Query.relate(:Chain, %{uuid: "s1"}, :Chain, %{uuid: "d1"}, :HEAD_TO_TAIL, :incoming,
+          guard: [{"name", :==, "b", false}]
+        )
+
+      {cypher, params} = AshNeo4j.Cypher.render(query)
+
+      assert cypher =~ ~r/MATCH \(s:Chain \{uuid: \$s_uuid\}\) WHERE s\.name = \$g_s_name_0/
+      assert cypher =~ "MERGE (s)<-[r:HEAD_TO_TAIL]-(d)"
+      assert params["g_s_name_0"] == "b"
+    end
+
+    test "unrelate threads guard after the path MATCH, before DELETE r" do
+      query =
+        AshNeo4j.Cypher.Query.unrelate(:Chain, %{uuid: "s1"}, :Chain, %{uuid: "d1"}, :HEAD_TO_TAIL, :incoming,
+          guard: [{"name", :==, "b", false}]
+        )
+
+      {cypher, params} = AshNeo4j.Cypher.render(query)
+
+      assert cypher =~ ~r/WHERE s\.name = \$g_s_name_0 DELETE r/
+      assert params["g_s_name_0"] == "b"
+    end
+
+    test "no guard renders the original statement unchanged" do
+      {cypher, _} =
+        AshNeo4j.Cypher.Query.relate(:Chain, %{uuid: "s1"}, :Chain, %{uuid: "d1"}, :HEAD_TO_TAIL, :incoming)
+        |> AshNeo4j.Cypher.render()
+
+      refute cypher =~ "WHERE"
+    end
+  end
+
+  describe "guarded attach (to-one belongs_to)" do
+    test "a guard that still holds attaches the edge" do
+      a = chain("a")
+      b = chain("b")
+
+      assert {:ok, related} =
+               b
+               |> Ash.Changeset.for_update(:update, %{head_id: a.id})
+               |> Ash.Changeset.filter(Ash.Expr.expr(name == "b"))
+               |> Ash.update()
+
+      assert related.head_id == a.id
+    end
+
+    test "a guard that no longer holds returns StaleRecord, not a silent attach" do
+      a = chain("a")
+      b = chain("b")
+
+      assert {:error, error} =
+               b
+               |> Ash.Changeset.for_update(:update, %{head_id: a.id})
+               |> Ash.Changeset.filter(Ash.Expr.expr(name == "renamed"))
+               |> Ash.update()
+
+      assert Enum.any?(flatten(error), &match?(%Ash.Error.Changes.StaleRecord{}, &1))
+      # The edge was not created.
+      assert head_id(b) == nil
+    end
+
+    test "an un-pushable guard (or) is refused, not applied unguarded" do
+      a = chain("a")
+      b = chain("b")
+
+      assert {:error, error} =
+               b
+               |> Ash.Changeset.for_update(:update, %{head_id: a.id})
+               |> Ash.Changeset.filter(Ash.Expr.expr(name == "b" or name == "c"))
+               |> Ash.update()
+
+      assert Enum.any?(flatten(error), &match?(%UnsupportedChangesetFilter{}, &1))
+      # Refused ⇒ no edge.
+      assert head_id(b) == nil
+    end
+  end
+
+  describe "guarded detach (to-one belongs_to)" do
+    test "a guard that still holds detaches the edge" do
+      a = chain("a")
+      b = chain("b")
+      {:ok, related} = b |> Ash.Changeset.for_update(:update, %{head_id: a.id}) |> Ash.update()
+      assert related.head_id == a.id
+
+      assert {:ok, _} =
+               related
+               |> Ash.Changeset.for_update(:unrelate, %{head_id: a.id})
+               |> Ash.Changeset.filter(Ash.Expr.expr(name == "b"))
+               |> Ash.update()
+
+      assert head_id(b) == nil
+    end
+
+    test "a guard that no longer holds returns StaleRecord, leaving the edge intact" do
+      a = chain("a")
+      b = chain("b")
+      {:ok, related} = b |> Ash.Changeset.for_update(:update, %{head_id: a.id}) |> Ash.update()
+
+      assert {:error, error} =
+               related
+               |> Ash.Changeset.for_update(:unrelate, %{head_id: a.id})
+               |> Ash.Changeset.filter(Ash.Expr.expr(name == "renamed"))
+               |> Ash.update()
+
+      assert Enum.any?(flatten(error), &match?(%Ash.Error.Changes.StaleRecord{}, &1))
+      # The edge survives the failed lock.
+      assert head_id(b) == a.id
+    end
+  end
+end


### PR DESCRIPTION
Closes #368.

## Summary

Threads `changeset.filter` into the relationship write path so a **to-one** `manage_relationship` attach/detach is gated by an optimistic lock against the **live source node**, in one Cypher-5 statement. Sibling of #361, no gate.

This is a **bug fix and an enhancement**:

- **Bug:** the relate/unrelate render dropped `changeset.filter` entirely. For a to-one (`belongs_to`) guarded `manage_relationship`, the unguarded edge write returned `{:ok}` and **masked** #361's property-path `StaleRecord` via `result = relationship_update_result || property_update_result` — so an attach/detach whose lock no longer held **succeeded silently**. Verified against pre-fix code (a guard-miss attach returned `{:ok, head_id: …}` with the edge created); the "not a silent attach" test is the regression guard.
- **Enhancement:** decision in the DB, one statement — no read-decide-in-Elixir, no read-write race, fewer round-trips.

## Changes

- `lib/cypher/query.ex` — `guard:` opt on `relate`/`unrelate` + the three exclusive variants; a shared `source_guard_where/1` emits a `WHERE` on source `s` right after its `MATCH`, `g_`-prefixed params (reusing `build_conditions/3`).
- `lib/neo4j_helper.ex` — guard threaded through; `relate_nodes/7` options-tuple became a keyword form (`:exclusive` + `:guard`), its sole caller updated.
- `lib/data_layer.ex` — all four relationship branches in `do_update/5` thread `guard_conditions` and raise `StaleRecord` on a guarded zero-row result, de-duped via `stale_record/2` (also reused by the #361 property path).
- `test/guarded_relate_test.exs` — render-level guard emission + guarded attach/detach (holds → edge, miss → `StaleRecord` + no write, un-pushable `or` → `UnsupportedChangesetFilter`).
- `docker-compose.yml` — pin `neo4j-bolt6` to `2026.05.0-community-ubi10` (the floating `2026.05` tag drifted to a build that exits 3 on boot under Apple Silicon).

## Reachability boundary

The guard reaches the data-layer relate render only for **to-one** relationships (FK on the subject), where Ash routes the FK edge write through our `update/2`. **has_many** appends are delegated by Ash to the child side under its own validating filter-read — same lock outcome, but the guard never reaches the relate Cypher. Hence the test targets `Chain` (to-one), not `Post`.

## Testing

- Default suite: `mix test` — 715 passed.
- Full suite incl. Cypher 25: `mix test --include cypher25 --include bolt6` — 724 passed, 0 failures.
