### PR TITLE
refactor: typed data-layer errors, no bare strings (#372)

### DIFF
--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -572,8 +572,9 @@ defmodule AshNeo4j.Cypher do
         # Expected control flow, not an error: a preservation guard held the node,
         # or an optimistic-lock destroy missed. The caller disambiguates this into
         # StaleRecord / Unavailable, so trace it at :debug rather than :error (#373).
+        # `:nothing_deleted` is an internal sentinel (never escapes to Ash), #372.
         Logger.debug("AshNeo4j.Cypher: nothing deleted")
-        {:error, "nothing deleted"}
+        {:error, :nothing_deleted}
       else
         Logger.debug("AshNeo4j.Cypher: run_expecting_deletions deleted #{deleted_nodes} nodes")
         bolty_result

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -3,7 +3,35 @@
 # SPDX-License-Identifier: MIT
 
 defmodule AshNeo4j.DataLayer do
-  @moduledoc "Ash DataLayer for Neo4j"
+  @moduledoc """
+  Ash DataLayer for Neo4j.
+
+  ## Errors (#372)
+
+  Every error the behaviour callbacks (`create`/`update`/`destroy`/`run_query`/…)
+  return is a **typed struct** — never a bare string (a string becomes
+  `Ash.Error.Unknown.UnknownError`: unclassified and only substring-matchable).
+  Pick by meaning:
+
+    * **Server/Bolt error** → `AshNeo4j.Error.Neo4j` (classifies by category).
+    * **Deliberate refusal** ("can't push this down / won't render it") → the
+      `AshNeo4j.Error.Unsupported*` / `Requires*` family (`class: :invalid`).
+    * **The node/edge we expected to act on wasn't there** → reuse Ash's own:
+      `Ash.Error.Changes.StaleRecord` (the record is gone / a guard no longer holds)
+      or `Ash.Error.Invalid.Unavailable` (a preservation guard blocked a destroy).
+    * **An internal invariant we couldn't satisfy** (unexpected input shape, a
+      relationship/aggregate path that won't resolve) → `AshNeo4j.Error.Internal`
+      (`class: :unknown`).
+
+  Two standing rules: **reuse an Ash error before inventing an `AshNeo4j.Error.*`**,
+  and **return, never raise**, from the behaviour path. Internal sentinels between
+  helpers (e.g. `{:error, :nothing_deleted}` from `run_expecting_deletions/2`) are
+  atoms, not strings, and are converted to a typed error before escaping. The
+  contract is enforced by `test/error_contract_test.exs`.
+
+  `Ash.Type` callbacks (cast/dump/load) are a separate contract — they follow Ash's
+  type-error convention (message strings), not this one.
+  """
 
   @behaviour Ash.DataLayer
 
@@ -187,7 +215,7 @@ defmodule AshNeo4j.DataLayer do
     if Enum.all?(attributes, &is_atom/1) do
       {:ok, attributes}
     else
-      {:error, "Expected all attribute names to be atoms"}
+      {:error, internal("expected all attribute names to be atoms, got #{inspect(attributes)}")}
     end
   end
 
@@ -318,7 +346,7 @@ defmodule AshNeo4j.DataLayer do
     result =
       with :ok <- validate_writable_geo(mapping, changeset.attributes) do
         if Enum.empty?(id_attributes) do
-          {:error, "no values supplied for primary keys #{primary_keys}"}
+          {:error, internal("no values supplied for primary keys #{inspect(primary_keys)}")}
         else
           create_from_attributes(mapping, changeset.attributes)
         end
@@ -370,7 +398,7 @@ defmodule AshNeo4j.DataLayer do
             update(resource, changeset)
 
           {:ok, _} ->
-            {:error, "Multiple records matching keys"}
+            {:error, internal("multiple records match the upsert keys")}
         end
       end
 
@@ -406,6 +434,10 @@ defmodule AshNeo4j.DataLayer do
     Ash.Error.Changes.StaleRecord.exception(resource: resource, filter: changeset.filter)
   end
 
+  # An internal invariant the data layer couldn't satisfy (#372) — typed,
+  # matchable, classified `:unknown`, in place of a bare-string error.
+  defp internal(detail), do: AshNeo4j.Error.Internal.exception(detail: detail)
+
   defp do_update(resource, changeset, %ResourceMapping{} = mapping, guard_conditions, atomic_sets) do
     subject_id = id_properties(mapping, changeset.data)
     subject_label = mapping.label_pair
@@ -425,12 +457,11 @@ defmodule AshNeo4j.DataLayer do
                guard: guard_conditions,
                atomics: atomic_sets
              ) do
