### PR TITLE
feat: enforce primary key as a Neo4j uniqueness constraint (#32)

### DIFF
--- a/lib/constraint.ex
+++ b/lib/constraint.ex
@@ -5,13 +5,17 @@
 defmodule AshNeo4j.Constraint do
   @moduledoc """
   Convenience helpers for creating the Neo4j uniqueness constraints that enforce a
-  resource's `identities` at the database level (#20).
+  resource's **primary key** (#32) and its `identities` (#20) at the database level.
 
-      # Create the constraints for every identity on a resource
+      # Create the constraints for a resource (primary key + every identity)
       AshNeo4j.Constraint.create_constraints(AssignmentRelationship)
 
       # Review the Cypher without touching the database
       AshNeo4j.Constraint.constraint_statements(AssignmentRelationship)
+
+  The primary-key constraint enforces uniqueness of the primary key among nodes of
+  the resource's label. It's skipped when an identity already constrains the same
+  attributes (no redundant constraint).
 
   Consistent with AshNeo4j's "no automatic migrations" stance — like
   `AshNeo4j.Vector`, this is an ergonomic tool you call (e.g. from a start-up or
@@ -29,8 +33,9 @@ defmodule AshNeo4j.Constraint do
 
   ## Naming
 
-  Each constraint is named `<label_lower>_<identity_name>`, e.g.
-  `assignmentrelationship_unique_assignment`.
+  Identity constraints are named `<label_lower>_<identity_name>` (e.g.
+  `assignmentrelationship_unique_assignment`); the primary-key constraint is
+  `<label_lower>_pk`.
   """
 
   alias AshNeo4j.Cypher
@@ -38,11 +43,12 @@ defmodule AshNeo4j.Constraint do
   alias AshNeo4j.Resource.Info, as: ResourceInfo
 
   @doc """
-  Runs `CREATE CONSTRAINT … IF NOT EXISTS` for every identity on `resource`.
+  Runs `CREATE CONSTRAINT … IF NOT EXISTS` for `resource`'s primary key and every
+  identity.
 
-  Returns `{:ok, [%Bolty.Response{}]}` (one per identity, empty when the resource
-  has none), or `{:error, %AshNeo4j.Error.UnsupportedIdentity{}}` if any identity
-  can't be enforced — in which case nothing is created.
+  Returns `{:ok, [%Bolty.Response{}]}` (one per constraint), or
+  `{:error, %AshNeo4j.Error.UnsupportedIdentity{}}` if any identity can't be
+  enforced — in which case nothing is created.
   """
   @spec create_constraints(Ash.Resource.t(), keyword()) ::
           {:ok, [Bolty.Response.t()]} | {:error, term()}
@@ -53,9 +59,9 @@ defmodule AshNeo4j.Constraint do
   end
 
   @doc """
-  Runs `DROP CONSTRAINT … IF EXISTS` for every identity on `resource`. A no-op for
-  absent constraints. Unsupported identities are refused (nothing was created for
-  them to drop), consistent with `create_constraints/2`.
+  Runs `DROP CONSTRAINT … IF EXISTS` for `resource`'s primary key and every identity.
+  A no-op for absent constraints. Unsupported identities are refused (nothing was
+  created for them to drop), consistent with `create_constraints/2`.
   """
   @spec drop_constraints(Ash.Resource.t(), keyword()) ::
           {:ok, [Bolty.Response.t()]} | {:error, term()}
@@ -70,7 +76,8 @@ defmodule AshNeo4j.Constraint do
   would run — without touching the database, or `{:error, %UnsupportedIdentity{}}`.
 
       AshNeo4j.Constraint.constraint_statements(Post)
-      #=> {:ok, ["CREATE CONSTRAINT post_unique_unique IF NOT EXISTS FOR (n:Post) REQUIRE n.unique IS UNIQUE"]}
+      #=> {:ok, ["CREATE CONSTRAINT post_pk IF NOT EXISTS FOR (n:Post) REQUIRE n.uuid IS UNIQUE",
+      #         "CREATE CONSTRAINT post_unique_unique IF NOT EXISTS FOR (n:Post) REQUIRE n.unique IS UNIQUE"]}
   """
   @spec constraint_statements(Ash.Resource.t()) :: {:ok, [String.t()]} | {:error, term()}
   def constraint_statements(resource) do
@@ -85,6 +92,12 @@ defmodule AshNeo4j.Constraint do
     label = ResourceInfo.module_label(resource)
     translations = ResourceInfo.translations(resource)
 
+    with {:ok, identity_specs} <- identity_specs(resource, label, translations) do
+      {:ok, primary_key_spec(resource, label, translations, identity_specs) ++ identity_specs}
+    end
+  end
+
+  defp identity_specs(resource, label, translations) do
     Enum.reduce_while(Ash.Resource.Info.identities(resource), {:ok, []}, fn identity, {:ok, acc} ->
       case spec(resource, label, translations, identity) do
         {:ok, spec} -> {:cont, {:ok, [spec | acc]}}
@@ -94,6 +107,26 @@ defmodule AshNeo4j.Constraint do
     |> case do
       {:ok, specs} -> {:ok, Enum.reverse(specs)}
       error -> error
+    end
+  end
+
+  # The primary-key uniqueness constraint (#32). Skipped when an identity already
+  # constrains the same property set (no redundant constraint). Always enforceable:
+  # primary-key attributes are required, so the `nils_distinct?`/`where` limits
+  # never apply.
+  defp primary_key_spec(resource, label, translations, identity_specs) do
+    case Ash.Resource.Info.primary_key(resource) do
+      [] ->
+        []
+
+      keys ->
+        properties = properties_for(keys, translations)
+
+        if Enum.any?(identity_specs, &(MapSet.new(&1.properties) == MapSet.new(properties))) do
+          []
+        else
+          [%{name: constraint_name(label, "pk"), label: label, properties: properties}]
+        end
     end
   end
 
@@ -107,15 +140,17 @@ defmodule AshNeo4j.Constraint do
   end
 
   defp spec(_resource, label, translations, identity) do
-    properties = Enum.map(identity.keys, fn key -> to_string(Keyword.get(translations, key, key)) end)
-
     {:ok,
      %{
-       name: "#{label |> to_string() |> String.downcase()}_#{identity.name}",
+       name: constraint_name(label, identity.name),
        label: label,
-       properties: properties
+       properties: properties_for(identity.keys, translations)
      }}
   end
+
+  defp properties_for(keys, translations), do: Enum.map(keys, &to_string(Keyword.get(translations, &1, &1)))
+
+  defp constraint_name(label, suffix), do: "#{label |> to_string() |> String.downcase()}_#{suffix}"
 
   # --- cypher ------------------------------------------------------------
 

--- a/test/identities_test.exs
+++ b/test/identities_test.exs
@@ -28,12 +28,17 @@ defmodule AshNeo4j.IdentitiesTest do
   defp flatten(e), do: [e]
 
   describe "constraint statements" do
-    test "single-property identity → unparenthesised REQUIRE" do
-      assert {:ok, ["CREATE CONSTRAINT post_unique_unique IF NOT EXISTS FOR (n:Post) REQUIRE n.unique IS UNIQUE"]} =
-               Constraint.constraint_statements(Post)
+    test "primary key (#32) + single-property identity → unparenthesised REQUIRE" do
+      assert {:ok,
+              [
+                "CREATE CONSTRAINT post_pk IF NOT EXISTS FOR (n:Post) REQUIRE n.uuid IS UNIQUE",
+                "CREATE CONSTRAINT post_unique_unique IF NOT EXISTS FOR (n:Post) REQUIRE n.unique IS UNIQUE"
+              ]} = Constraint.constraint_statements(Post)
     end
 
-    test "composite identity → parenthesised, camelCased properties" do
+    test "composite identity → parenthesised, camelCased properties; pk dedup'd (pk == identity)" do
+      # Upsert's primary key is [first_name, surname], the same as identity :full_name,
+      # so no separate `_pk` constraint is emitted (#32 dedup).
       assert {:ok,
               [
                 "CREATE CONSTRAINT upsert_full_name IF NOT EXISTS FOR (n:Upsert) REQUIRE (n.firstName, n.surname) IS UNIQUE"

--- a/usage-rules/identities.md
+++ b/usage-rules/identities.md
@@ -4,12 +4,13 @@ SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-de
 SPDX-License-Identifier: MIT
 -->
 
-# Identities and uniqueness constraints
+# Primary keys, identities and uniqueness constraints
 
 An Ash `identity` declares that a set of attributes is unique. AshNeo4j enforces
 that at the database level with a Neo4j uniqueness constraint, so concurrent writes
 can't create duplicates and you don't need `pre_check?` (an Elixir-side read that
-still leaves a race window).
+still leaves a race window). The resource's **primary key** gets a constraint too,
+enforcing primary-key uniqueness among nodes of the resource's label.
 
 ```elixir
 identities do
@@ -36,9 +37,11 @@ AshNeo4j.Constraint.constraint_statements(AssignmentRelationship)
 AshNeo4j.Constraint.drop_constraints(AssignmentRelationship)
 ```
 
-Single- and multi-attribute identities are both supported (composite `IS UNIQUE`
-constraints work on Neo4j Community Edition). Each constraint is named
-`<label_lower>_<identity_name>`.
+This creates the **primary-key** constraint (`<label_lower>_pk`) and one per
+identity (`<label_lower>_<identity_name>`). Single- and multi-attribute keys are
+both supported (composite `IS UNIQUE` constraints work on Neo4j Community Edition).
+The primary-key constraint is skipped when an identity already constrains the same
+attributes (e.g. a natural composite primary key that's also declared an identity).
 
 ## Conflicts are surfaced in Ash terms
 


### PR DESCRIPTION
Closes #32. Builds on #20 (the identity-constraint helper).

## Summary

Extends `AshNeo4j.Constraint` to also create a uniqueness constraint for the resource's **primary key** — single or composite (composite `IS UNIQUE` works on Community Edition, verified in #20). It's **deduped** against identities: when an identity already constrains the same attribute set (e.g. a natural composite PK that's also declared an identity), no separate `_pk` constraint is emitted.

## Changes

- `create_constraints/2`, `constraint_statements/1`, `drop_constraints/2` now cover the primary key (named `<label_lower>_pk`) alongside identities.
- Always enforceable: primary-key attributes are required, so the `nils_distinct?: false` / filtered-`where:` limits that refuse some identities never apply to the PK.
- Factored the shared name/property mapping (`constraint_name/2`, `properties_for/2`).

Manual, like the identity constraints and vector indexes — no migrations on boot.

## Testing

`mix test` — **724 passed**; `mix dialyzer` clean; `--warnings-as-errors` clean. Statement tests cover the PK + identity case (`Post`: `post_pk` on `uuid` + `post_unique_unique`) and the dedup case (`Upsert`: PK == identity ⇒ one constraint).

## Scope note

I dropped an earlier draft claim that the PK constraint makes `Ash.get/2` "an index seek not a label scan" — couldn't verify the planner uses the resource-label index for AshNeo4j's actual get query (which matches the full domain+resource label set and enriches relationships). This PR is uniqueness enforcement only; whether get-by-PK exploits the constraint's backing index is a separate, unverified question.
