### PR TITLE
fix: fail fast on many-to-many modelled as back-to-back has_many (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ See [Conventional Commits](Https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* **`belongs_to` FK always nil after read** (#258) — `belongs_to` source attributes (e.g. `specification_id`) were correctly populated on create but lost on any subsequent read. The enrichment step now correctly extracts the FK from the destination node returned by the OPTIONAL MATCH traversal when the source resource uses a fragment-inherited relationship whose destination lives in a different domain.
+* **`belongs_to` source attribute always nil after read** (#258) — `belongs_to` source attributes (e.g. `specification_id`) were correctly populated on create but lost on any subsequent read. The enrichment step now correctly extracts the relationship attribute from the destination node returned by the OPTIONAL MATCH traversal when the source resource uses a fragment-inherited relationship whose destination lives in a different domain.
 
 * **Domain fragment label dropped on Ash 3.25+** — `ResourceInfo.all_labels/1` was returning the compile-time persisted label list, which is baked before the domain extension compiles under Ash 3.25's updated compilation order, causing the domain fragment label to be silently omitted. `all_labels/1` now always computes dynamically from the individual label accessors, consistent with how `mapping/1` already worked.
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ JSON types are stored as maps. We encode with AshNeo4j.Util.json_encode, which e
 Interestingly many Ash.Types have identical JSON representations (e.g. Map, Struct, Tuple, Keyword). Neo4j lists are used for arrays since JSON and Base64 are strings.
 
 A few things to note:
-* Ash.Type.UUID, Ash.Type.UUIDv7 - we persist in the 'cast_input' format rather than as compacted binary for readability, so we don't use Ash.Type.dump_to_native and Ash.Type.cast_stored at all. However foreign keys aren't persisted using properties, we of course use relationships.
+* Ash.Type.UUID, Ash.Type.UUIDv7 - we persist in the 'cast_input' format rather than as compacted binary for readability, so we don't use Ash.Type.dump_to_native and Ash.Type.cast_stored at all. However relationship attributes aren't persisted as properties, we of course use relationships (edges).
 * Ash.Type.Function - we persist external functions as a string MFA, rather than binary, so we don't use Ash.Type.dump_to_native and Ash.Type.cast_stored at all. Persisting local functions is not supported.
 
 ## Keys

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -499,7 +499,19 @@ defmodule AshNeo4j.DataLayer do
 
           case map_size(object_id) do
             0 ->
-              {:error, "couldn't relate nodes"}
+              # Empty object id ⇒ the inverse-relationship resolution failed. If both sides are
+              # `has_many` over one edge, that's a back-to-back-has_many m2m (#127) —
+              # fail fast with guidance toward a joiner node rather than a bare string.
+              if back_to_back_has_many?(resource, object_resource, object_relationship_name) do
+                {:error,
+                 AshNeo4j.Error.UnsupportedManyToMany.exception(
+                   resource: object_resource,
+                   related: resource,
+                   relationship: object_relationship_name
+                 )}
+              else
+                {:error, "couldn't relate nodes"}
+              end
 
             _ ->
               {_relationship_name, edge_label, object_to_subject_direction, _object_label} = object_node_relationship
@@ -660,8 +672,9 @@ defmodule AshNeo4j.DataLayer do
 
     cond do
       # Relationship management (manage_relationship) is routed here as an atomic
-      # FK set, but in the graph the FK is an *edge*, not a property. Hand it to the
-      # per-record path, which creates the edge (and renders the atomic) (#361).
+      # set of the relationship attribute, but in the graph that relationship is an
+      # *edge*, not a stored property. Hand it to the per-record path, which creates
+      # the edge (and renders the atomic) (#361).
       Map.has_key?(changeset.context, :accessing_from) ->
         single_update_query_result(resource, changeset, mapping, opts)
 
@@ -671,11 +684,12 @@ defmodule AshNeo4j.DataLayer do
   end
 
   defp single_update_query_result(resource, changeset, mapping, opts) do
-    # Ash atomic-ises the relationship FK set, so the edge key arrives in `atomics`
-    # — as a literal (belongs_to) or a guard expression like
-    # `if is_distinct_from(new, fk), do: new, else: fk` (has_one). The per-record
-    # relationship path reads the FK from `attributes`, so evaluate each atomic
-    # against the live record and fold it back, then delegate (creates the edge).
+    # Ash atomic-ises the relationship attribute, so the edge key arrives in
+    # `atomics` — as a literal (belongs_to) or a guard expression like
+    # `if is_distinct_from(new, current), do: new, else: current` (has_one). The
+    # per-record relationship path reads that attribute from `attributes`, so
+    # evaluate each atomic against the live record and fold it back, then delegate
+    # (creates the edge).
     with {:ok, changeset} <- fold_atomics_to_attributes(resource, changeset),
          {:ok, record} <- do_update(resource, changeset, mapping) do
       if Map.get(opts, :return_records?), do: {:ok, [record]}, else: :ok
@@ -1341,6 +1355,21 @@ defmodule AshNeo4j.DataLayer do
     else
       %{}
     end
+  end
+
+  # Detects a many-to-many modelled as back-to-back `has_many` (#127): the source's
+  # relationship is `has_many` AND the accessed resource declares a `has_many` back
+  # to it, so one edge is described by two scalar FKs — which can't represent m2m.
+  # (Their FKs aren't a clean inverse — which is *why* the resolution failed and we
+  # land here — so this scans the relationships directly rather than relying on
+  # `reverse_node_relationship`, which returns nil for exactly this shape.) Used to
+  # turn the failure into an actionable error rather than a bare "couldn't relate
+  # nodes". Joiner nodes are the supported shape; native many_to_many is #370.
+  defp back_to_back_has_many?(resource, object_resource, object_relationship_name) do
+    match?(%{type: :has_many}, Ash.Resource.Info.relationship(object_resource, object_relationship_name)) and
+      Enum.any?(Ash.Resource.Info.relationships(resource), fn rel ->
+        rel.destination == object_resource and rel.type == :has_many
+      end)
   end
 
   # Property names to REMOVE on update: those the OLD value of each changed

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -123,6 +123,30 @@ defmodule AshNeo4j.Error.UnresolvableTraversal do
   end
 end
 
+defmodule AshNeo4j.Error.UnsupportedManyToMany do
+  @moduledoc """
+  **Returned** (never raised) when a relationship write resolves to a many-to-many
+  modelled as **back-to-back `has_many`** — two resources each declaring a
+  `has_many` to the other over one edge (#127). Ash anchors a `has_many` by an
+  attribute on the *related* resource; with a `has_many` on both sides there is no
+  to-one side to anchor the connect, so the data layer can't determine which node
+  to relate. The edge itself already represents the many-to-many; the model just
+  needs a to-one side on each hop to anchor the connect.
+
+  Model many-to-many with a **joiner node** instead — two to-one (`belongs_to`)
+  hops through a join resource (`Source →[E1] Join →[E2] Dest`); see the
+  `Party → PlaceRef → Place` example. Native `many_to_many` is tracked in #370.
+  """
+  use Splode.Error, fields: [:resource, :related, :relationship], class: :invalid
+
+  def message(%{resource: resource, related: related, relationship: relationship}) do
+    "cannot relate #{inspect(resource)} to #{inspect(related)} via :#{relationship} — this is a " <>
+      "many-to-many modelled as back-to-back has_many (a has_many on both sides of one edge), which " <>
+      "leaves no to-one side to anchor the connect. Model it with a joiner node (two to-one hops " <>
+      "through a join resource; see Party → PlaceRef → Place). Native many_to_many is tracked in #370."
+  end
+end
+
 defmodule AshNeo4j.Error.Neo4j do
   @moduledoc """
   Wraps a Neo4j server error surfaced from `AshNeo4j.Cypher.run/1` (a

--- a/lib/resource_mapping.ex
+++ b/lib/resource_mapping.ex
@@ -32,7 +32,7 @@ defmodule AshNeo4j.ResourceMapping do
     insertion order is preserved.
   - `:edges` — list of `AshNeo4j.EdgeDescriptor.t()` structs, one per `relate` entry.
   - `:relationship_attributes` — keyword list of `{source_attribute, relationship_name}` pairs for
-    attributes that hold foreign keys; used to create edges during CREATE.
+    attributes that back relationships; used to create edges during CREATE.
   - `:guards` — list of `{edge_label, direction, destination_label}` tuples that block deletion.
   - `:skip` — list of relationship names excluded from automatic edge management.
   """

--- a/test/blog_test.exs
+++ b/test/blog_test.exs
@@ -626,58 +626,28 @@ defmodule AshNeo4j.BlogTest do
   end
 
   describe "many-to-many relationship tests" do
-    @tag :skip
-    @tag bugged: "fails with Ash.Error.Unknown couldn't relate notes, despite attributes containing post_id"
-    test "many posts can be tagged with each tag" do
+    # #127: Post↔Tag is modelled as back-to-back has_many (Post.tags ⇆ Tag.posts)
+    # over one TAGS edge — a has_many on both sides, with no to-one side to anchor
+    # the connect, so the data layer can't resolve which node to relate. It now
+    # fails fast with AshNeo4j.Error.UnsupportedManyToMany pointing at the joiner
+    # node pattern (see Party → PlaceRef → Place), rather than the old cryptic
+    # "couldn't relate nodes". Native many_to_many is tracked in #370.
+    test "tagging via back-to-back has_many fails fast with UnsupportedManyToMany guidance" do
       {:ok, author} = Author |> Ash.Changeset.for_create(:create, %{name: "author"}) |> Ash.create()
-      {:ok, post1} = Post |> Ash.create(%{title: "post1", written_by: author.id})
-      {:ok, post2} = Post |> Ash.create(%{title: "post2", written_by: author.id})
+      {:ok, post} = Post |> Ash.create(%{title: "post1", written_by: author.id})
       {:ok, tag1} = Tag |> Ash.create(%{value: "tag1"})
       {:ok, tag2} = Tag |> Ash.create(%{value: "tag2"})
-      posts = [post1, post2]
-      tag_ids = [tag1.id, tag2.id]
 
-      # tag posts
-      Enum.into(posts, [], fn post ->
-        {:ok, post} =
-          post
-          |> Ash.Changeset.new()
-          |> Ash.Changeset.for_update(:manage_tags, tags: tag_ids)
-          |> Ash.update()
+      assert {:error, error} =
+               post
+               |> Ash.Changeset.for_update(:manage_tags, tags: [tag1.id, tag2.id])
+               |> Ash.update()
 
-        post
-      end)
+      errors = error |> Map.get(:errors, [error]) |> List.flatten()
+      assert Enum.any?(errors, &match?(%AshNeo4j.Error.UnsupportedManyToMany{}, &1))
 
-      # check relationships in neo4j
-      for post <- posts, tag_id <- tag_ids do
-        assert Neo4jHelper.nodes_relate_how?(
-                 [:SRM, :Post],
-                 %{title: post.title},
-                 [:SRM, :Tag],
-                 %{uuid: tag_id},
-                 :TAGS,
-                 :incoming
-               )
-      end
-
-      # retrieve posts and check they have tags
-      for post <- posts do
-        retrieved_post =
-          Post
-          |> Ash.Query.for_read(:read)
-          |> Ash.Query.filter(id: post.id)
-          |> Ash.read_one!()
-
-        assert length(retrieved_post.tags) == length(tag_ids)
-      end
-
-      # retrieve tags and check they are related to posts
-      for tag_id <- tag_ids do
-        tag =
-          Tag |> Ash.Query.for_read(:read) |> Ash.Query.filter(id: tag_id) |> Ash.read_one!()
-
-        assert length(tag.posts) == length(posts)
-      end
+      # The cryptic legacy string must not surface.
+      refute Enum.any?(errors, &match?(%{error: "couldn't relate nodes"}, &1))
     end
   end
 

--- a/test/guarded_relate_test.exs
+++ b/test/guarded_relate_test.exs
@@ -12,8 +12,9 @@ defmodule AshNeo4j.GuardedRelateTest do
   push down in full is refused with `AshNeo4j.Error.UnsupportedChangesetFilter` —
   never applied unguarded. Plain Cypher 5, no gate (sibling of #361).
 
-  `Chain` is a to-one (`belongs_to :head`/`:tail`, FK on the subject), so Ash routes
-  the FK edge write through this data layer's own update — where the guard threads.
+  `Chain` is a to-one (`belongs_to :head`/`:tail`, the relationship attribute on the
+  subject), so Ash routes the edge write through this data layer's own update — where
+  the guard threads.
   has_many appends are delegated by Ash to the related side under a parent
   filter-read, so they keep the same lock semantics without reaching the relate
   render; covered by Ash's own behaviour, not here.


### PR DESCRIPTION
Closes #127.

## Summary

#127's bugged test modelled Post↔Tag many-to-many as **back-to-back `has_many`** (`Post.tags ⇆ Tag.posts`) over one `TAGS` edge. A `has_many` on both sides leaves no to-one side to anchor each connect, so the relate path couldn't resolve which node to relate and raised a cryptic `"couldn't relate nodes"` deep in the write path — the test was `@tag :skip` / `bugged`. (Back-to-back has_many m2m was even listed as a feature in v0.2.1; it never worked.)

In the graph an edge already represents many-to-many — the fix isn't to make this model work (it can't), but to **fail fast with guidance**:

- New `AshNeo4j.Error.UnsupportedManyToMany`, returned (never raised) when the relate path resolves to a back-to-back-`has_many` shape, pointing at the supported **joiner-node** pattern (two to-one hops; see `Party → PlaceRef → Place`).
- Detection at the resolution-failure point in `do_update/5`: the source relationship is `has_many` and the accessed resource declares a `has_many` back to it.
- The unskipped test now asserts the fail-fast error (and that the old cryptic string is gone).

Native `many_to_many` (mapping a join resource onto a joiner node, or a direct edge when there's no edge metadata) is tracked as a follow-up enhancement in #370.

## Changes

- `lib/error.ex` — `AshNeo4j.Error.UnsupportedManyToMany`.
- `lib/data_layer.ex` — `back_to_back_has_many?/3` detection; return the error instead of `"couldn't relate nodes"` when it matches.
- `test/blog_test.exs` — replace the `:skip`/`bugged` test with a fail-fast assertion.
- Terminology cleanup commit: describe relationships in the data layer's own terms (attributes mapping to edges) across comments, the error module, tests, README and a CHANGELOG entry.

## Testing

`mix test` — 716 passed, 0 failures.