-          # No row matched the id + guard: a present guard ⇒ the row is stale
-          # (the predicate no longer holds); otherwise the id itself didn't match.
+          # No row matched: a present guard ⇒ the predicate no longer holds;
+          # otherwise the id itself didn't match. Either way the record we meant to
+          # update is gone — StaleRecord (#372).
           {:ok, %Bolty.Response{results: []}} ->
-            if guarded?,
-              do: {:error, stale_record(resource, changeset)},
-              else: {:error, "no result to update node"}
+            {:error, stale_record(resource, changeset)}
 
           {:ok, %Bolty.Response{results: [node_map | _]}} ->
             node = Map.get(node_map, "n")
@@ -454,7 +485,7 @@ defmodule AshNeo4j.DataLayer do
 
           case map_size(object_id) do
             0 ->
-              {:error, "couldn't unrelate nodes"}
+              {:error, internal("couldn't resolve the node to unrelate from #{inspect(resource)}.#{object_relationship_name}")}
 
             _ ->
               {_relationship_name, edge_label, object_to_subject_direction, _destination_label} =
@@ -470,7 +501,7 @@ defmodule AshNeo4j.DataLayer do
                      guard_conditions
                    ) do
                 {:ok, %Bolty.Response{results: []}} ->
-                  if guarded?, do: {:error, stale_record(resource, changeset)}, else: {:error, "no result to unrelate nodes"}
+                  {:error, stale_record(resource, changeset)}
 
                 {:ok, %Bolty.Response{results: [node_map | _]}} ->
                   node = Map.get(node_map, "s")
@@ -496,7 +527,7 @@ defmodule AshNeo4j.DataLayer do
                    relationship: object_relationship_name
                  )}
               else
-                {:error, "couldn't relate nodes"}
+                {:error, internal("couldn't resolve the node to relate from #{inspect(resource)}.#{object_relationship_name}")}
               end
 
             _ ->
@@ -512,7 +543,7 @@ defmodule AshNeo4j.DataLayer do
                      guard: guard_conditions
                    ) do
                 {:ok, %Bolty.Response{results: []}} ->
-                  if guarded?, do: {:error, stale_record(resource, changeset)}, else: {:error, "no result to relate nodes"}
+                  {:error, stale_record(resource, changeset)}
 
                 {:ok, %Bolty.Response{results: [node_map | _]}} ->
                   node = Map.get(node_map, "s")
@@ -550,7 +581,7 @@ defmodule AshNeo4j.DataLayer do
 
                 case map_size(object_id) do
                   0 ->
-                    {:halt, {:error, "couldn't unrelate nodes"}}
+                    {:halt, {:error, internal("couldn't resolve the node to unrelate for #{inspect(resource)}.#{relationship_name}")}}
 
                   _ ->
                     case Neo4jHelper.unrelate_nodes(
@@ -563,9 +594,7 @@ defmodule AshNeo4j.DataLayer do
                            guard_conditions
                          ) do
                       {:ok, %Bolty.Response{results: []}} ->
-                        if guarded?,
-                          do: {:halt, {:error, stale_record(resource, changeset)}},
-                          else: {:halt, {:error, "no result to unrelate nodes"}}
+                        {:halt, {:error, stale_record(resource, changeset)}}
 
                       {:ok, %Bolty.Response{results: [node_map | _]}} ->
                         node = Map.get(node_map, "s")
@@ -587,7 +616,7 @@ defmodule AshNeo4j.DataLayer do
 
                     case map_size(object_id) do
                       0 ->
