### PR TITLE
feat: atomic MERGE-based upsert keyed on identity (#379)

### DIFF
--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -23,6 +23,8 @@ defmodule AshNeo4j.Cypher do
     Where,
     With,
     Set,
+    OnCreateSet,
+    OnMatchSet,
     Remove,
     Delete,
     DetachDelete,
@@ -420,6 +422,8 @@ defmodule AshNeo4j.Cypher do
   defp render_clause(%Where{conditions: conds}), do: "WHERE #{Enum.join(conds, " AND ")}"
   defp render_clause(%With{items: items}), do: "WITH #{Enum.join(items, ", ")}"
   defp render_clause(%Set{expression: e}), do: "SET #{e}"
+  defp render_clause(%OnCreateSet{expression: e}), do: "ON CREATE SET #{e}"
+  defp render_clause(%OnMatchSet{expression: e}), do: "ON MATCH SET #{e}"
   defp render_clause(%Remove{items: items}), do: "REMOVE #{Enum.join(items, ", ")}"
   defp render_clause(%Delete{items: items}), do: "DELETE #{Enum.join(items, ", ")}"
   defp render_clause(%DetachDelete{items: items}), do: "DETACH DELETE #{Enum.join(items, ", ")}"

--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -46,6 +46,18 @@ defmodule AshNeo4j.Cypher.Set do
   defstruct [:expression]
 end
 
+defmodule AshNeo4j.Cypher.OnCreateSet do
+  @moduledoc "ON CREATE SET clause (MERGE). `expression` is the full SET expression, e.g. `\"n += {born: $nc_born}\"`."
+  @type t :: %__MODULE__{expression: String.t()}
+  defstruct [:expression]
+end
+
+defmodule AshNeo4j.Cypher.OnMatchSet do
+  @moduledoc "ON MATCH SET clause (MERGE). `expression` is the full SET expression, e.g. `\"n += {touched: $nm_touched}\"`."
+  @type t :: %__MODULE__{expression: String.t()}
+  defstruct [:expression]
+end
+
 defmodule AshNeo4j.Cypher.Remove do
   @moduledoc "REMOVE clause. `items` is a list of property references, e.g. `[\"n.born\"]`."
   @type t :: %__MODULE__{items: [String.t()]}
@@ -138,6 +150,8 @@ defmodule AshNeo4j.Cypher.Query do
     Where,
     With,
     Set,
+    OnCreateSet,
+    OnMatchSet,
     Remove,
     Delete,
     DetachDelete,
@@ -157,6 +171,8 @@ defmodule AshNeo4j.Cypher.Query do
           | Where.t()
           | With.t()
           | Set.t()
+          | OnCreateSet.t()
+          | OnMatchSet.t()
           | Remove.t()
           | Delete.t()
           | DetachDelete.t()
@@ -778,6 +794,33 @@ defmodule AshNeo4j.Cypher.Query do
   def merge_node(label, properties) when is_atom(label) and is_map(properties) do
     {pattern, params} = Cypher.parameterized_node(:n, [label], properties)
     %__MODULE__{clauses: [%Merge{pattern: pattern}, %Return{items: ["n"]}], params: params}
+  end
+
+  @doc """
+  Atomic upsert (#379): `MERGE (n:L1:L2 {merge_props}) [ON CREATE SET n += {create_props}]
+  [ON MATCH SET n += {match_props}] RETURN n`.
+
+  `merge_props` are the upsert identity's properties (matched-or-created on);
+  `create_props` are the rest of the node, set only when a new node is created;
+  `match_props` are the `set_on_upsert` fields, set only when an existing node is
+  matched. With the identity's uniqueness constraint (#20) this is a race-free,
+  single-statement upsert. Param prefixes are distinct (`n_`/`nc_`/`nm_`) so the
+  three property sets on the `:n` alias don't collide.
+  """
+  @spec upsert_node(atom() | [atom()], map(), map(), map()) :: t()
+  def upsert_node(label, merge_props, create_props, match_props)
+      when is_map(merge_props) and is_map(create_props) and is_map(match_props) do
+    {merge_pattern, merge_params} = Cypher.parameterized_node(:n, List.wrap(label), merge_props)
+    {create_cypher, create_params} = Cypher.parameterized_properties(:nc, create_props)
+    {match_cypher, match_params} = Cypher.parameterized_properties(:nm, match_props)
+
+    on_create = if map_size(create_props) > 0, do: [%OnCreateSet{expression: "n += #{create_cypher}"}], else: []
+    on_match = if map_size(match_props) > 0, do: [%OnMatchSet{expression: "n += #{match_cypher}"}], else: []
+
+    %__MODULE__{
+      clauses: [%Merge{pattern: merge_pattern}] ++ on_create ++ on_match ++ [%Return{items: ["n"]}],
+      params: merge_params |> Map.merge(create_params) |> Map.merge(match_params)
+    }
   end
 
   @doc """

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -394,49 +394,95 @@ defmodule AshNeo4j.DataLayer do
     Logger.debug("AshNeo4j.DataLayer: upsert(#{inspect(resource)}, #{inspect(changeset)}, #{inspect(keys)})")
 
     mapping = ResourceInfo.mapping(resource)
-    id_properties = id_properties(mapping, changeset.attributes)
 
     result =
-      if Enum.any?(Map.values(id_properties), &is_nil(&1)) do
-        create(resource, changeset)
+      if mergeable_upsert?(changeset) do
+        merge_upsert(resource, changeset, keys, mapping)
       else
-        key_filters =
-          Enum.map(keys, fn key ->
-            {key,
-             Ash.Changeset.get_attribute(changeset, key) || Map.get(changeset.params, key) ||
-               Map.get(changeset.params, to_string(key))}
-          end)
-
-        query = Ash.Query.do_filter(resource, and: [key_filters])
-
-        resource
-        |> resource_to_query(changeset.domain)
-        |> Map.put(:filter, query.filter)
-        |> Map.put(:tenant, changeset.tenant)
-        |> run_query(resource)
-        |> case do
-          {:ok, []} ->
-            create(resource, changeset)
-
-          {:ok, [result]} ->
-            to_set = Ash.Changeset.set_on_upsert(changeset, keys)
-
-            changeset =
-              changeset
-              |> Map.put(:attributes, %{})
-              |> Map.put(:data, result)
-              |> Ash.Changeset.force_change_attributes(to_set)
-
-            update(resource, changeset)
-
-          {:ok, _} ->
-            {:error, internal("multiple records match the upsert keys")}
-        end
+        # Atomics, managed relationships or an upsert condition can't be expressed
+        # in a single MERGE — keep the read-then-write path for those.
+        legacy_upsert(resource, changeset, keys, mapping)
       end
 
     Logger.debug("AshNeo4j.DataLayer: upsert result #{inspect(result)}")
 
     result
+  end
+
+  # Only a plain attribute upsert can be a single atomic MERGE (#379).
+  defp mergeable_upsert?(changeset) do
+    changeset.atomics in [nil, []] and
+      (changeset.relationships == nil or changeset.relationships == %{}) and
+      is_nil(changeset.filter)
+  end
+
+  # Atomic, race-free, single-statement upsert (#379): MERGE on the upsert
+  # identity's properties, ON CREATE SET the rest of the node, ON MATCH SET the
+  # `set_on_upsert` fields. Backed by the identity's uniqueness constraint (#20).
+  defp merge_upsert(resource, changeset, keys, mapping) do
+    key_values = Map.new(keys, fn key -> {key, Ash.Changeset.get_attribute(changeset, key)} end)
+
+    if Enum.any?(Map.values(key_values), &is_nil/1) do
+      # No identity to merge on — a plain create.
+      create(resource, changeset)
+    else
+      merge_props = dump_properties(mapping, key_values)
+      create_props = dump_properties(mapping, Map.drop(changeset.attributes, keys))
+      match_props = dump_properties(mapping, Map.new(Ash.Changeset.set_on_upsert(changeset, keys)))
+
+      case Neo4jHelper.upsert_node(mapping.label_pair, merge_props, create_props, match_props) do
+        {:ok, %Bolty.Response{results: [node_map | _]}} ->
+          convert_node_to_resource(resource, Map.get(node_map, "n"))
+
+        {:ok, %Bolty.Response{results: []}} ->
+          {:error, internal("upsert affected no node")}
+
+        {:error, error} ->
+          {:error, AshNeo4j.Error.Neo4j.from_bolt(error)}
+      end
+      |> map_identity_conflict(resource, changeset)
+    end
+  end
+
+  defp legacy_upsert(resource, changeset, keys, mapping) do
+    id_properties = id_properties(mapping, changeset.attributes)
+
+    if Enum.any?(Map.values(id_properties), &is_nil(&1)) do
+      create(resource, changeset)
+    else
+      key_filters =
+        Enum.map(keys, fn key ->
+          {key,
+           Ash.Changeset.get_attribute(changeset, key) || Map.get(changeset.params, key) ||
+             Map.get(changeset.params, to_string(key))}
+        end)
+
+      query = Ash.Query.do_filter(resource, and: [key_filters])
+
+      resource
+      |> resource_to_query(changeset.domain)
+      |> Map.put(:filter, query.filter)
+      |> Map.put(:tenant, changeset.tenant)
+      |> run_query(resource)
+      |> case do
+        {:ok, []} ->
+          create(resource, changeset)
+
+        {:ok, [result]} ->
+          to_set = Ash.Changeset.set_on_upsert(changeset, keys)
+
+          changeset =
+            changeset
+            |> Map.put(:attributes, %{})
+            |> Map.put(:data, result)
+            |> Ash.Changeset.force_change_attributes(to_set)
+
+          update(resource, changeset)
+
+        {:ok, _} ->
+          {:error, internal("multiple records match the upsert keys")}
+      end
+    end
   end
 
   @impl true

--- a/lib/neo4j_helper.ex
+++ b/lib/neo4j_helper.ex
@@ -140,6 +140,19 @@ defmodule AshNeo4j.Neo4jHelper do
     |> Cypher.run()
   end
 
+  @spec upsert_node(atom() | [atom()], map(), map(), map()) ::
+          {:error, %{:__exception__ => true, :__struct__ => atom(), optional(atom()) => any()}}
+          | {:ok, any()}
+  @doc """
+  Atomic upsert (#379): MERGE on `merge_props` (the identity), `ON CREATE SET` the
+  rest (`create_props`), `ON MATCH SET` the `set_on_upsert` fields (`match_props`).
+  """
+  def upsert_node(label, merge_props, create_props, match_props)
+      when (is_atom(label) or is_list(label)) and is_map(merge_props) and is_map(create_props) and is_map(match_props) do
+    Query.upsert_node(label, merge_props, create_props, match_props)
+    |> Cypher.run()
+  end
+
   @spec update_node(atom() | [atom()], map(), map(), list()) ::
           {:error, %{:__exception__ => true, :__struct__ => atom(), optional(atom()) => any()}}
           | {:ok, any()}

--- a/test/upsert_test.exs
+++ b/test/upsert_test.exs
@@ -18,6 +18,36 @@ defmodule AshNeo4j.UpsertTest do
     on_exit(&Sandbox.rollback/0)
   end
 
+  describe "upsert_node render (#379)" do
+    test "MERGE on the identity, ON CREATE/ON MATCH SET, distinct param prefixes" do
+      query =
+        AshNeo4j.Cypher.Query.upsert_node(
+          :Upsert,
+          %{firstName: "Donald"},
+          %{field: "one"},
+          %{field: "two"}
+        )
+
+      {cypher, params} = AshNeo4j.Cypher.render(query)
+
+      assert cypher ==
+               "MERGE (n:Upsert {firstName: $n_firstName}) " <>
+                 "ON CREATE SET n += {field: $nc_field} " <>
+                 "ON MATCH SET n += {field: $nm_field} RETURN n"
+
+      # Distinct prefixes (n_/nc_/nm_) so the three property sets don't collide.
+      assert params == %{"n_firstName" => "Donald", "nc_field" => "one", "nm_field" => "two"}
+    end
+
+    test "omits ON CREATE / ON MATCH when their property sets are empty" do
+      {cypher, _} =
+        AshNeo4j.Cypher.Query.upsert_node(:Upsert, %{firstName: "Donald"}, %{}, %{})
+        |> AshNeo4j.Cypher.render()
+
+      assert cypher == "MERGE (n:Upsert {firstName: $n_firstName}) RETURN n"
+    end
+  end
+
   describe "Ash Upsert tests" do
     test "upsert node can be upserted using ash" do
       {:ok, upsert} =

--- a/usage-rules/identities.md
+++ b/usage-rules/identities.md
@@ -68,3 +68,19 @@ back to a database constraint.
 
 The default `nils_distinct?: true` maps cleanly: a node missing any of the
 constrained attributes is not subject to the constraint (its `nil`s are distinct).
+
+## Atomic upsert
+
+An `upsert?: true` create keyed on an identity is a single, race-free `MERGE`:
+
+```cypher
+MERGE (n:Label {<identity properties>})
+ON CREATE SET n += {<the rest of the node>}
+ON MATCH  SET n += {<set_on_upsert fields>}
+RETURN n
+```
+
+— no read-then-write round-trip and no race window (the identity's uniqueness
+constraint backs it). This is plain Cypher, so it works on any supported server.
+Upserts that also carry `changeset.atomics`, managed relationships, or an upsert
+condition fall back to the read-then-write path.


### PR DESCRIPTION
Closes #379. Builds on #20 (the identity uniqueness constraint).

## Summary

The upsert path read the identity keys, then created-or-updated in Elixir — the same race window the pre-check workaround has (two concurrent upserts can both read empty and both create) plus an extra round-trip. This replaces it with a single, atomic statement:

```cypher
MERGE (n:Label {<identity properties>})
ON CREATE SET n += {<the rest of the node>}
ON MATCH  SET n += {<set_on_upsert fields>}
RETURN n
```

Race-free and one round-trip, backed by the identity's uniqueness constraint (#20).

**Cypher 5 and 25** — `MERGE … ON CREATE SET … ON MATCH SET …` is core Cypher, no `cypher25?` gate. Verified directly on both 5.26 and 2026.05.

## Changes

- `OnCreateSet` / `OnMatchSet` clause structs + render; `Cypher.Query.upsert_node/4` (distinct `n_`/`nc_`/`nm_` param prefixes so the three property sets on the `:n` alias can't collide) + `Neo4jHelper.upsert_node/4`.
- `upsert/3` takes the MERGE path for plain attribute upserts. Upserts that also carry `changeset.atomics`, managed relationships, or an upsert condition keep the existing read-then-write path (preserved as `legacy_upsert/4`) — no regression.
- A constraint violation on the MERGE still maps to the Ash identity error from #20.

## Testing

`mix test` — **724 passed**; `mix dialyzer` clean; `--warnings-as-errors` clean. Adds render unit tests for `upsert_node` (MERGE/ON CREATE/ON MATCH shape, distinct prefixes, empty-set omission); the existing Ash upsert behaviour test now exercises the MERGE path.
