### PR TITLE
fix: demote expected "nothing deleted" from error to debug (#373)

### DIFF
--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -573,7 +573,10 @@ defmodule AshNeo4j.Cypher do
         end
 
       if deleted_nodes == 0 do
-        Logger.error("AshNeo4j.Cypher: nothing deleted")
+        # Expected control flow, not an error: a preservation guard held the node,
+        # or an optimistic-lock destroy missed. The caller disambiguates this into
+        # StaleRecord / Unavailable, so trace it at :debug rather than :error (#373).
+        Logger.debug("AshNeo4j.Cypher: nothing deleted")
         {:error, "nothing deleted"}
       else
         Logger.debug("AshNeo4j.Cypher: run_expecting_deletions deleted #{deleted_nodes} nodes")


### PR DESCRIPTION
Closes #373.

`run_expecting_deletions/2` logged `Logger.error("AshNeo4j.Cypher: nothing deleted")` on every zero-delete — but zero-delete is **expected control flow**, fully handled by the caller ([data_layer.ex:841](../blob/dev/lib/data_layer.ex#L841)), which converts it into `StaleRecord` (optimistic-lock miss) or `Ash.Error.Invalid.Unavailable` (preservation guard held the node). Logging it at `:error` turned handled outcomes into noise that littered nearly every test run.

Demoted to `:debug`. The returned `{:error, …}` is the signal; no information is lost.

**Testing:** full suite 716 passed; `grep -c "nothing deleted"` over default-level test output now **0** (was on most runs). Scoped narrowly per the ticket — the broader log-level/prefix/lazy-dump sweep is #374.