-                        {:halt, {:error, "couldn't relate nodes using argument"}}
+                        {:halt, {:error, internal("couldn't resolve the node to relate for #{inspect(resource)}.#{relationship_name} from argument #{inspect(argument)}")}}
 
                       _ ->
                         subject_exclusive? = ResourceInfo.source_exclusive?(resource, relationship_name)
@@ -603,13 +632,11 @@ defmodule AshNeo4j.DataLayer do
                                exclusive: {subject_exclusive?, object_exclusive?},
                                guard: guard_conditions
                              ) do
-                          # With a `changeset.filter` guard (#368), zero rows means the
-                          # live source no longer satisfies it ⇒ StaleRecord (as #361);
-                          # without a guard it's an unmatched id/dest as before.
+                          # Zero rows: with a guard (#368) the live source no longer
+                          # satisfies it; without one the subject/dest didn't match.
+                          # Either way the record is gone ⇒ StaleRecord (#372).
                           {:ok, %Bolty.Response{results: []}} ->
-                            if guarded?,
-                              do: {:halt, {:error, stale_record(resource, changeset)}},
-                              else: {:halt, {:error, "no result to relate nodes"}}
+                            {:halt, {:error, stale_record(resource, changeset)}}
 
                           {:ok, %Bolty.Response{results: [node_map | _]}} ->
                             node = Map.get(node_map, "s")
@@ -635,7 +662,7 @@ defmodule AshNeo4j.DataLayer do
             end
           end)
         else
-          {:error, "changeset not handled"}
+          {:error, internal("update changeset not handled (no attributes, atomics or relationships to apply)")}
         end
       end
 
@@ -816,13 +843,13 @@ defmodule AshNeo4j.DataLayer do
 
       # Nothing deleted: if the node still matches the filter it was held back by a
       # guard (Unavailable); otherwise the optimistic lock didn't hold (StaleRecord).
-      {:error, "nothing deleted"} ->
+      {:error, :nothing_deleted} ->
         case Neo4jHelper.node_matching(label, id_properties, conditions) do
           {:ok, %Bolty.Response{results: [_ | _]}} ->
             {:error, unavailable_guarded(resource)}
 
           _ ->
-            {:error, Ash.Error.Changes.StaleRecord.exception(resource: resource, filter: changeset.filter)}
+            {:error, stale_record(resource, changeset)}
         end
 
       {:error, error} ->
@@ -844,7 +871,7 @@ defmodule AshNeo4j.DataLayer do
         {:ok, _} ->
           :ok
 
-        {:error, "nothing deleted"} ->
+        {:error, :nothing_deleted} ->
           {:error, unavailable_guarded(resource)}
 
         {:error, error} ->
@@ -1282,7 +1309,7 @@ defmodule AshNeo4j.DataLayer do
                     convert_to_resource(query, mapping, hd(consolidated_groups))
 
                   true ->
-                    {:error, "expected groups to consolidate to a single group (resource)"}
+                    {:error, internal("expected enrichment groups to consolidate to a single resource")}
                 end
 
               {:error, error} ->
@@ -1617,7 +1644,7 @@ defmodule AshNeo4j.DataLayer do
             |> Map.new(fn {source_id, dest_nodes} -> {source_id, project_reached(resource, dest_nodes)} end)
 
           {:error, reason} ->
-            raise "AshNeo4j: traverse projection query failed: #{inspect(reason)}"
+            raise AshNeo4j.Error.Internal, detail: "traverse projection query failed: #{inspect(reason)}"
         end
     end
   end
