### PR TITLE
refactor: unify data-layer log format; fix prefix typos (#374)

### DIFF
--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -534,16 +534,12 @@ defmodule AshNeo4j.Cypher do
   def run(cypher, params \\ %{}) when is_bitstring(cypher) do
     cypher = cypher25_prefix() <> cypher
 
-    Logger.debug("""
-    AshNeo4j.Cypher: run(#{cypher}, #{inspect(params)})
-    """)
+    Logger.debug("AshNeo4j.Cypher: run(#{cypher}, #{inspect(params)})")
 
     bolty_result = sandboxed_query(cypher, params)
 
     if elem(bolty_result, 0) == :ok do
-      Logger.debug("""
-      AshNeo4j.Cypher: run result #{inspect(elem(bolty_result, 1).results)}
-      """)
+      Logger.debug("AshNeo4j.Cypher: run result #{inspect(elem(bolty_result, 1).results)}")
     end
 
     bolty_result
@@ -556,7 +552,7 @@ defmodule AshNeo4j.Cypher do
 
   def run_expecting_deletions(cypher, params \\ %{}) when is_bitstring(cypher) do
     cypher = cypher25_prefix() <> cypher
-    Logger.debug("AshNeo4.Cypher: run_expecting_deletions(#{cypher})")
+    Logger.debug("AshNeo4j.Cypher: run_expecting_deletions(#{cypher})")
 
     bolty_result = sandboxed_query(cypher, params)
 

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -229,9 +229,7 @@ defmodule AshNeo4j.DataLayer do
   @impl true
   @spec run_query(any(), atom()) :: {:error, any()} | {:ok, any()}
   def run_query(query, resource) do
-    Logger.debug("""
-    AshNeo4j.DataLayer: run_query(#{inspect(query)}, #{inspect(resource)})
-    """)
+    Logger.debug("AshNeo4j.DataLayer: run_query(#{inspect(query)}, #{inspect(resource)})")
 
     result =
       case QueryHelper.query_nodes(query) do
@@ -268,9 +266,7 @@ defmodule AshNeo4j.DataLayer do
           end
       end
 
-    Logger.debug("""
-    AshNeo4j.DataLayer: run_query result #{inspect(result)}
-    """)
+    Logger.debug("AshNeo4j.DataLayer: run_query result #{inspect(result)}")
 
     result
   end
@@ -313,9 +309,7 @@ defmodule AshNeo4j.DataLayer do
           {:error, <<_::64, _::_*8>> | %{:__exception__ => true, :__struct__ => atom(), optional(atom()) => any()}}
           | {:ok, any()}
   def create(resource, changeset) do
-    Logger.debug("""
-    AshNeo4j.DataLayer: create(#{inspect(resource)}, #{inspect(changeset)})
-    """)
+    Logger.debug("AshNeo4j.DataLayer: create(#{inspect(resource)}, #{inspect(changeset)})")
 
     mapping = ResourceInfo.mapping(resource)
     primary_keys = Ash.Resource.Info.primary_key(mapping.module)
@@ -330,18 +324,14 @@ defmodule AshNeo4j.DataLayer do
         end
       end
 
-    Logger.debug("""
-    AshNeo4j.DataLayer: create result #{inspect(result)}
-    """)
+    Logger.debug("AshNeo4j.DataLayer: create result #{inspect(result)}")
 
     result
   end
 
   @impl true
   def upsert(resource, changeset, keys) do
-    Logger.debug("""
-    AshNeo4j.DataLayer: upsert(#{inspect(resource)}, #{inspect(changeset)}, #{inspect(keys)})
-    """)
+    Logger.debug("AshNeo4j.DataLayer: upsert(#{inspect(resource)}, #{inspect(changeset)}, #{inspect(keys)})")
 
     mapping = ResourceInfo.mapping(resource)
     id_properties = id_properties(mapping, changeset.attributes)
@@ -384,18 +374,14 @@ defmodule AshNeo4j.DataLayer do
         end
       end
 
-    Logger.debug("""
-    AshNeo4j.DataLayer: upsert result #{inspect(result)}
-    """)
+    Logger.debug("AshNeo4j.DataLayer: upsert result #{inspect(result)}")
 
     result
   end
 
   @impl true
   def update(resource, changeset) do
-    Logger.debug("""
-    AshNeo4j.DataLayer: update(#{inspect(resource)}, #{inspect(changeset)}})
-    """)
+    Logger.debug("AshNeo4j.DataLayer: update(#{inspect(resource)}, #{inspect(changeset)})")
 
     mapping = ResourceInfo.mapping(resource)
 
@@ -655,18 +641,14 @@ defmodule AshNeo4j.DataLayer do
 
     result = relationship_update_result || property_update_result
 
-    Logger.debug("""
-    AshNeo4j.DataLayer: update result #{inspect(result)}
-    """)
+    Logger.debug("AshNeo4j.DataLayer: update result #{inspect(result)}")
 
     result
   end
 
   @impl true
   def update_query(query, changeset, resource, opts) do
-    Logger.debug("""
-    AshNeo4j.DataLayer: update_query(#{inspect(query)}, #{inspect(changeset)}, #{inspect(resource)})
-    """)
+    Logger.debug("AshNeo4j.DataLayer: update_query(#{inspect(query)}, #{inspect(changeset)}, #{inspect(resource)})")
 
     mapping = ResourceInfo.mapping(resource)
 
@@ -747,9 +729,7 @@ defmodule AshNeo4j.DataLayer do
 
   @impl true
   def destroy_query(query, changeset, resource, opts) do
-    Logger.debug("""
-    AshNeo4j.DataLayer: destroy_query(#{inspect(query)}, #{inspect(changeset)}, #{inspect(resource)})
-    """)
+    Logger.debug("AshNeo4j.DataLayer: destroy_query(#{inspect(query)}, #{inspect(changeset)}, #{inspect(resource)})")
 
     mapping = ResourceInfo.mapping(resource)
 
@@ -809,9 +789,7 @@ defmodule AshNeo4j.DataLayer do
 
   @impl true
   def destroy(resource, changeset) do
-    Logger.debug("""
-    AshNeo4j.DataLayer: destroy(#{inspect(resource)}, #{inspect(changeset)}})
-    """)
+    Logger.debug("AshNeo4j.DataLayer: destroy(#{inspect(resource)}, #{inspect(changeset)})")
 
     mapping = ResourceInfo.mapping(resource)
 

--- a/lib/neo4j_helper.ex
+++ b/lib/neo4j_helper.ex
@@ -486,7 +486,7 @@ defmodule AshNeo4j.Neo4jHelper do
         length(records) > 0
 
       {:error, error} ->
-        Logger.error("AshNeo4j.Neo4jHelper.Error running query: #{inspect(error)}")
+        Logger.error("AshNeo4j.Neo4jHelper: error running query: #{inspect(error)}")
         :error
     end
   end
@@ -528,7 +528,7 @@ defmodule AshNeo4j.Neo4jHelper do
         length(records) > 0
 
       {:error, error} ->
-        Logger.error("AshNeo4j.Neo4jHelper.Error running query: #{inspect(error)}")
+        Logger.error("AshNeo4j.Neo4jHelper: error running query: #{inspect(error)}")
         :error
     end
   end


### PR DESCRIPTION
Closes #374.

Logging hygiene pass across the data layer.

## Changes
- **Flatten** the 13 multi-line heredoc `Logger.debug("""…""")` dumps to single lines — no more leading/trailing newlines cluttering each log entry.
- **Fix the `AshNeo4.Cypher` typo** (missing `j`) in `run_expecting_deletions`.
- **Fix two `}})` brace typos** in the `update`/`destroy` debug lines.
- **Standardize** the `AshNeo4j.Neo4jHelper.Error running query:` prefix → `AshNeo4j.Neo4jHelper: error running query:`.

## What changed vs. the ticket
The ticket's *eager expensive `inspect`* premise was **wrong** and I dropped it — verified empirically that Elixir's `Logger` macros already defer evaluation when the level is off (interpolation ran **0 times** at `:info`), so lazy-wrapping would be pointless churn. Left correctly-leveled sites alone: the Cypher-5-sunset `Logger.warning` (once-per-pool, dedup'd) and the `nodes_relate?` `:error` logs (the only surfacing of an otherwise-discarded error). See the [ticket comment](https://github.com/diffo-dev/ash_neo4j/issues/374#issuecomment-4740561742).

## Testing
`mix compile --warnings-as-errors` clean; full suite **716 passed**. `DEBUG=1` output now shows clean single-line `[debug] AshNeo4j.<Module>: …` entries.