### PR TITLE
feat: APOC availability healthcheck + round-trip fragment test (#386)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,13 +210,13 @@ The data layer talks to a configurable Bolty pool — `AshNeo4j.BoltyHelper.curr
 
 ### Running the suite
 
-The suite needs a Neo4j at `bolt://localhost:7687` (`neo4j` / `password`, the `Bolt` block in `config/test.exs`). The `:cypher25` / `:bolt6` tests — excluded by default — additionally need a Neo4j ≥ 2025.06 at `bolt://localhost:7689` (the `Bolt6` block). The bundled `docker-compose.yml` brings both up (community edition is deliberate — it runs everything the suite needs, including vector search and Cypher 25):
+The suite needs a Neo4j at `bolt://localhost:7687` (`neo4j` / `password`, the `Bolt` block in `config/test.exs`). The `:cypher25` / `:bolt6` tests — excluded by default — additionally need a Neo4j ≥ 2025.06 at `bolt://localhost:7689` (the `Bolt6` block), and the `:apoc` test needs a Neo4j + APOC at `bolt://localhost:7691` (the `BoltApoc` block). The bundled `docker-compose.yml` brings all three up (community edition is deliberate — it runs everything the suite needs, including vector search and Cypher 25; APOC is on its own opt-in server since it's not part of the default surface):
 
 ```sh
-docker compose up -d --wait                    # neo4j-bolt5 → 7687, neo4j-bolt6 → 7689
-mix test                                        # default suite (7687 only)
-mix test --include cypher25 --include bolt6     # full suite (7687 + 7689)
-docker compose down                             # tear down
+docker compose up -d --wait                          # bolt5 → 7687, bolt6 → 7689, apoc → 7691
+mix test                                              # default suite (7687 only)
+mix test --include cypher25 --include bolt6 --include apoc   # full suite
+docker compose down                                   # tear down
 ```
 
 Elixir/Erlang versions are pinned in `.tool-versions` (read by [mise](https://mise.jdx.dev) or asdf): `mise install` (or `asdf install`).

--- a/config/test.exs
+++ b/config/test.exs
@@ -37,6 +37,20 @@ config :bolty, Bolt6,
   log_hex: true,
   level: level
 
+# Neo4j 5.x Community + APOC — the `:apoc` round-trip fragment test (#386).
+config :bolty, BoltApoc,
+  uri: "bolt://localhost:7691",
+  auth: [username: "neo4j", password: "password"],
+  versions: [5.8],
+  user_agent: "boltyTest/1",
+  pool_size: 5,
+  max_overflow: 1,
+  prefix: :default,
+  name: BoltApoc,
+  log: true,
+  log_hex: true,
+  level: level
+
 config :logger, :console,
   level: level,
   format: "$date $time [$level] $metadata$message\n"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,15 @@
 #
 #   neo4j-bolt5 → bolt://localhost:7687  (Bolt 5.x / Cypher 5)   — default suite
 #   neo4j-bolt6 → bolt://localhost:7689  (Bolt 6.0 / Cypher 25)  — :cypher25 / :bolt6 tests
+#   neo4j-apoc  → bolt://localhost:7691  (Bolt 5.x + APOC)       — :apoc tests
 #
-# Ports and creds match the Bolt and Bolt6 blocks in config/test.exs
+# Ports and creds match the Bolt, Bolt6 and BoltApoc blocks in config/test.exs
 # (neo4j / password). Community edition is deliberate — it's the floor of the
 # user base and runs everything the suite needs (vector search + Cypher 25 are
-# in Community). No volumes: tests roll back via AshNeo4j.Sandbox, so the data
-# is ephemeral by design.
+# in Community). APOC is *not* on the default server — a `fragment(...)` that
+# calls `apoc.*` is the operator's responsibility — so it lives on its own
+# opt-in server for the :apoc round-trip test (#386). No volumes: tests roll
+# back via AshNeo4j.Sandbox, so the data is ephemeral by design.
 services:
   neo4j-bolt5:
     image: neo4j:5.26.27
@@ -40,6 +43,22 @@ services:
       NEO4J_AUTH: neo4j/password
     healthcheck:
       test: ["CMD-SHELL", "cypher-shell -u neo4j -p password 'RETURN 1' || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  neo4j-apoc:
+    image: neo4j:5.26.27
+    container_name: neo4j-ash-apoc
+    ports:
+      - "7691:7687"
+      - "7476:7474"
+    environment:
+      NEO4J_AUTH: neo4j/password
+      # Auto-installs APOC Core (matching the Neo4j version) on first boot.
+      NEO4J_PLUGINS: '["apoc"]'
+    healthcheck:
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p password 'RETURN apoc.version()' || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/lib/bolty_helper.ex
+++ b/lib/bolty_helper.ex
@@ -37,6 +37,17 @@ defmodule AshNeo4j.BoltyHelper do
     end
   end
 
+  @doc """
+  Starts the BoltApoc pool (Neo4j 5.x Community + APOC, #386). Returns :ok,
+  {:error, error}, or {:error, :not_configured} when no BoltApoc config is present.
+  """
+  def start_bolt_apoc() do
+    case Application.get_env(:bolty, BoltApoc) do
+      nil -> {:error, :not_configured}
+      config -> start(config)
+    end
+  end
+
   @default_pool Bolt
 
   @doc """
@@ -137,5 +148,39 @@ defmodule AshNeo4j.BoltyHelper do
       %{dynamic_labels: dynamic_labels} -> dynamic_labels
       nil -> false
     end
+  end
+
+  @doc """
+  Returns `true` when the current pool (see `current_pool/0`) is connected to a
+  Neo4j server with **APOC** installed (#386) — useful as a deploy/start-up
+  healthcheck before relying on an `apoc.*` `fragment(...)`.
+
+  Unlike `cypher25?/0` / `dynamic_labels?/0` (negotiated server features), APOC is
+  a plugin, so this introspects the server with `SHOW PROCEDURES`. Cached in
+  `:persistent_term` per pool after the first call. `false` when the pool is not
+  started. Installing APOC is the operator's job — this only reports it.
+  """
+  def apoc_available?(), do: apoc_available?(current_pool())
+
+  @doc "APOC availability for an explicit `pool`."
+  def apoc_available?(pool) do
+    case :persistent_term.get({__MODULE__, :apoc, pool}, :not_cached) do
+      :not_cached ->
+        available = query_apoc_available?(pool)
+        :persistent_term.put({__MODULE__, :apoc, pool}, available)
+        available
+
+      cached ->
+        cached
+    end
+  end
+
+  defp query_apoc_available?(pool) do
+    case Bolty.query(pool, "SHOW PROCEDURES YIELD name WHERE name STARTS WITH 'apoc' RETURN count(name) > 0 AS available") do
+      {:ok, %Bolty.Response{results: [%{"available" => available} | _]}} -> available == true
+      _ -> false
+    end
+  rescue
+    _ -> false
   end
 end

--- a/test/apoc_test.exs
+++ b/test/apoc_test.exs
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.ApocTest do
+  @moduledoc """
+  APOC availability healthcheck and a round-trip `apoc.*` `fragment(...)` (#386).
+
+  Installing APOC is the operator's job; AshNeo4j only reports it
+  (`AshNeo4j.BoltyHelper.apoc_available?/0,1`). The default `Bolt` server is plain
+  Community (no APOC), so the healthcheck reads `false` there; the `:apoc`-tagged
+  tests route to the `BoltApoc` pool (Neo4j + APOC, `docker-compose` `neo4j-apoc`)
+  and are excluded by default — like `:cypher25` / `:bolt6`.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshNeo4j.{BoltyHelper, Sandbox}
+  alias AshNeo4j.Test.Resource.{Author, Post}
+
+  require Ash.Query
+
+  setup_all do
+    BoltyHelper.start()
+    :ok
+  end
+
+  test "apoc_available? is false on the plain default server" do
+    refute BoltyHelper.apoc_available?(Bolt)
+    refute BoltyHelper.apoc_available?()
+  end
+
+  describe "with APOC (BoltApoc pool)" do
+    @describetag :apoc
+
+    setup do
+      Process.put(:ash_neo4j_pool, BoltApoc)
+      Sandbox.checkout()
+      on_exit(&Sandbox.rollback/0)
+      {:ok, a} = Author |> Ash.Changeset.for_create(:create, %{name: "a"}) |> Ash.create()
+      %{author: a}
+    end
+
+    test "apoc_available? is true" do
+      assert BoltyHelper.apoc_available?(BoltApoc)
+    end
+
+    test "a real apoc.* fragment round-trips and is correct", %{author: a} do
+      # apoc.text.clean strips non-word chars and lowercases, so "Hello, World!"
+      # and "hello world" normalise to the same value — typo/spacing/case-tolerant.
+      Post |> Ash.Changeset.for_create(:create, %{title: "Hello, World!", written_by: a.id}) |> Ash.create!()
+      Post |> Ash.Changeset.for_create(:create, %{title: "Something else", written_by: a.id}) |> Ash.create!()
+
+      titles =
+        Post
+        |> Ash.Query.filter(fragment("apoc.text.clean(?) = apoc.text.clean(?)", title, "hello world"))
+        |> Ash.read!()
+        |> Enum.map(& &1.title)
+
+      assert titles == ["Hello, World!"]
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -9,8 +9,13 @@
 # excluded by default.
 AshNeo4j.BoltyHelper.start_bolt6()
 
+# Start the BoltApoc pool (Neo4j 5.x Community + APOC) for the :apoc round-trip
+# fragment test (#386). Harmless when absent — `:apoc` tests are excluded by default.
+AshNeo4j.BoltyHelper.start_bolt_apoc()
+
 # `:cypher25` — needs a Neo4j ≥ 2025.06 server (the Bolt6 pool / 2026.05).
 # `:bolt6` — reserved for tests that genuinely require the Bolt 6.0 protocol.
+# `:apoc` — needs the BoltApoc pool (Neo4j + APOC).
 #
 # Cap test concurrency to the Bolt pool (#304). Each async test holds one sandbox
 # connection (an open transaction) for its whole duration, so concurrency must
@@ -21,4 +26,4 @@ AshNeo4j.BoltyHelper.start_bolt6()
 # `connection_info` checkouts).
 bolt_pool_size = Application.get_env(:bolty, Bolt)[:pool_size] || 15
 
-ExUnit.start(exclude: [:show_neo4j, :bolt6, :cypher25], max_cases: bolt_pool_size)
+ExUnit.start(exclude: [:show_neo4j, :bolt6, :cypher25, :apoc], max_cases: bolt_pool_size)

--- a/usage-rules/cypher-fragments.md
+++ b/usage-rules/cypher-fragments.md
@@ -38,7 +38,9 @@ The raw text between the `?`s is author-supplied Cypher, written as-is. So
 
 You are responsible for what the server can run — e.g. APOC must be installed for an
 `apoc.*` fragment. AshNeo4j renders the call faithfully; it doesn't load or require
-APOC.
+APOC. Check from a deploy/start-up healthcheck with
+`AshNeo4j.BoltyHelper.apoc_available?/0` (it introspects the server; installing APOC
+is the operator's job).
 
 ## Scope and limits
 


### PR DESCRIPTION
Closes #386. Follow-up to #33 (the `fragment(...)` filter escape hatch).

## Summary

APOC powers the headline fragment use case (fuzzy text matching), but it's a server plugin AshNeo4j neither installs nor requires. This adds a healthcheck for it and proves the escape hatch end-to-end against a server that has it.

- **`AshNeo4j.BoltyHelper.apoc_available?/0,1`** — a per-pool healthcheck (introspects via `SHOW PROCEDURES`, cached in `:persistent_term`). For a deploy/start-up check before relying on an `apoc.*` fragment. Installing APOC stays the operator's job; this only reports it.
- **A dedicated APOC test server** — `docker-compose` `neo4j-apoc` (Community 5.26 + `NEO4J_PLUGINS='["apoc"]'`, port 7691) and a `BoltApoc` pool started from `test_helper`. The default `Bolt` server stays plain, so `apoc_available?` reads `false` there and the round-trip runs against the APOC pool.
- **`test/apoc_test.exs`** — healthcheck `false` (default) / `true` (APOC pool), and a live `apoc.text.clean` fragment round-trip asserting correct results. Tagged `:apoc`, **excluded by default** — same opt-in pattern as `:cypher25` / `:bolt6`.

Deliberately *not* first-class APOC support or install tooling — just a healthcheck and a gated test. Installing a server plugin is a deployment concern a Bolt client can't (and shouldn't) do.

## Docs

`apoc_available?` noted in `usage-rules/cypher-fragments.md`; README "Running the suite" + `docker-compose.yml` cover the APOC server.

## Testing

`mix test` — **732 passed** (the `:apoc` round-trip excluded); `mix test --include apoc` — **734 passed** (with `docker compose up neo4j-apoc`). `mix dialyzer` clean; `--warnings-as-errors` clean.

> CI is type-checks + REUSE only (no database — the DB suite runs locally), so the `:apoc` round-trip runs locally against the bundled `neo4j-apoc` server, not in CI.
