### PR TITLE
feat: enforce identities as Neo4j uniqueness constraints (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ The DSL is verified against misconfiguration and violation of accepted neo4j con
 * relate: relationship_name must match the name of a relationship
 * relate: relationship enrichment not possible, edge_label, edge_direction and destination_label must be unique
 * attribute type requires unsupported term
+* identity cannot be enforced as a uniqueness constraint (`nils_distinct?: false`, or a filtered `where:`)
 
 ## Testing
 
@@ -303,6 +304,10 @@ A few things to note:
 ## Keys
 
 We've generally used :uuid_primary_key, which Ash creates. While it *may* be possible to use other types for primary keys, we haven't done so yet.
+
+## Identities
+
+An Ash `identity` is enforced at the database level with a Neo4j uniqueness constraint, so you don't need `pre_check?` (and its race window). Create the constraints yourself — like vector indexes, AshNeo4j runs no migrations on boot — with `AshNeo4j.Constraint.create_constraints/1` (single and composite identities are both supported on Community Edition). A conflicting create surfaces as Ash's own `Ash.Error.Changes.InvalidAttribute` ("has already been taken"), in Ash terms. Identities Neo4j can't enforce (`nils_distinct?: false`, or a filtered `where:`) are refused — at compile time and by the helper — rather than silently left unenforced. See `usage-rules/identities.md`.
 
 ## Elixir nil and Neo4j Null
 

--- a/lib/constraint.ex
+++ b/lib/constraint.ex
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Constraint do
+  @moduledoc """
+  Convenience helpers for creating the Neo4j uniqueness constraints that enforce a
+  resource's `identities` at the database level (#20).
+
+      # Create the constraints for every identity on a resource
+      AshNeo4j.Constraint.create_constraints(AssignmentRelationship)
+
+      # Review the Cypher without touching the database
+      AshNeo4j.Constraint.constraint_statements(AssignmentRelationship)
+
+  Consistent with AshNeo4j's "no automatic migrations" stance — like
+  `AshNeo4j.Vector`, this is an ergonomic tool you call (e.g. from a start-up or
+  release task), not run on boot. Statements use `IF NOT EXISTS`, so they are safe
+  to run repeatedly.
+
+  ## Unsupported identities are refused, not skipped
+
+  An identity that can't be enforced — `nils_distinct?: false`, or a filtered
+  identity (`where:`) — returns `{:error, %AshNeo4j.Error.UnsupportedIdentity{}}`
+  and creates **nothing** for the resource (all-or-nothing). Skipping would leave
+  the identity unenforced and permit the duplicate records the constraint exists to
+  prevent. The same cases are refused at compile time by
+  `AshNeo4j.Verifiers.VerifyIdentities`.
+
+  ## Naming
+
+  Each constraint is named `<label_lower>_<identity_name>`, e.g.
+  `assignmentrelationship_unique_assignment`.
+  """
+
+  alias AshNeo4j.Cypher
+  alias AshNeo4j.Error.UnsupportedIdentity
+  alias AshNeo4j.Resource.Info, as: ResourceInfo
+
+  @doc """
+  Runs `CREATE CONSTRAINT … IF NOT EXISTS` for every identity on `resource`.
+
+  Returns `{:ok, [%Bolty.Response{}]}` (one per identity, empty when the resource
+  has none), or `{:error, %AshNeo4j.Error.UnsupportedIdentity{}}` if any identity
+  can't be enforced — in which case nothing is created.
+  """
+  @spec create_constraints(Ash.Resource.t(), keyword()) ::
+          {:ok, [Bolty.Response.t()]} | {:error, term()}
+  def create_constraints(resource, _opts \\ []) do
+    with {:ok, specs} <- specs(resource) do
+      run_all(Enum.map(specs, &create_cypher/1))
+    end
+  end
+
+  @doc """
+  Runs `DROP CONSTRAINT … IF EXISTS` for every identity on `resource`. A no-op for
+  absent constraints. Unsupported identities are refused (nothing was created for
+  them to drop), consistent with `create_constraints/2`.
+  """
+  @spec drop_constraints(Ash.Resource.t(), keyword()) ::
+          {:ok, [Bolty.Response.t()]} | {:error, term()}
+  def drop_constraints(resource, _opts \\ []) do
+    with {:ok, specs} <- specs(resource) do
+      run_all(Enum.map(specs, &drop_cypher/1))
+    end
+  end
+
+  @doc """
+  Returns `{:ok, [statement]}` — the `CREATE CONSTRAINT` Cypher `create_constraints/2`
+  would run — without touching the database, or `{:error, %UnsupportedIdentity{}}`.
+
+      AshNeo4j.Constraint.constraint_statements(Post)
+      #=> {:ok, ["CREATE CONSTRAINT post_unique_unique IF NOT EXISTS FOR (n:Post) REQUIRE n.unique IS UNIQUE"]}
+  """
+  @spec constraint_statements(Ash.Resource.t()) :: {:ok, [String.t()]} | {:error, term()}
+  def constraint_statements(resource) do
+    with {:ok, specs} <- specs(resource), do: {:ok, Enum.map(specs, &create_cypher/1)}
+  end
+
+  # --- resolution --------------------------------------------------------
+
+  # Resolves every identity to a constraint spec, or refuses the first one that
+  # can't be enforced (all-or-nothing).
+  defp specs(resource) do
+    label = ResourceInfo.module_label(resource)
+    translations = ResourceInfo.translations(resource)
+
+    Enum.reduce_while(Ash.Resource.Info.identities(resource), {:ok, []}, fn identity, {:ok, acc} ->
+      case spec(resource, label, translations, identity) do
+        {:ok, spec} -> {:cont, {:ok, [spec | acc]}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, specs} -> {:ok, Enum.reverse(specs)}
+      error -> error
+    end
+  end
+
+  defp spec(resource, _label, _translations, %{where: where} = identity) when where != nil do
+    {:error, UnsupportedIdentity.exception(resource: resource, identity: identity.name, keys: identity.keys, reason: :filtered)}
+  end
+
+  defp spec(resource, _label, _translations, %{nils_distinct?: false} = identity) do
+    {:error,
+     UnsupportedIdentity.exception(resource: resource, identity: identity.name, keys: identity.keys, reason: :nils_not_distinct)}
+  end
+
+  defp spec(_resource, label, translations, identity) do
+    properties = Enum.map(identity.keys, fn key -> to_string(Keyword.get(translations, key, key)) end)
+
+    {:ok,
+     %{
+       name: "#{label |> to_string() |> String.downcase()}_#{identity.name}",
+       label: label,
+       properties: properties
+     }}
+  end
+
+  # --- cypher ------------------------------------------------------------
+
+  defp create_cypher(%{name: name, label: label, properties: properties}) do
+    "CREATE CONSTRAINT #{name} IF NOT EXISTS FOR (n:#{label}) REQUIRE #{require_clause(properties)} IS UNIQUE"
+  end
+
+  defp drop_cypher(%{name: name}), do: "DROP CONSTRAINT #{name} IF EXISTS"
+
+  defp require_clause([property]), do: "n.#{property}"
+  defp require_clause(properties), do: "(" <> Enum.map_join(properties, ", ", &"n.#{&1}") <> ")"
+
+  defp run_all(statements) do
+    Enum.reduce_while(statements, {:ok, []}, fn cypher, {:ok, acc} ->
+      case Cypher.run(cypher) do
+        {:ok, response} -> {:cont, {:ok, [response | acc]}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, responses} -> {:ok, Enum.reverse(responses)}
+      error -> error
+    end
+  end
+end

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -236,7 +236,8 @@ defmodule AshNeo4j.DataLayer do
       AshNeo4j.Verifiers.VerifyGuard,
       AshNeo4j.Verifiers.VerifyPropertiesCamelCase,
       AshNeo4j.Verifiers.VerifyEnrichable,
-      AshNeo4j.Verifiers.VerifyAttributeType
+      AshNeo4j.Verifiers.VerifyAttributeType,
+      AshNeo4j.Verifiers.VerifyIdentities
     ]
 
   defmodule Query do
@@ -351,10 +352,41 @@ defmodule AshNeo4j.DataLayer do
           create_from_attributes(mapping, changeset.attributes)
         end
       end
+      |> map_identity_conflict(resource, changeset)
 
     Logger.debug("AshNeo4j.DataLayer: create result #{inspect(result)}")
 
     result
+  end
+
+  # A Neo4j uniqueness-constraint violation (#20) means the resource's `identity`
+  # was breached. Surface it as Ash's own identity-conflict error — one
+  # `InvalidAttribute` ("has already been taken") per attribute of the violated
+  # identity — so it reads in Ash terms (resource + attributes), not as a raw graph
+  # error. Through the driver the violation's code is reliable
+  # (`ConstraintValidationFailed`) but its message is generic, so the identity is
+  # found from the changeset: the one whose keys are all set (so could have
+  # collided). Exactly one such identity ⇒ map it; none or ambiguous ⇒ fall back to
+  # the raw error rather than guess.
+  defp map_identity_conflict({:error, %AshNeo4j.Error.Neo4j{category: :constraint}} = error, resource, changeset) do
+    case conflicting_identity(resource, changeset.attributes) do
+      %{keys: keys} ->
+        {:error, Enum.map(keys, &Ash.Error.Changes.InvalidAttribute.exception(field: &1, message: "has already been taken"))}
+
+      nil ->
+        error
+    end
+  end
+
+  defp map_identity_conflict(result, _resource, _changeset), do: result
+
+  defp conflicting_identity(resource, attributes) do
+    case Enum.filter(Ash.Resource.Info.identities(resource), fn identity ->
+           Enum.all?(identity.keys, &(Map.get(attributes, &1) != nil))
+         end) do
+      [identity] -> identity
+      _ -> nil
+    end
   end
 
   @impl true

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -147,6 +147,39 @@ defmodule AshNeo4j.Error.UnsupportedManyToMany do
   end
 end
 
+defmodule AshNeo4j.Error.UnsupportedIdentity do
+  @moduledoc """
+  **Returned** (never raised) when an `identity` can't be enforced as a Neo4j
+  uniqueness constraint (#20), so it can't be created by `AshNeo4j.Constraint` —
+  and is refused rather than skipped, since silently leaving it unenforced would
+  permit the duplicate/split records the constraint exists to prevent.
+
+  Two cases Neo4j's `REQUIRE … IS UNIQUE` can't express:
+
+    * `nils_distinct?: false` — Neo4j treats `nil`s as distinct (a node missing a
+      listed property is not constrained) and can't be made to treat them as equal.
+    * a **filtered** identity (`where:`) — Neo4j has no partial/filtered constraint.
+
+  Drop the unsupported option, or enforce that identity another way (it won't fall
+  back to a database constraint). The same refusal is raised at compile time by
+  `AshNeo4j.Verifiers.VerifyIdentities`.
+  """
+  use Splode.Error, fields: [:resource, :identity, :keys, :reason], class: :invalid
+
+  # Framed in Ash terms (resource, identity, attributes, identity options) — the
+  # Ash user shouldn't need to reason about the graph mapping; the *why* (Neo4j's
+  # constraint limitations) lives in the moduledoc above, for maintainers.
+  def message(%{resource: resource, identity: identity, keys: keys, reason: reason}) do
+    "cannot enforce uniqueness for identity :#{identity} (#{inspect(keys)}) on #{inspect(resource)} — " <>
+      "the AshNeo4j data layer doesn't support #{explain(reason)}. Drop the option, or enforce that " <>
+      "identity another way (#20)."
+  end
+
+  defp explain(:nils_not_distinct), do: "identities with `nils_distinct?: false`"
+  defp explain(:filtered), do: "filtered identities (`where:`)"
+  defp explain(other), do: inspect(other)
+end
+
 defmodule AshNeo4j.Error.Internal do
   @moduledoc """
   **Returned** (never raised) for an internal invariant the data layer couldn't

--- a/lib/verifiers/verify_identities.ex
+++ b/lib/verifiers/verify_identities.ex
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Verifiers.VerifyIdentities do
+  @moduledoc """
+  Refuses, at compile time, any `identity` that can't be enforced as a Neo4j
+  uniqueness constraint (#20) — so an unenforceable identity is caught loudly here
+  rather than silently leaving a gap that permits duplicate/split records.
+
+  Neo4j's `REQUIRE … IS UNIQUE` can't express two identity options:
+
+    * `nils_distinct?: false` — Neo4j treats `nil`s as distinct and can't be made
+      to treat them as equal.
+    * a **filtered** identity (`where:`) — there is no partial/filtered constraint.
+
+  The runtime counterpart is `AshNeo4j.Error.UnsupportedIdentity`, returned by
+  `AshNeo4j.Constraint` for the same cases.
+  """
+  use Spark.Dsl.Verifier
+
+  alias Spark.Dsl.Verifier
+  alias Spark.Error.DslError
+
+  @impl true
+  def verify(dsl) do
+    resource = Verifier.get_persisted(dsl, :module)
+
+    dsl
+    |> Verifier.get_entities([:identities])
+    |> Enum.find_value(:ok, fn identity ->
+      cond do
+        identity.where != nil ->
+          refuse(resource, identity, "filtered identities (`where:`)")
+
+        identity.nils_distinct? == false ->
+          refuse(resource, identity, "identities with `nils_distinct?: false`")
+
+        true ->
+          nil
+      end
+    end)
+  end
+
+  # Framed in Ash terms (resource, identity, attributes, identity options); the
+  # graph reason lives in the moduledoc, not in what the resource author sees.
+  defp refuse(resource, identity, unsupported) do
+    {:error,
+     DslError.exception(
+       module: resource,
+       path: [:identities, identity.name],
+       message:
+         "cannot enforce uniqueness for identity :#{identity.name} (#{inspect(identity.keys)}) — " <>
+           "the AshNeo4j data layer doesn't support #{unsupported}. Drop the unsupported option, " <>
+           "or enforce that identity another way (#20)."
+     )}
+  end
+end

--- a/test/identities_test.exs
+++ b/test/identities_test.exs
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.IdentitiesTest do
+  @moduledoc """
+  Ash `identities` enforced as Neo4j uniqueness constraints (#20):
+  `AshNeo4j.Constraint` renders/creates the constraints; a violation surfaces as an
+  Ash identity conflict (`InvalidAttribute`, "has already been taken"), in Ash terms;
+  and identities Neo4j can't enforce are refused — at compile time by
+  `AshNeo4j.Verifiers.VerifyIdentities`, and by the helper.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshNeo4j.{BoltyHelper, Constraint, Sandbox}
+  alias AshNeo4j.Test.Resource.{Author, Post, Upsert}
+  alias AshNeo4j.Test.Util
+
+  setup_all do
+    BoltyHelper.start()
+    # No sandbox here ⇒ runs as a committed schema change; dropped after the suite.
+    {:ok, _} = Constraint.create_constraints(Post)
+    on_exit(fn -> Constraint.drop_constraints(Post) end)
+    :ok
+  end
+
+  defp flatten(%{errors: errors}) when is_list(errors), do: Enum.flat_map(errors, &flatten/1)
+  defp flatten(e), do: [e]
+
+  describe "constraint statements" do
+    test "single-property identity → unparenthesised REQUIRE" do
+      assert {:ok, ["CREATE CONSTRAINT post_unique_unique IF NOT EXISTS FOR (n:Post) REQUIRE n.unique IS UNIQUE"]} =
+               Constraint.constraint_statements(Post)
+    end
+
+    test "composite identity → parenthesised, camelCased properties" do
+      assert {:ok,
+              [
+                "CREATE CONSTRAINT upsert_full_name IF NOT EXISTS FOR (n:Upsert) REQUIRE (n.firstName, n.surname) IS UNIQUE"
+              ]} = Constraint.constraint_statements(Upsert)
+    end
+  end
+
+  describe "compile-time verifier refuses unenforceable identities" do
+    test "nils_distinct?: false" do
+      Util.assert_compile_time_warning(Spark.Error.DslError, "identities with `nils_distinct?: false`", fn ->
+        defmodule NilsNotDistinct do
+          use Ash.Resource, domain: AshNeo4j.Test.SRM, data_layer: AshNeo4j.DataLayer
+
+          neo4j do
+            label :NilsNotDistinct
+          end
+
+          attributes do
+            uuid_primary_key :id
+            attribute :code, :string, public?: true
+          end
+
+          identities do
+            identity :by_code, [:code], nils_distinct?: false
+          end
+        end
+      end)
+    end
+
+    test "filtered identity (where:)" do
+      Util.assert_compile_time_warning(Spark.Error.DslError, "filtered identities", fn ->
+        defmodule FilteredIdentity do
+          use Ash.Resource, domain: AshNeo4j.Test.SRM, data_layer: AshNeo4j.DataLayer
+          require Ash.Expr
+
+          neo4j do
+            label :FilteredIdentity
+          end
+
+          attributes do
+            uuid_primary_key :id
+            attribute :code, :string, public?: true
+            attribute :active, :boolean, public?: true
+          end
+
+          identities do
+            identity :by_code, [:code] do
+              where expr(active == true)
+            end
+          end
+        end
+      end)
+    end
+  end
+
+  describe "database constraint enforces the identity" do
+    setup do
+      Sandbox.checkout()
+      on_exit(&Sandbox.rollback/0)
+      {:ok, author} = Author |> Ash.Changeset.for_create(:create, %{name: "author"}) |> Ash.create()
+      %{author: author}
+    end
+
+    test "a duplicate surfaces as an Ash identity conflict, not a raw graph error", %{author: author} do
+      {:ok, _} =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "p1", unique: "x", written_by: author.id})
+        |> Ash.create()
+
+      assert {:error, error} =
+               Post
+               |> Ash.Changeset.for_create(:create, %{title: "p2", unique: "x", written_by: author.id})
+               |> Ash.create()
+
+      errors = flatten(error)
+      # In Ash terms: InvalidAttribute on the identity's attribute, "has already been taken".
+      assert Enum.any?(
+               errors,
+               &match?(%Ash.Error.Changes.InvalidAttribute{field: :unique, message: "has already been taken"}, &1)
+             )
+
+      # Not the raw graph error.
+      refute Enum.any?(errors, &match?(%AshNeo4j.Error.Neo4j{}, &1))
+    end
+  end
+end

--- a/usage-rules/identities.md
+++ b/usage-rules/identities.md
@@ -1,0 +1,70 @@
+<!--
+SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+
+SPDX-License-Identifier: MIT
+-->
+
+# Identities and uniqueness constraints
+
+An Ash `identity` declares that a set of attributes is unique. AshNeo4j enforces
+that at the database level with a Neo4j uniqueness constraint, so concurrent writes
+can't create duplicates and you don't need `pre_check?` (an Elixir-side read that
+still leaves a race window).
+
+```elixir
+identities do
+  identity :unique_assignment, [:source_id, :pool, :thing, :value]
+end
+```
+
+## Creating the constraints
+
+Like vector indexes, this is an ergonomic helper you run yourself (e.g. from a
+start-up or release task) — AshNeo4j does not run migrations on boot. Statements use
+`IF NOT EXISTS`, so they are safe to run repeatedly.
+
+```elixir
+# Create the uniqueness constraint(s) for every identity on a resource
+AshNeo4j.Constraint.create_constraints(AssignmentRelationship)
+
+# Review the Cypher without touching the database
+AshNeo4j.Constraint.constraint_statements(AssignmentRelationship)
+#=> {:ok, ["CREATE CONSTRAINT assignmentrelationship_unique_assignment IF NOT EXISTS " <>
+#          "FOR (n:AssignmentRelationship) REQUIRE (n.sourceId, n.pool, n.thing, n.value) IS UNIQUE"]}
+
+# Drop them
+AshNeo4j.Constraint.drop_constraints(AssignmentRelationship)
+```
+
+Single- and multi-attribute identities are both supported (composite `IS UNIQUE`
+constraints work on Neo4j Community Edition). Each constraint is named
+`<label_lower>_<identity_name>`.
+
+## Conflicts are surfaced in Ash terms
+
+When a create violates a constraint, AshNeo4j returns Ash's own identity-conflict
+error — an `Ash.Error.Changes.InvalidAttribute` ("has already been taken") on each
+attribute of the identity — not a raw Neo4j error. So forms and changesets handle it
+exactly as they would on any other data layer.
+
+```elixir
+{:error, error} = AssignmentRelationship |> Ash.create(%{source_id: 1, pool: :p, thing: :t, value: 7})
+# => InvalidAttribute on :source_id/:pool/:thing/:value, message "has already been taken"
+```
+
+## What can't be enforced (refused, not silently skipped)
+
+Two Ash identity options have no Neo4j uniqueness-constraint equivalent. Rather than
+create nothing and silently leave the identity unenforced — which would permit the
+duplicates the constraint exists to prevent — AshNeo4j **refuses** them:
+
+| Identity option | Why | When you find out |
+|---|---|---|
+| `nils_distinct?: false` | Neo4j treats `nil`s as distinct and can't be made to treat them as equal | compile time (`AshNeo4j.Verifiers.VerifyIdentities`) and from `AshNeo4j.Constraint` (`AshNeo4j.Error.UnsupportedIdentity`) |
+| a filtered identity (`where:`) | Neo4j has no partial/filtered constraint | same |
+
+Drop the unsupported option, or enforce that identity another way — it will not fall
+back to a database constraint.
+
+The default `nils_distinct?: true` maps cleanly: a node missing any of the
+constrained attributes is not subject to the constraint (its `nil`s are distinct).


### PR DESCRIPTION
Closes #20 (scope A — the correctness fix). Atomic `MERGE` upsert is #379; migrations deferred.

## Summary

Ash `identities` were silently ignored at the data layer — uniqueness was only ever a racy Elixir-side `pre_check?`. This enforces them in the database.

**Feasibility verified:** composite `… REQUIRE (n.a, n.b, …) IS UNIQUE` works on Neo4j **Community** 5.26 (the motivating 4-attribute `AssignmentRelationship` case); `IS NODE KEY` is Enterprise-only but unneeded (identities are uniqueness, not existence).

## What's here

- **`AshNeo4j.Constraint`** — manual DDL helpers (`constraint_statements/1`, `create_constraints/2`, `drop_constraints/2`) mirroring `AshNeo4j.Vector`, deriving `CREATE CONSTRAINT <label_lower>_<identity_name> IF NOT EXISTS FOR (n:Label) REQUIRE … IS UNIQUE` from a resource's identities. Single and composite supported. No migrations on boot — run it from a start-up/release task (`IF NOT EXISTS`, safe to repeat).
- **Violation → Ash identity error** in `create/2`: a uniqueness-constraint violation becomes `Ash.Error.Changes.InvalidAttribute` ("has already been taken") on each identity attribute — in Ash terms, not a raw graph error, so forms/changesets handle it normally. Through the driver the violation message is generic, so the identity is found from the changeset (the one whose keys are all set), not by parsing the message.
- **Refuse, don't skip** the unenforceable: `nils_distinct?: false` and filtered (`where:`) identities have no Neo4j equivalent and would leave uniqueness silently unenforced. Refused at **compile time** (`AshNeo4j.Verifiers.VerifyIdentities`) and by the helper (`AshNeo4j.Error.UnsupportedIdentity`).
- Error/verifier messages are framed in **Ash terms** (resource, identity, attributes, identity options) — the graph mechanics stay in moduledocs for maintainers.
- Docs: `usage-rules/identities.md` + README section + verifier list.

## Testing

`mix test` — **722 passed**; `mix dialyzer` clean; `--warnings-as-errors` clean. Covers: statement rendering (single + composite, camelCased), compile-time refusal of both unsupported options, and a live duplicate surfacing as an `InvalidAttribute` identity conflict (constraint managed in `setup_all` outside the sandbox transaction, dropped after — no leak).

## Note

A real constraint violation logs `[error] Bolty … :ignored` on the way out. This is **not** ash_neo4j logging — it's an upstream bolty bug: a FAILURE inside a transaction leaves the Bolt connection in the protocol's FAILED state, so the subsequent rollback is `IGNORED` and the connection is force-disconnected. Root-caused and reported with a minimal repro in [diffo-dev/bolty#54](https://github.com/diffo-dev/bolty/issues/54). ash_neo4j's handling is correct (the violation surfaces as a proper `InvalidAttribute`); there's no clean ash_neo4j-side workaround (bolty exposes no `RESET`), so the noise clears once bolty#54 is addressed upstream.

