### PR TITLE
feat: cypher fragment filter escape hatch (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,10 @@ Calculations can be:
 
 Only `expr(...)` calculations are currently supported. Custom `:calculate` callback modules are not.
 
+## Cypher Fragments
+
+`fragment(...)` is a filter escape hatch — embed a snippet of raw Cypher in a filter for a condition AshNeo4j doesn't push down (e.g. an APOC function), so the read stays a normal Ash query instead of being hand-written as a raw Cypher query (and losing authorization, the resource model and composability). `?` arguments are bound safely: an attribute reference renders to `s.<property>`, a literal to a `$param`. The fragment must be the whole filter, and arguments must be attribute references or literals — anything else is refused (`AshNeo4j.Error.UnsupportedFilterFragment`), never silently dropped. (This is the *expression* `fragment/N`, not an Ash *resource* fragment.) See `usage-rules/cypher-fragments.md`.
+
 ## Limitations and Future Work
 
 Ash Neo4j has support for Ash create, update, read, destroy actions, aggregates, expression calculations, spatial types, and vector embeddings. The cypher is now parameterised but is by no means optimised. The DSL is likely to evolve further and this may break back compatibility. Storage formats are subject to infrequent change so upgrade *may* require data migration (not included).

--- a/lib/cypher/query.ex
+++ b/lib/cypher/query.ex
@@ -235,6 +235,24 @@ defmodule AshNeo4j.Cypher.Query do
   end
 
   @doc """
+  `MATCH (s:L1:L2) WHERE <where> OPTIONAL MATCH (s)-[r]-(d) RETURN s, r, d` with a
+  pre-rendered `WHERE` string and its params — the `fragment(...)` escape hatch (#33),
+  where the condition is author-supplied Cypher rather than a derived predicate.
+  """
+  @spec node_read_fragment(atom() | [atom()], String.t(), map()) :: t()
+  def node_read_fragment(label, where, params) when is_binary(where) and is_map(params) do
+    %__MODULE__{
+      clauses: [
+        %Match{pattern: Cypher.node(:s, List.wrap(label))},
+        %Where{conditions: [where]},
+        %OptionalMatch{pattern: "(s)-[r]-(d)"},
+        %Return{items: ["s", "r", "d"]}
+      ],
+      params: params
+    }
+  end
+
+  @doc """
   `MATCH (s:L1:L2) [WHERE <conditions>] RETURN s` — a single combination-query
   branch, sized to fit inside a `CALL { … }` block.
 

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -1053,6 +1053,11 @@ defmodule AshNeo4j.DataLayer do
     %{negation | expression: drop_pushdown_only_expr(expression)}
   end
 
+  # A `fragment(...)` that reached the data layer was pushed down (we refuse the
+  # ones we can't push) — and it can't be evaluated in-memory anyway — so drop it
+  # from the in-memory residual (#33).
+  defp drop_pushdown_only_expr(%Ash.Query.Function.Fragment{}), do: true
+
   defp drop_pushdown_only_expr(expression) do
     if contains_pushdown_only?(expression), do: true, else: expression
   end

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -123,6 +123,38 @@ defmodule AshNeo4j.Error.UnresolvableTraversal do
   end
 end
 
+defmodule AshNeo4j.Error.UnsupportedFilterFragment do
+  @moduledoc """
+  **Returned** (never raised) when a `fragment(...)` filter (the Cypher escape
+  hatch, #33) can't be pushed down — and, because raw Cypher can't be evaluated in
+  Elixir, it can't fall back to in-memory filtering either, so the data layer
+  refuses rather than silently return wrong results.
+
+  Two cases today:
+
+    * the fragment is **combined with other filter conditions** (it isn't the whole
+      filter) — only a filter that is a single `fragment(...)` is pushed down so far;
+    * a `?` argument is **not a plain attribute reference or a literal** (e.g. a
+      related field, calculation or nested expression).
+
+  Make the fragment the whole filter and reference attributes (`?` with an attribute)
+  or literals, or express the condition without a fragment.
+  """
+  use Splode.Error, fields: [:resource, :reason], class: :invalid
+
+  def message(%{resource: resource, reason: reason}) do
+    "cannot push down a fragment filter on #{inspect(resource)} — #{explain(reason)}."
+  end
+
+  defp explain(:combined),
+    do: "the fragment is combined with other filter conditions; only a filter that is a single fragment(...) is supported"
+
+  defp explain({:unsupported_argument, arg}),
+    do: "a fragment argument must be an attribute reference or a literal, got #{inspect(arg)}"
+
+  defp explain(other), do: inspect(other)
+end
+
 defmodule AshNeo4j.Error.UnsupportedManyToMany do
   @moduledoc """
   **Returned** (never raised) when a relationship write resolves to a many-to-many

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -200,26 +200,102 @@ defmodule AshNeo4j.QueryHelper do
   end
 
   defp build_query(ash_query, %ResourceMapping{} = mapping) do
-    if ash_query.filter == nil do
-      Query.node_read(mapping.label_pair)
-    else
-      simple_filter = Ash.Filter.to_simple_filter(ash_query.filter, skip_invalid?: true)
+    expression = if ash_query.filter, do: Map.get(ash_query.filter, :expression)
 
-      predicates =
-        simple_filter
-        |> Map.get(:predicates, [])
-        |> Enum.reject(fn pred ->
-          match?(%Ash.Query.Ref{attribute: %Ash.Query.Calculation{}}, Map.get(pred, :left))
-        end)
-
-      if predicates == [] do
-        Logger.debug("AshNeo4j.QueryHelper: filter #{inspect(ash_query.filter)} is not a simple filter")
+    cond do
+      ash_query.filter == nil ->
         Query.node_read(mapping.label_pair)
-      else
-        build_filtered_query(mapping, predicates)
-      end
+
+      # A filter that *is* a single `fragment(...)` (the Cypher escape hatch, #33) —
+      # render it straight into the WHERE.
+      match?(%Ash.Query.Function.Fragment{}, expression) ->
+        build_fragment_query(expression, mapping)
+
+      # A fragment combined with other conditions can't be rendered yet, and raw
+      # Cypher can't be evaluated in-memory — refuse rather than silently mis-answer.
+      contains_fragment?(expression) ->
+        {:error, AshNeo4j.Error.UnsupportedFilterFragment.exception(resource: mapping.module, reason: :combined)}
+
+      true ->
+        simple_filter = Ash.Filter.to_simple_filter(ash_query.filter, skip_invalid?: true)
+
+        predicates =
+          simple_filter
+          |> Map.get(:predicates, [])
+          |> Enum.reject(fn pred ->
+            match?(%Ash.Query.Ref{attribute: %Ash.Query.Calculation{}}, Map.get(pred, :left))
+          end)
+
+        if predicates == [] do
+          Logger.debug("AshNeo4j.QueryHelper: filter #{inspect(ash_query.filter)} is not a simple filter")
+          Query.node_read(mapping.label_pair)
+        else
+          build_filtered_query(mapping, predicates)
+        end
     end
   end
+
+  # Renders a single `fragment(...)` (#33) to a node read with the fragment as the
+  # WHERE: `MATCH (s:Label) WHERE <fragment> OPTIONAL MATCH (s)-[r]-(d) RETURN …`.
+  # Refuses (no silent in-memory fallback) when an argument isn't a plain attribute
+  # reference or literal.
+  defp build_fragment_query(%Ash.Query.Function.Fragment{} = fragment, %ResourceMapping{} = mapping) do
+    case render_fragment(fragment, mapping) do
+      {:ok, {where, params}} ->
+        Query.node_read_fragment(mapping.label_pair, where, params)
+
+      {:error, reason} ->
+        {:error, AshNeo4j.Error.UnsupportedFilterFragment.exception(resource: mapping.module, reason: reason)}
+    end
+  end
+
+  @doc false
+  # Walks the fragment tokens — `{:raw, cypher}` literal (author-controlled), an
+  # attribute `{:expr, ref}` → `s.<property>`, a literal `{:expr, value}` → a bound
+  # `$frag_N` param (injection-safe). Other argument shapes are refused. Public for
+  # testing the render of a `fragment(...)` without a live (APOC) server.
+  def render_fragment(%Ash.Query.Function.Fragment{arguments: tokens}, %ResourceMapping{} = mapping) do
+    tokens
+    |> Enum.reduce_while({:ok, {"", %{}, 0}}, fn token, {:ok, {acc_str, acc_params, index}} ->
+      case render_fragment_token(token, mapping, index) do
+        {:ok, piece, params, next_index} ->
+          {:cont, {:ok, {acc_str <> piece, Map.merge(acc_params, params), next_index}}}
+
+        {:error, _} = error ->
+          {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, {where, params, _index}} -> {:ok, {where, params}}
+      error -> error
+    end
+  end
+
+  defp render_fragment_token({:raw, cypher}, _mapping, index) when is_binary(cypher), do: {:ok, cypher, %{}, index}
+
+  defp render_fragment_token({:expr, %Ash.Query.Ref{attribute: attribute, relationship_path: []}}, mapping, index) do
+    name = Map.get(attribute, :name, attribute)
+
+    if Ash.Resource.Info.attribute(mapping.module, name) do
+      {:ok, "s.#{Keyword.get(mapping.properties, name, name)}", %{}, index}
+    else
+      {:error, {:unsupported_argument, attribute}}
+    end
+  end
+
+  defp render_fragment_token({:expr, value}, _mapping, index)
+       when is_number(value) or is_binary(value) or is_boolean(value) do
+    key = "frag_#{index}"
+    {:ok, "$#{key}", %{key => value}, index + 1}
+  end
+
+  defp render_fragment_token({:expr, other}, _mapping, _index), do: {:error, {:unsupported_argument, other}}
+
+  defp contains_fragment?(%Ash.Query.Function.Fragment{}), do: true
+  defp contains_fragment?(%_struct{} = struct), do: struct |> Map.from_struct() |> Map.values() |> Enum.any?(&contains_fragment?/1)
+  defp contains_fragment?(list) when is_list(list), do: Enum.any?(list, &contains_fragment?/1)
+  defp contains_fragment?(%{} = map), do: map |> Map.values() |> Enum.any?(&contains_fragment?/1)
+  defp contains_fragment?(_), do: false
 
   defp build_filtered_query(%ResourceMapping{} = mapping, predicates) do
     case Enum.find(predicates, &traverse_predicate?/1) do

--- a/test/expression_fragment_test.exs
+++ b/test/expression_fragment_test.exs
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.ExpressionFragmentTest do
+  @moduledoc """
+  The `fragment(...)` Cypher escape hatch in *expressions* (#33) — distinct from Ash
+  *resource* fragments (see `AshNeo4j.FragmentTest`). A filter that is a single
+  fragment renders straight into the `WHERE`: `?` arguments are attribute refs
+  (→ `s.<prop>`) or literals (→ bound `$frag_N` params, injection-safe); raw text is
+  author-supplied Cypher. It keeps an un-pushable-but-expressible condition (e.g. an
+  APOC function) inside Ash rather than dropping to raw Cypher. A fragment combined
+  with other conditions, or a non-ref/non-literal argument, is refused — never
+  silently dropped (raw Cypher can't be re-checked in-memory).
+  """
+  use ExUnit.Case, async: false
+
+  alias AshNeo4j.{BoltyHelper, Sandbox}
+  alias AshNeo4j.Error.UnsupportedFilterFragment
+  alias AshNeo4j.QueryHelper
+  alias AshNeo4j.Resource.Info, as: ResourceInfo
+  alias AshNeo4j.Test.Resource.{Author, Post}
+
+  require Ash.Query
+
+  setup_all do
+    BoltyHelper.start()
+    :ok
+  end
+
+  defp mapping, do: ResourceInfo.mapping(Post)
+  defp flatten(%{errors: errors}) when is_list(errors), do: Enum.flat_map(errors, &flatten/1)
+  defp flatten(e), do: [e]
+
+  describe "render — refs become s.<property>, literals become bound params" do
+    test "operator fragment" do
+      expression = Ash.Query.filter(Post, fragment("? > ?", score, 5)).filter.expression
+
+      assert {:ok, {"(s.score > $frag_0)", %{"frag_0" => 5}}} =
+               QueryHelper.render_fragment(expression, mapping())
+    end
+
+    # APOC text functions — the fuzzy/typo-tolerant text-matching use case. Needs APOC
+    # on the server to *run*; here we assert the fragment renders the call correctly
+    # (the escape-hatch contract: we render faithfully, your server provides APOC).
+    test "apoc.text.clean for typo/spacing/case-insensitive matching" do
+      expression =
+        Ash.Query.filter(Post, fragment("apoc.text.clean(?) = apoc.text.clean(?)", title, "Hello World")).filter.expression
+
+      assert {:ok, {"(apoc.text.clean(s.title) = apoc.text.clean($frag_0))", %{"frag_0" => "Hello World"}}} =
+               QueryHelper.render_fragment(expression, mapping())
+    end
+
+    test "apoc.text.levenshteinDistance for fuzzy matching" do
+      expression =
+        Ash.Query.filter(Post, fragment("apoc.text.levenshteinDistance(?, ?) <= ?", title, "John Smith", 2)).filter.expression
+
+      assert {:ok, {"(apoc.text.levenshteinDistance(s.title, $frag_0) <= $frag_1)", %{"frag_0" => "John Smith", "frag_1" => 2}}} =
+               QueryHelper.render_fragment(expression, mapping())
+    end
+  end
+
+  describe "live pushdown" do
+    setup do
+      Sandbox.checkout()
+      on_exit(&Sandbox.rollback/0)
+      {:ok, a} = Author |> Ash.Changeset.for_create(:create, %{name: "a"}) |> Ash.create()
+      Post |> Ash.Changeset.for_create(:create, %{title: "p7", score: 7, written_by: a.id}) |> Ash.create!()
+      Post |> Ash.Changeset.for_create(:create, %{title: "p3", score: 3, written_by: a.id}) |> Ash.create!()
+      :ok
+    end
+
+    test "operator fragment pushes down and is correct" do
+      titles = Post |> Ash.Query.filter(fragment("? > ?", score, 5)) |> Ash.read!() |> Enum.map(& &1.title)
+      assert titles == ["p7"]
+    end
+
+    test "built-in Cypher function in a fragment" do
+      # toLower is built-in (no APOC), proving function-call fragments work live.
+      titles = Post |> Ash.Query.filter(fragment("toLower(?) = ?", title, "p7")) |> Ash.read!() |> Enum.map(& &1.title)
+      assert titles == ["p7"]
+    end
+  end
+
+  describe "refuse, never silently drop" do
+    setup do
+      Sandbox.checkout()
+      on_exit(&Sandbox.rollback/0)
+      :ok
+    end
+
+    test "a fragment combined with another condition is refused" do
+      assert {:error, error} =
+               Post |> Ash.Query.filter(fragment("? > ?", score, 5) and title == "p7") |> Ash.read()
+
+      assert Enum.any?(flatten(error), &match?(%UnsupportedFilterFragment{reason: :combined}, &1))
+    end
+
+    test "a non-literal / non-attribute argument is refused" do
+      # `author.name` is a related-field ref, not a plain attribute of Post.
+      assert {:error, error} =
+               Post |> Ash.Query.filter(fragment("? = ?", author.name, "a")) |> Ash.read()
+
+      assert Enum.any?(flatten(error), &match?(%UnsupportedFilterFragment{}, &1))
+    end
+  end
+end

--- a/usage-rules/cypher-fragments.md
+++ b/usage-rules/cypher-fragments.md
@@ -1,0 +1,73 @@
+<!--
+SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+
+SPDX-License-Identifier: MIT
+-->
+
+# Cypher fragments — the filter escape hatch
+
+`fragment(...)` lets you drop a snippet of raw Cypher into a **filter**, for a
+condition AshNeo4j doesn't push down on its own — for example an APOC function. The
+point is to keep that query *inside Ash* (authorization, the resource model,
+composability) instead of dropping to raw Cypher for the one condition.
+
+> This is the **expression** `fragment/N` (analogous to `ash_postgres`'s SQL
+> fragment), not an Ash **resource** fragment — they share the word only.
+
+```elixir
+require Ash.Query
+
+# Fuzzy, typo-tolerant text match with an APOC function
+Post
+|> Ash.Query.filter(fragment("apoc.text.levenshteinDistance(?, ?) <= ?", title, "John Smith", 2))
+|> Ash.read!()
+```
+
+## How arguments are rendered
+
+The `?` arguments are bound, never interpolated, so the fragment is injection-safe:
+
+| `?` argument | Renders to |
+|---|---|
+| an attribute reference (e.g. `title`) | `s.<property>` (the node alias + camelCased property) |
+| a literal (number, string, boolean) | a bound `$frag_N` parameter |
+
+The raw text between the `?`s is author-supplied Cypher, written as-is. So
+`fragment("apoc.text.levenshteinDistance(?, ?) <= ?", title, "John Smith", 2)` renders
+`WHERE (apoc.text.levenshteinDistance(s.title, $frag_0) <= $frag_1)`.
+
+You are responsible for what the server can run — e.g. APOC must be installed for an
+`apoc.*` fragment. AshNeo4j renders the call faithfully; it doesn't load or require
+APOC.
+
+## Scope and limits
+
+- **The fragment must be the whole filter.** A fragment combined with other
+  conditions (`fragment(...) and x == 1`) is **refused** with
+  `AshNeo4j.Error.UnsupportedFilterFragment` — not silently dropped. Raw Cypher
+  can't be re-evaluated in Elixir, so a half-applied fragment would give wrong
+  results; refusing is the safe floor. (Combining fragments with other predicates is
+  a possible future enhancement.)
+- **Arguments must be a plain attribute reference or a literal.** A related field,
+  calculation or nested expression is refused.
+- Fragments apply to **filters** only (not calculations or sorts, which AshNeo4j
+  evaluates in-memory).
+
+## Staying inside the data layer
+
+A fragment carries an *expression* into a filter while the data layer still does the
+heavy lifting: it translates the `?` attribute references to the right `s.<property>`,
+scopes the read to the resource's labels, and handles types. That translation is the
+hard part — AshNeo4j introspects the DSL and maps domains, resources, attributes and
+relationships onto labels, nodes, edges and properties, with a lot of nuance — and a
+fragment lets you reach raw Cypher *without* giving it up.
+
+For something a fragment genuinely can't express — a `CALL apoc.*` procedure, a
+one-off migration — `AshNeo4j.Cypher.run/2` will run arbitrary Cypher on the data
+layer's Bolt pool (see `usage-rules/spatial.md`). But that hands *you* everything the
+data layer reconciles: the exact labels (domain + resource + any fragment base),
+camelCased property names, label scoping and type conversion — plus the Ash,
+data-layer, Cypher, transaction, filter and changeset semantics it weaves together.
+It's a genuine last resort, not a path we encourage: you'd be reimplementing by hand a
+deep, nuanced layer, and it's easy to get subtly wrong. It's there if you need to
+descend — just come equipped for everything down there.


### PR DESCRIPTION
Closes #33.

## Summary

Adds the expression `fragment(...)` (the AshNeo4j analogue of `ash_postgres`'s SQL fragment) as a **filter escape hatch** — a snippet of raw Cypher for a condition AshNeo4j doesn't push down on its own (e.g. an APOC function like `apoc.text.levenshteinDistance` for fuzzy matching). The point is to keep that read a **normal Ash query** — the data layer still translates the `?` attribute refs to `s.<property>`, scopes to the resource's labels, and handles types — rather than hand-writing raw Cypher.

> This is the *expression* `fragment/N`, not an Ash *resource* fragment (those are in `dsl.md` / `AshNeo4j.FragmentTest`) — they share the word only.

## Behaviour

A filter that **is** a single fragment renders into the `WHERE`:
- `?` arguments that are **attribute references** → `s.<property>`;
- `?` arguments that are **literals** → bound `$frag_N` params (injection-safe, never interpolated);
- raw text between the `?`s is author-supplied Cypher, passed through.

e.g. `fragment("apoc.text.levenshteinDistance(?, ?) <= ?", title, "John Smith", 2)` → `WHERE (apoc.text.levenshteinDistance(s.title, $frag_0) <= $frag_1)`.

### Closes a correctness gap

A fragment filter previously reached the data layer, couldn't be reduced by the predicate pipeline, and was **silently dropped** — wrong results, no error. Raw Cypher can't be re-evaluated in Elixir, so anything we can't push down — a fragment combined with other conditions, or a non-ref/non-literal argument — now **refuses** with `AshNeo4j.Error.UnsupportedFilterFragment` rather than mis-answering. Combining fragments with other predicates is a follow-up.

## Changes

- `Cypher.Query.node_read_fragment/3`; `QueryHelper.render_fragment/2` + `build_query` integration; `drop_pushdown_only` `Fragment` clause; `AshNeo4j.Error.UnsupportedFilterFragment`.
- `test/expression_fragment_test.exs` — render tests (incl. the two APOC examples; render-only since the suite runs plain Community without APOC), live pushdown, and the two refuse cases.
- Docs: `usage-rules/cypher-fragments.md` + a README section. The doc frames raw `AshNeo4j.Cypher.run` as a **caveated last resort** ("a ladder you can descend if you must, but come equipped") — not encouraged, because bypassing the data layer means reimplementing its deep, nuanced work (DSL → graph mapping, label scoping, Ash/Cypher/transaction/filter/changeset semantics) by hand.

## Testing

`mix test` — **731 passed**; `mix dialyzer` clean; `--warnings-as-errors` clean.