@@ -2149,7 +2176,7 @@ defmodule AshNeo4j.DataLayer do
     Enum.reduce_while(relationship_path, {mapping, []}, fn name, {current_mapping, segments} ->
       case Enum.find(current_mapping.edges, &(&1.relationship == name)) do
         nil ->
-          {:halt, {:error, "relationship #{name} not found on #{current_mapping.module}"}}
+          {:halt, {:error, internal("relationship #{name} not found on #{inspect(current_mapping.module)}")}}
 
         %EdgeDescriptor{label: edge_label, direction: direction, destination_label: dest_label} ->
           relationship = Ash.Resource.Info.relationship(current_mapping.module, name)

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -147,6 +147,28 @@ defmodule AshNeo4j.Error.UnsupportedManyToMany do
   end
 end
 
+defmodule AshNeo4j.Error.Internal do
+  @moduledoc """
+  **Returned** (never raised) for an internal invariant the data layer couldn't
+  satisfy — an input shape it didn't expect, or a relationship/aggregate path it
+  couldn't resolve (#372). Distinct from the `Unsupported*` / `Requires*` family
+  (deliberate refusals, `:invalid`) and from `Neo4j` (server errors): this is "we
+  reached a state we shouldn't have", so its class is `:unknown`.
+
+  Carries a `:detail` string (and optional `:context`) for diagnosis. A typed,
+  matchable replacement for the bare-string `{:error, "…"}` returns the data layer
+  used to leak — which Ash wrapped as `Ash.Error.Unknown.UnknownError`, unclassified
+  and only substring-matchable.
+  """
+  use Splode.Error, fields: [:detail, :context], class: :unknown
+
+  def message(%{detail: detail, context: context}) when context not in [nil, %{}] do
+    "AshNeo4j internal error: #{detail} (#{inspect(context)})"
+  end
+
+  def message(%{detail: detail}), do: "AshNeo4j internal error: #{detail}"
+end
+
 defmodule AshNeo4j.Error.Neo4j do
   @moduledoc """
   Wraps a Neo4j server error surfaced from `AshNeo4j.Cypher.run/1` (a

--- a/lib/neo4j_helper.ex
+++ b/lib/neo4j_helper.ex
@@ -411,7 +411,7 @@ defmodule AshNeo4j.Neo4jHelper do
   end
 
   @spec relate_nodes(atom() | [atom()], map(), list()) ::
-          {:error, bitstring()}
+          {:error, Exception.t()}
           | :ok
   @doc """
   Creates source neo4j node with label, properties and relationships to existing nodes

--- a/lib/neo4j_helper.ex
+++ b/lib/neo4j_helper.ex
@@ -91,7 +91,7 @@ defmodule AshNeo4j.Neo4jHelper do
   @doc """
   Single filtered + guarded destroy (#361): deletes the `id`-matched node when it
   satisfies `filter_conditions` (optimistic lock) and isn't `guard`-protected.
-  `{:ok, _}` when deleted, `{:error, "nothing deleted"}` otherwise.
+  `{:ok, _}` when deleted, `{:error, :nothing_deleted}` otherwise.
   """
   def delete_node_filtered(label, id_props, filter_conditions, guards)
       when (is_atom(label) or is_list(label)) and is_map(id_props) and is_list(filter_conditions) and
@@ -454,8 +454,8 @@ defmodule AshNeo4j.Neo4jHelper do
       end)
 
     case results do
-      :error -> {:error, "error relating nodes"}
-      [] -> {:error, "unexpected empty result relating nodes"}
+      :error -> {:error, AshNeo4j.Error.Internal.exception(detail: "error relating nodes during create")}
+      [] -> {:error, AshNeo4j.Error.Internal.exception(detail: "unexpected empty result relating nodes during create")}
       _ -> :ok
     end
   end

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -167,7 +167,8 @@ defmodule AshNeo4j.QueryHelper do
     end
   end
 
-  defp classify_combination(_), do: {:error, "AshNeo4j: combination_of must start with :base"}
+  defp classify_combination(_),
+    do: {:error, AshNeo4j.Error.Internal.exception(detail: "combination_of must start with :base")}
 
   # builder: :nodes | :ids — which branch_node_read variant to use.
   # Returns the branch Cypher.Query, or `{:error, _}` if a branch predicate

--- a/test/error_contract_test.exs
+++ b/test/error_contract_test.exs
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.ErrorContractTest do
+  @moduledoc """
+  Guards the data-layer error contract (#372): the behaviour modules must never
+  return a bare-string `{:error, "…"}`. Every error the data layer surfaces is a
+  typed struct — an `AshNeo4j.Error.*` (e.g. `Internal`, `Neo4j`, `Unsupported*`)
+  or a reused Ash error (`StaleRecord`, `Unavailable`, …) — so it carries a `class`
+  and structured fields and is pattern-matchable. A bare string becomes
+  `Ash.Error.Unknown.UnknownError` (unclassified, only substring-matchable).
+
+  Internal sentinels between helpers (e.g. `{:error, :nothing_deleted}`) are atoms,
+  not strings, and never escape to Ash.
+
+  `Ash.Type` callback modules (`data_layer/cast.ex`, `data_layer/dump.ex`,
+  `util.ex`, `type/*`, `vector.ex`, `spatial.ex`) are **deliberately excluded** —
+  type callbacks follow Ash's type-error convention (message strings / `:error`),
+  which is a different contract from the data-layer behaviour callbacks.
+  """
+  use ExUnit.Case, async: true
+
+  # The data-layer behaviour callbacks and their direct helpers — the surface whose
+  # `{:error, _}` is returned to Ash and classified by `class`.
+  @behaviour_modules ~w(
+    lib/data_layer.ex
+    lib/neo4j_helper.ex
+    lib/cypher.ex
+    lib/query_helper.ex
+  )
+
+  test "behaviour modules never return a bare-string {:error, \"…\"}" do
+    offenders =
+      for path <- @behaviour_modules,
+          {line, idx} <- Enum.with_index(String.split(File.read!(path), "\n"), 1),
+          String.match?(line, ~r/\{:error,\s*"/),
+          do: "#{path}:#{idx}: #{String.trim(line)}"
+
+    assert offenders == [],
+           "Found bare-string error return(s) in behaviour modules — use a typed " <>
+             "AshNeo4j.Error.* or a reused Ash error instead (#372):\n" <>
+             Enum.join(offenders, "\n")
+  end
+end


### PR DESCRIPTION
Closes #372.

## Summary

The data-layer behaviour callbacks returned a mix of typed `AshNeo4j.Error.*` structs and ~22 bare-string `{:error, "…"}` returns. A bare string becomes `Ash.Error.Unknown.UnknownError` — wrong `class` (most of these are a stale-record or internal-invariant condition, not `:unknown`), no structured fields, and only substring-matchable. This makes the `{:error, _}` shape a real, typed, matchable contract.

## Decision rule applied

| The failure is… | Now returns |
|---|---|
| Server/Bolt error | `AshNeo4j.Error.Neo4j` (already) |
| Deliberate refusal | `Unsupported*` / `Requires*` (already) |
| The node/edge we meant to act on wasn't there | reuse `Ash.Error.Changes.StaleRecord` / `Ash.Error.Invalid.Unavailable` |
| An internal invariant we couldn't satisfy | **new** `AshNeo4j.Error.Internal` (`class: :unknown`) |

Standing rules codified: **reuse an Ash error before inventing one**, and **return, never raise**.

## Changes

- **`AshNeo4j.Error.Internal`** (new, `:unknown`) — typed catch-all for invariant/resolution failures, carries `:detail`/`:context`.
- **`StaleRecord`** for the `no result to update/relate/unrelate` cluster — collapses the now-redundant `guarded?` branches (guarded miss and unguarded id-miss are both "the record is gone").
- **`Internal`** for `changeset not handled`, `Multiple records matching keys`, unresolvable relate/aggregate paths, `combination_of must start with :base`, etc.
- **Internal sentinel** `"nothing deleted"` → atom `:nothing_deleted` (it never escapes to Ash; converted to `StaleRecord`/`Unavailable` at the destroy callers).
- The one behaviour-path `raise` → a typed exception.
- **`Ash.Type` callbacks left as-is** (cast/dump/load) — those follow Ash's type-error convention (message strings), a separate contract; documented.

## Guardrail + docs

- `test/error_contract_test.exs` — asserts the behaviour modules never contain a bare-string `{:error, "…"}` (static source check), so this can't silently regress.
- An **Errors** section in the `AshNeo4j.DataLayer` moduledoc codifying the policy + decision rule.

## Testing

`mix compile --warnings-as-errors` clean; full suite **717 passed** (716 + the new guard). Existing StaleRecord / `UnsupportedManyToMany` tests still pass, confirming the conversions preserved behaviour.
