### PR TITLE
feat: render query results as Mermaid flowcharts (#60)

### DIFF
--- a/ash_neo4j_datalayer.livemd
+++ b/ash_neo4j_datalayer.livemd
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
 
 SPDX-License-Identifier: MIT
@@ -9,7 +9,8 @@ SPDX-License-Identifier: MIT
 ```elixir
 Mix.install(
   [
-    {:ash_neo4j, "~> 0.9"}
+    {:ash_neo4j, "~> 0.9"},
+    {:kino, "~> 0.14"}
   ],
   consolidate_protocols: false
 )
@@ -27,17 +28,17 @@ If already familiar with the [Ash Framework](https://ash-hq.org) in this liveboo
 
 ## Why have an Ash Neo4j DataLayer?
 
-I've been using developing systems for about 30 years, often working with relational databases. I've been developing with graph databases for the last five years. I've found graph aligns naturally with the way I think about things and how they are related. Graphistas see graphs everywhere, because they are everywhere. Graph is similar to Elixir, in that once you start you don't want to go back. In fact life is too short, I won't go back...
+Graphs align naturally with the way many developers think about things and how they relate. Graphistas see graphs everywhere, because they are everywhere. Graph is similar to Elixir, in that once you start you don't want to go back.
 
-Similarly I've found [Ash](https://ash-hq.org) to be an exceptional framework for declarative application development. It has a learning curve, however the Ash way is to use and build abstractions for exceptional maintainability.
+[Ash](https://ash-hq.org) is an exceptional framework for declarative application development. It has a learning curve, however the Ash way is to use and build abstractions for exceptional maintainability.
 
 The Ash Framework contains some basic datalayers and the ecosystem already offers a choice of datalayer extensions, including the popular and feature rich [AshPostgres](https://github.com/ash-project/ash_postgres) above the open source [Postgres](https://github.com/postgres/postgres).
 
-I hitched my wagon to Ash Framework aware of the lack of graph datalayers, knowing that they could be built using an Ash Extension. Indeed Ash does a good job of abstracting SQL databases away and making refactorings easier, so arguably there is less demand for such a thing. However as you refactor your resources you still need to migrate database schemas - so the complexity doesn't go away, it is just better hidden.
+Before AshNeo4j the ecosystem lacked a graph datalayer, even though one can be built as an Ash Extension. Ash does a good job of abstracting SQL databases away and making refactorings easier, so arguably there is less demand for such a thing. However as you refactor your resources you still need to migrate database schemas — so the complexity doesn't go away, it is just better hidden.
 
-Neo4j is defacto in data science and well entrenched in security, fraud, logistics, network management and recommendation applications. Increasingly our applications need to work with both facts and knowledge and these are best represented using graphs.
+Neo4j is defacto in data science and well entrenched in security, fraud, logistics, network management and recommendation applications. Increasingly our applications need to work with both facts and knowledge, and these are best represented using graphs.
 
-So here we both are with Ash and graph. Enjoy the combination.
+So here Ash and graph come together. Enjoy the combination.
 
 ## Brief Introduction to Neo4j
 
@@ -51,13 +52,13 @@ We can relate them with the cypher `MATCH (s:Actor {name: 'Bill Nighy'}), (d:Mov
 
 Cypher is not meant as a graphical language, but has an ASCII art influence and is fairly expressive in that `(s) -[r:ACTED_IN]-> (d)`, which mirrors how these nodes could look related in a browser. Cypher influenced international standard [GQL](https://www.gqlstandards.org) and is being aligned, however to maintain back compatibility with Neo4j 4.x we use Cypher.
 
-We connect to the Neo4j database using the [Bolt protocol](https://neo4j.com/docs/bolt/current/bolt/). Ash Neo4j uses [bolty](https://github.com/diffo-dev/bolty) which is a fork of the inactive [bolt-sips](https://github.com/florinpatrascu/bolt_sips).
+We connect to the Neo4j database using the [Bolt protocol](https://neo4j.com/docs/bolt/current/bolt/). Ash Neo4j uses [bolty](https://github.com/diffo-dev/bolty) which is a fork of the inactive [boltx](https://github.com/sagastume/boltx).
 
 ## Installing Neo4j and Configuring Bolty
 
 While [Neo4j community edition](https://github.com/neo4j/neo4j) is open source and you can build from source it is likely that you'll use an installation.
 
-[AshNeo4j](https://github.com/diffo-dev/ash_neo4j) uses [neo4j](https://github.com/neo4j/neo4j) which must be installed and running. You can install latest major Neo4j versions from the community tab at [Neo4j Deployment Center](https://neo4j.com/deployment-center/?desktop-gdb), or use the [5.26.10 direct link](https://neo4j.com/download-thanks/?edition=community&release=5.26.10&flavour=unix)
+[AshNeo4j](https://github.com/diffo-dev/ash_neo4j) uses [neo4j](https://github.com/neo4j/neo4j) which must be installed and running. We recommend either the 5.26.x LTS release or the latest 2026.x release. You can install Neo4j from the community tab at [Neo4j Deployment Center](https://neo4j.com/deployment-center/?desktop-gdb).
 
 When you install neo4j you'll typically have a default username and password. Take note of this and any other non-standard config.
 
@@ -72,6 +73,13 @@ config = [
   max_overflow: 3,
   prefix: :default,
   name: Bolt,
+  # Pin negotiation to the Bolt protocol versions AshNeo4j is known to support.
+  # If the server (or a future Bolty) advertises something newer and untested,
+  # negotiation still settles within this known-good range rather than onto a
+  # version AshNeo4j hasn't been verified against. Entries are a single version
+  # (`6.0`) or a `{major, range}` tuple across the handshake's four slots; the
+  # two 5.x ranges span the gap where 5.5 was never a Bolt version.
+  versions: [6.0, {5, 6..8}, {5, 0..4}],
   log: false,
   log_hex: false
 ]
@@ -89,6 +97,12 @@ Now you should be able to verify that Ash Neo4j is connected to Neo4j using Bolt
 AshNeo4j.BoltyHelper.is_connected()
 ```
 
+Once connected, Bolty negotiates a `%Bolty.Policy{}` — the resolved set of capabilities for this connection, distilled from the negotiated Bolt version and the server's HELLO response. It's what AshNeo4j reads internally to decide, for example, whether to emit the `CYPHER 25` selector or use dynamic labels, and it's about as deep as most people ever need to go with Bolty:
+
+```elixir
+AshNeo4j.BoltyHelper.policy()
+```
+
 You can get all nodes related to other nodes the following query:
 
 ```elixir
@@ -102,6 +116,49 @@ http://localhost:7474/browser/
 Once you connect and issue a query like the one above you'll be able to explore the results interactively.
 
 <!-- livebook:{"break_markdown":true} -->
+
+### Rendering results as a Mermaid flowchart
+
+You don't need the browser to see the shape of a result. `AshNeo4j.Mermaid.flowchart/2` turns a query result — the `{:ok, response}` tuple returned by `AshNeo4j.Cypher.run/2` — into a [Mermaid](https://mermaid.js.org/syntax/flowchart.html) flowchart string. Pipe it into [`Kino.Mermaid`](https://hexdocs.pm/kino/Kino.Mermaid.html) (the `:kino` dependency added at the top of this livebook) to render the graph inline:
+
+```elixir
+"MATCH (n1)-[r]->(n2) RETURN n1, r, n2 LIMIT 25"
+|> AshNeo4j.Cypher.run()
+|> AshNeo4j.Mermaid.flowchart()
+|> Kino.Mermaid.new()
+```
+
+Nodes show their labels and stored properties. Use options to tune the output — `:direction` (`"TD"`, `"LR"`, …) and `:properties` (`true`, `false`, or a list of property names to keep):
+
+```elixir
+"MATCH (n1)-[r]->(n2) RETURN n1, r, n2 LIMIT 25"
+|> AshNeo4j.Cypher.run()
+|> AshNeo4j.Mermaid.flowchart(direction: "LR", properties: false)
+|> Kino.Mermaid.new()
+```
+
+### Keeping a chart in sync as you explore
+
+`AshNeo4j.Mermaid.tap/0` attaches a telemetry handler that remembers the most recent query result, so any later query can be re-rendered with `AshNeo4j.Mermaid.last/1` without threading the result through by hand. Wire it to a `Kino.Frame` to keep a chart live:
+
+```elixir
+frame = Kino.Frame.new()
+AshNeo4j.Mermaid.tap()
+frame
+```
+
+Now each time you run a query, refresh the frame from the captured result:
+
+```elixir
+AshNeo4j.Cypher.run("MATCH (n1)-[r]->(n2) RETURN n1, r, n2 LIMIT 25")
+Kino.Frame.render(frame, Kino.Mermaid.new(AshNeo4j.Mermaid.last()))
+```
+
+When you're done, detach the handler:
+
+```elixir
+AshNeo4j.Mermaid.untap()
+```
 
 **OPTIONAL** If you want to clear your database you can evaluate:
 

--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -540,7 +540,18 @@ defmodule AshNeo4j.Cypher do
 
     Logger.debug("AshNeo4j.Cypher: run(#{cypher}, #{inspect(params)})")
 
+    start = System.monotonic_time()
     bolty_result = sandboxed_query(cypher, params)
+
+    # Telemetry seam (#60): emit every query with its rendered Cypher, params and
+    # raw bolty result. No handlers are attached by default, so this is ~free; it
+    # lets opt-in tooling (e.g. `AshNeo4j.Mermaid.tap/0`) observe the last result
+    # without `Cypher.run` knowing anything about its consumers.
+    :telemetry.execute(
+      [:ash_neo4j, :query],
+      %{duration: System.monotonic_time() - start},
+      %{cypher: cypher, params: params, result: bolty_result}
+    )
 
     if elem(bolty_result, 0) == :ok do
       Logger.debug("AshNeo4j.Cypher: run result #{inspect(elem(bolty_result, 1).results)}")

--- a/lib/mermaid.ex
+++ b/lib/mermaid.ex
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.Mermaid do
+  @moduledoc """
+  Render a graph query result as a [Mermaid flowchart](https://mermaid.js.org/syntax/flowchart.html)
+  string.
+
+  The input is what `AshNeo4j.Cypher.run/2` (and `AshNeo4j.Neo4jHelper`) return —
+  a `%Bolty.Response{}` or the `{:ok, response}` tuple. The output is a plain
+  string, with no `Kino` dependency, so it renders anywhere a Mermaid flowchart
+  is accepted: `Kino.Mermaid.new/1` in the AshNeo4j livebook, Artefact import, or
+  a Markdown fence.
+
+  Graph values in the result rows are rendered structurally:
+
+  - `%Bolty.Types.Node{}` → a flowchart node `n<id>["Label<br/>key: value"]`,
+    showing its labels and stored (graph, not Ash-cast) properties.
+  - `%Bolty.Types.Relationship{}` → a directed edge `n<start> -->|TYPE| n<end>`.
+  - `%Bolty.Types.Path{}` → its nodes and relationships, with edge direction
+    reconstructed from the path's traversal sequence.
+
+  Nodes are de-duplicated by graph id, so the same node returned in several rows
+  appears once. Scalars (strings, numbers, points, …) in the result are ignored —
+  only graph entities are drawn.
+
+  ## Options
+
+  - `:direction` — flowchart direction, `"TD"` (default), `"LR"`, `"BT"`, `"RL"`.
+  - `:properties` — `true` (default, all stored properties), `false` (labels
+    only), or a list of property names to keep, in that order.
+
+  ## Examples
+  ```
+  iex> node = %Bolty.Types.Node{id: 0, labels: ["Person"], properties: %{"name" => "Bill"}}
+  iex> AshNeo4j.Mermaid.flowchart(%Bolty.Response{results: [%{"n" => node}]})
+  "flowchart TD\\n    n0[\\"Person<br/>name: Bill\\"]"
+
+  iex> a = %Bolty.Types.Node{id: 1, labels: ["Person"], properties: %{}}
+  iex> b = %Bolty.Types.Node{id: 2, labels: ["Movie"], properties: %{}}
+  iex> r = %Bolty.Types.Relationship{id: 9, type: "ACTED_IN", start: 1, end: 2}
+  iex> AshNeo4j.Mermaid.flowchart({:ok, %Bolty.Response{results: [%{"a" => a, "r" => r, "b" => b}]}})
+  "flowchart TD\\n    n1[\\"Person\\"]\\n    n2[\\"Movie\\"]\\n    n1 -->|ACTED_IN| n2"
+
+  iex> node = %Bolty.Types.Node{id: 0, labels: ["Person"], properties: %{"name" => "Bill"}}
+  iex> AshNeo4j.Mermaid.flowchart(%Bolty.Response{results: [%{"n" => node}]}, properties: false)
+  "flowchart TD\\n    n0[\\"Person\\"]"
+  ```
+  """
+
+  alias Bolty.Response
+  alias Bolty.Types.{Node, Relationship}
+
+  @indent "    "
+
+  @doc """
+  Renders a graph result as a Mermaid flowchart string. See the module docs for
+  accepted inputs and options.
+  """
+  @spec flowchart(Response.t() | {:ok, Response.t()} | {:error, term()} | list(), keyword()) ::
+          String.t()
+  def flowchart(result, opts \\ [])
+
+  def flowchart({:ok, %Response{} = response}, opts), do: flowchart(response, opts)
+
+  def flowchart({:error, reason}, _opts) do
+    raise ArgumentError, "AshNeo4j.Mermaid.flowchart/2 cannot render an error result: #{inspect(reason)}"
+  end
+
+  def flowchart(%Response{results: results}, opts), do: flowchart(results, opts)
+
+  def flowchart(results, opts) when is_list(results) do
+    direction = opts |> Keyword.get(:direction, "TD") |> to_string()
+
+    {nodes, edges} = Enum.reduce(results, {[], []}, &collect/2)
+
+    nodes = nodes |> Enum.reverse() |> Enum.uniq_by(&node_gid/1)
+    edges = edges |> Enum.reverse() |> Enum.uniq()
+
+    # Draw a placeholder for any edge endpoint whose node was not itself returned
+    # (e.g. `MATCH ()-[r]->() RETURN r`), so the edge still connects.
+    drawn = MapSet.new(nodes, &node_gid/1)
+
+    placeholders =
+      edges
+      |> Enum.flat_map(fn {from, to, _label} -> [from, to] end)
+      |> Enum.uniq()
+      |> Enum.reject(&MapSet.member?(drawn, &1))
+      |> Enum.map(&{:placeholder, &1})
+
+    lines =
+      ["flowchart #{direction}"] ++
+        Enum.map(nodes ++ placeholders, &node_line(&1, opts)) ++
+        Enum.map(edges, &edge_line/1)
+
+    Enum.join(lines, "\n")
+  end
+
+  # --- live tap -------------------------------------------------------------
+
+  @handler_id "ash_neo4j_mermaid_tap"
+  @agent __MODULE__.Tap
+
+  @doc """
+  Starts capturing the most recent query result, for `last/1`.
+
+  Attaches a `[:ash_neo4j, :query]` telemetry handler (see `AshNeo4j.Cypher.run/2`)
+  that stashes the most recent successful `%Bolty.Response{}` *containing graph
+  entities* (nodes/relationships/paths) in a small `Agent` — so a plain scalar or
+  stat query between graph queries won't clobber the captured view. Idempotent.
+  Pair with `untap/0`. Intended for interactive use (livebook, IEx); the rest of
+  the library never attaches a handler, so without `tap/0` the seam costs nothing.
+
+  ## Example
+      AshNeo4j.Mermaid.tap()
+      AshNeo4j.Cypher.run("MATCH (n:Person)-[r]->(m) RETURN n, r, m")
+      AshNeo4j.Mermaid.last() |> Kino.Mermaid.new()
+  """
+  @spec tap() :: :ok
+  def tap do
+    case Agent.start(fn -> nil end, name: @agent) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+
+    case :telemetry.attach(@handler_id, [:ash_neo4j, :query], &__MODULE__.__handle_query__/4, nil) do
+      :ok -> :ok
+      {:error, :already_exists} -> :ok
+    end
+  end
+
+  @doc """
+  Stops capturing: detaches the telemetry handler and discards the stashed result.
+  Idempotent.
+  """
+  @spec untap() :: :ok
+  def untap do
+    :telemetry.detach(@handler_id)
+    if pid = Process.whereis(@agent), do: Agent.stop(pid)
+    :ok
+  end
+
+  @doc """
+  Renders the most recently captured query result as a flowchart string.
+
+  Requires a prior `tap/0` and at least one successful query since. `opts` are
+  passed to `flowchart/2`. Raises if nothing has been captured.
+  """
+  @spec last(keyword()) :: String.t()
+  def last(opts \\ []) do
+    case Process.whereis(@agent) && Agent.get(@agent, & &1) do
+      %Response{} = response ->
+        flowchart(response, opts)
+
+      _ ->
+        raise "AshNeo4j.Mermaid.last/1: nothing captured yet — call AshNeo4j.Mermaid.tap/0, then run a query"
+    end
+  end
+
+  @doc false
+  def __handle_query__(_event, _measurements, %{result: {:ok, %Response{} = response}}, _config) do
+    # Only stash results that actually contain graph entities, so a plain scalar
+    # (count/stat) query between graph queries doesn't clobber the last view.
+    if graph_result?(response), do: Agent.update(@agent, fn _ -> response end)
+    :ok
+  end
+
+  def __handle_query__(_event, _measurements, _metadata, _config), do: :ok
+
+  # True if any result value is (or contains) a node, relationship or path.
+  # Short-circuits on the first entity found.
+  defp graph_result?(%Response{results: results}), do: Enum.any?(results, &has_entity?/1)
+
+  defp has_entity?(%Node{}), do: true
+  defp has_entity?(%Relationship{}), do: true
+  defp has_entity?(%Bolty.Types.Path{}), do: true
+  defp has_entity?(list) when is_list(list), do: Enum.any?(list, &has_entity?/1)
+
+  defp has_entity?(map) when is_map(map) and not is_struct(map),
+    do: Enum.any?(Map.values(map), &has_entity?/1)
+
+  defp has_entity?(_other), do: false
+
+  # --- collection -----------------------------------------------------------
+  # Walk a result value, accumulating {nodes, edges} (each prepended; reversed
+  # by the caller). Graph entities are collected; everything else is ignored.
+
+  defp collect(%Node{} = node, {nodes, edges}), do: {[node | nodes], edges}
+
+  defp collect(%Relationship{} = rel, {nodes, edges}), do: {nodes, [rel_edge(rel) | edges]}
+
+  defp collect(%Bolty.Types.Path{} = path, {nodes, edges}) do
+    nodes = Enum.reduce(path.nodes || [], nodes, fn n, acc -> [n | acc] end)
+    edges = Enum.reduce(path_edges(path), edges, fn e, acc -> [e | acc] end)
+    {nodes, edges}
+  end
+
+  defp collect(list, acc) when is_list(list), do: Enum.reduce(list, acc, &collect/2)
+
+  defp collect(map, acc) when is_map(map) and not is_struct(map),
+    do: Enum.reduce(Map.values(map), acc, &collect/2)
+
+  defp collect(_scalar, acc), do: acc
+
+  # --- paths ----------------------------------------------------------------
+  # `Bolty.Types.Path.graph/1` rebuilds the walk but its UnboundRelationships
+  # drop start/end (UnboundRelationship has no such fields, so struct/2 discards
+  # them — bolty#55), so we reconstruct edge direction here straight from the
+  # traversal sequence.
+  #
+  # `sequence` is [rel_index, node_index, rel_index, node_index, …]; the walk
+  # starts at nodes[0]. A positive rel_index means the relationship is traversed
+  # outgoing (current → next); a negative one (Neo4j sends 255 for -1) means
+  # incoming (next → current). Relationship indices are 1-based into `relationships`.
+
+  defp path_edges(%Bolty.Types.Path{nodes: nodes, relationships: rels, sequence: seq})
+       when is_list(seq) and is_list(nodes) do
+    seq
+    |> Enum.chunk_every(2)
+    |> Enum.reduce({List.first(nodes), []}, fn [rel_index, node_index], {current, acc} ->
+      next = Enum.at(nodes, node_index)
+      rel_index = if rel_index == 255, do: -1, else: rel_index
+
+      {rel, from, to} =
+        if rel_index > 0 do
+          {Enum.at(rels, rel_index - 1), current, next}
+        else
+          {Enum.at(rels, -rel_index - 1), next, current}
+        end
+
+      {next, [{node_gid(from), node_gid(to), escape(to_string(rel.type))} | acc]}
+    end)
+    |> elem(1)
+    |> Enum.reverse()
+  end
+
+  defp path_edges(_), do: []
+
+  # --- rendering ------------------------------------------------------------
+
+  defp node_line(%Node{} = node, opts), do: ~s(#{@indent}#{node_gid(node)}["#{node_text(node, opts)}"])
+  defp node_line({:placeholder, gid}, _opts), do: ~s(#{@indent}#{gid}["?"])
+
+  defp edge_line({from, to, ""}), do: "#{@indent}#{from} --> #{to}"
+  defp edge_line({from, to, label}), do: "#{@indent}#{from} -->|#{label}| #{to}"
+
+  defp node_text(%Node{labels: labels, properties: properties}, opts) do
+    label_text = (labels || []) |> Enum.map_join(":", &escape(to_string(&1)))
+
+    [label_text | property_lines(properties, opts)]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join("<br/>")
+  end
+
+  defp property_lines(properties, opts) when is_map(properties) do
+    case Keyword.get(opts, :properties, true) do
+      false -> []
+      keys when is_list(keys) -> Enum.flat_map(keys, &fetch_property(properties, &1))
+      _ -> properties |> Map.to_list() |> Enum.map(&property_line/1)
+    end
+  end
+
+  defp property_lines(_properties, _opts), do: []
+
+  defp fetch_property(properties, key) do
+    cond do
+      Map.has_key?(properties, key) -> [property_line({key, Map.get(properties, key)})]
+      Map.has_key?(properties, to_string(key)) -> [property_line({key, Map.get(properties, to_string(key))})]
+      true -> []
+    end
+  end
+
+  defp property_line({key, value}), do: "#{escape(to_string(key))}: #{escape(format_value(value))}"
+
+  defp format_value(value) when is_binary(value), do: value
+  defp format_value(value) when is_boolean(value), do: to_string(value)
+  defp format_value(value) when is_number(value), do: to_string(value)
+  defp format_value(nil), do: "null"
+  defp format_value(value), do: inspect(value)
+
+  # --- ids and escaping -----------------------------------------------------
+  # Key nodes (and edge endpoints) by the integer graph id where present — it is
+  # consistent across Node.id, Relationship.start/end and path nodes — falling
+  # back to the string element id.
+
+  defp node_gid(%Node{id: id}) when not is_nil(id), do: gid(id)
+  defp node_gid(%Node{element_id: element_id}), do: gid(element_id)
+
+  defp rel_edge(%Relationship{} = rel) do
+    {endpoint_gid(rel.start, rel.start_node_element_id), endpoint_gid(rel.end, rel.end_node_element_id),
+     escape(to_string(rel.type))}
+  end
+
+  defp endpoint_gid(id, _element_id) when not is_nil(id), do: gid(id)
+  defp endpoint_gid(_id, element_id), do: gid(element_id)
+
+  defp gid(id) when is_integer(id), do: "n#{id}"
+  defp gid(id) when is_binary(id), do: "n" <> String.replace(id, ~r/[^A-Za-z0-9]/, "_")
+
+  # Escape text destined for the inside of a `["…"]` label. `&` first, then the
+  # angle brackets and quote, then turn newlines into Mermaid line breaks.
+  defp escape(text) do
+    text
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+    |> String.replace("\"", "&quot;")
+    |> String.replace("\n", "<br/>")
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -40,12 +40,12 @@ defmodule AshNeo4j.MixProject do
 
   defp usage_rules do
     [
-    skills: [
-      location: ".claude/skills",
-      # Pull in pre-built skills shipped directly by packages
-      package_skills: [:bolty, ~r/^bolty/]
+      skills: [
+        location: ".claude/skills",
+        # Pull in pre-built skills shipped directly by packages
+        package_skills: [:bolty, ~r/^bolty/]
+      ]
     ]
-  ]
   end
 
   def cli do
@@ -99,6 +99,7 @@ defmodule AshNeo4j.MixProject do
         Utilities: [
           AshNeo4j.BoltyHelper,
           AshNeo4j.Neo4jHelper,
+          AshNeo4j.Mermaid,
           AshNeo4j.QueryHelper,
           AshNeo4j.Util
         ],
@@ -143,6 +144,7 @@ defmodule AshNeo4j.MixProject do
       {:topo, "~> 1.0"},
       {:nx, "~> 0.9"},
       {:jason, "~> 1.4"},
+      {:telemetry, "~> 1.0"},
       {:igniter, ">= 0.6.29 and < 1.0.0-0", [env: :prod, hex: "igniter", repo: "hexpm", optional: true]},
       {:ex_doc, "~> 0.37", only: [:dev, :test], runtime: false},
       {:ex_check, "~> 0.12", only: [:dev, :test]},

--- a/test/mermaid_tap_test.exs
+++ b/test/mermaid_tap_test.exs
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.MermaidTapTest do
+  @moduledoc """
+  Tests for the live tap (`tap/0` / `last/1` / `untap/0`). Drives the
+  `[:ash_neo4j, :query]` telemetry seam directly — no Neo4j connection — and
+  runs sync because the handler and stash Agent are process-global state.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshNeo4j.Mermaid
+  alias Bolty.Response
+  alias Bolty.Types.Node
+
+  setup do
+    on_exit(&Mermaid.untap/0)
+    :ok
+  end
+
+  defp emit(result) do
+    :telemetry.execute([:ash_neo4j, :query], %{duration: 1}, %{cypher: "…", params: %{}, result: result})
+  end
+
+  defp ok_node(id, labels, properties \\ %{}) do
+    {:ok, %Response{results: [%{"n" => %Node{id: id, labels: labels, properties: properties}}]}}
+  end
+
+  test "captures the last successful result and last/1 renders it" do
+    Mermaid.tap()
+    emit(ok_node(0, ["Person"], %{"name" => "Bill"}))
+
+    assert Mermaid.last() == "flowchart TD\n    n0[\"Person<br/>name: Bill\"]"
+  end
+
+  test "last/1 reflects only the most recent result" do
+    Mermaid.tap()
+    emit(ok_node(0, ["Person"]))
+    emit(ok_node(9, ["Movie"]))
+
+    assert Mermaid.last() == "flowchart TD\n    n9[\"Movie\"]"
+  end
+
+  test "last/1 forwards options to flowchart/2" do
+    Mermaid.tap()
+    emit(ok_node(0, ["Person"], %{"name" => "Bill"}))
+
+    assert Mermaid.last(properties: false) == "flowchart TD\n    n0[\"Person\"]"
+  end
+
+  test "tap/0 is idempotent" do
+    assert Mermaid.tap() == :ok
+    assert Mermaid.tap() == :ok
+    emit(ok_node(0, ["Person"]))
+    assert Mermaid.last() == "flowchart TD\n    n0[\"Person\"]"
+  end
+
+  test "error results are not captured" do
+    Mermaid.tap()
+    emit(ok_node(0, ["Person"]))
+    emit({:error, :boom})
+
+    assert Mermaid.last() == "flowchart TD\n    n0[\"Person\"]"
+  end
+
+  test "scalar-only results don't clobber the last graph view" do
+    Mermaid.tap()
+    emit(ok_node(0, ["Person"]))
+    emit({:ok, %Response{results: [%{"count" => 5}]}})
+
+    assert Mermaid.last() == "flowchart TD\n    n0[\"Person\"]"
+  end
+
+  test "nothing is captured until a graph result arrives" do
+    Mermaid.tap()
+    emit({:ok, %Response{results: [%{"count" => 5}]}})
+
+    assert_raise RuntimeError, ~r/nothing captured/, fn -> Mermaid.last() end
+  end
+
+  test "untap/0 stops capture and clears the stash" do
+    Mermaid.tap()
+    emit(ok_node(0, ["Person"]))
+    Mermaid.untap()
+    emit(ok_node(9, ["Movie"]))
+
+    assert_raise RuntimeError, ~r/nothing captured/, fn -> Mermaid.last() end
+  end
+
+  test "untap/0 is idempotent" do
+    assert Mermaid.untap() == :ok
+    assert Mermaid.untap() == :ok
+  end
+
+  test "last/1 raises when nothing has been captured" do
+    assert_raise RuntimeError, ~r/call AshNeo4j.Mermaid.tap/, fn -> Mermaid.last() end
+  end
+end

--- a/test/mermaid_test.exs
+++ b/test/mermaid_test.exs
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2025 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.MermaidTest do
+  @moduledoc """
+  Pure renderer tests for `AshNeo4j.Mermaid.flowchart/2` — builds Bolty graph
+  structs directly, no Neo4j connection required.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshNeo4j.Mermaid
+  alias Bolty.Response
+  alias Bolty.Types.{Node, Path, Relationship}
+
+  doctest AshNeo4j.Mermaid
+
+  defp response(rows), do: %Response{results: rows}
+
+  defp node(id, labels, properties),
+    do: %Node{id: id, labels: labels, properties: properties, element_id: "4:e:#{id}"}
+
+  describe "nodes" do
+    test "renders labels and properties, sorted by key" do
+      n = node(0, ["Person"], %{"name" => "Bill", "born" => 1949})
+
+      assert Mermaid.flowchart(response([%{"n" => n}])) ==
+               """
+               flowchart TD
+                   n0["Person<br/>born: 1949<br/>name: Bill"]\
+               """
+    end
+
+    test "joins multiple labels with a colon" do
+      n = node(0, ["Cinema", "Actor"], %{})
+      assert Mermaid.flowchart(response([%{"n" => n}])) =~ ~s(n0["Cinema:Actor"])
+    end
+
+    test "de-duplicates a node returned across rows" do
+      n = node(7, ["Person"], %{"name" => "Bill"})
+      rendered = Mermaid.flowchart(response([%{"n" => n}, %{"n" => n}]))
+
+      assert rendered ==
+               """
+               flowchart TD
+                   n7["Person<br/>name: Bill"]\
+               """
+    end
+
+    test "ignores scalar values in rows" do
+      n = node(0, ["Person"], %{})
+      rendered = Mermaid.flowchart(response([%{"n" => n, "count" => 5, "name" => "Bill"}]))
+      assert rendered == "flowchart TD\n    n0[\"Person\"]"
+    end
+
+    test "formats nil, boolean and number property values" do
+      n = node(0, ["X"], %{"a" => nil, "b" => true, "c" => 3.5})
+
+      assert Mermaid.flowchart(response([%{"n" => n}])) ==
+               "flowchart TD\n    n0[\"X<br/>a: null<br/>b: true<br/>c: 3.5\"]"
+    end
+  end
+
+  describe "options" do
+    test ":direction overrides the default TD" do
+      n = node(0, ["Person"], %{})
+      assert Mermaid.flowchart(response([%{"n" => n}]), direction: "LR") =~ "flowchart LR"
+      assert Mermaid.flowchart(response([%{"n" => n}]), direction: :BT) =~ "flowchart BT"
+    end
+
+    test ":properties false drops all properties" do
+      n = node(0, ["Person"], %{"name" => "Bill"})
+      assert Mermaid.flowchart(response([%{"n" => n}]), properties: false) == "flowchart TD\n    n0[\"Person\"]"
+    end
+
+    test ":properties list keeps only the named keys, in order" do
+      n = node(0, ["Person"], %{"name" => "Bill", "born" => 1949, "secret" => "x"})
+
+      assert Mermaid.flowchart(response([%{"n" => n}]), properties: [:name, :born]) ==
+               "flowchart TD\n    n0[\"Person<br/>name: Bill<br/>born: 1949\"]"
+    end
+  end
+
+  describe "relationships" do
+    test "renders a directed edge between two returned nodes" do
+      a = node(1, ["Person"], %{})
+      b = node(2, ["Movie"], %{})
+      r = %Relationship{id: 9, type: "ACTED_IN", start: 1, end: 2}
+
+      assert Mermaid.flowchart(response([%{"a" => a, "r" => r, "b" => b}])) ==
+               """
+               flowchart TD
+                   n1["Person"]
+                   n2["Movie"]
+                   n1 -->|ACTED_IN| n2\
+               """
+    end
+
+    test "draws placeholders for endpoints that were not returned" do
+      r = %Relationship{id: 9, type: "KNOWS", start: 1, end: 2}
+      rendered = Mermaid.flowchart(response([%{"r" => r}]))
+
+      assert rendered =~ ~s(n1["?"])
+      assert rendered =~ ~s(n2["?"])
+      assert rendered =~ "n1 -->|KNOWS| n2"
+    end
+
+    test "de-duplicates identical edges" do
+      a = node(1, ["Person"], %{})
+      b = node(2, ["Movie"], %{})
+      r = %Relationship{id: 9, type: "ACTED_IN", start: 1, end: 2}
+
+      rendered = Mermaid.flowchart(response([%{"a" => a, "r" => r, "b" => b}, %{"a" => a, "r" => r, "b" => b}]))
+
+      assert rendered |> String.split("ACTED_IN") |> length() == 2
+    end
+  end
+
+  describe "paths" do
+    test "renders nodes and direction-correct edges from the traversal sequence" do
+      # (n0:Person)-[ACTED_IN]->(n1:Movie): outgoing first hop.
+      n0 = node(0, ["Person"], %{"name" => "Bill"})
+      n1 = node(1, ["Movie"], %{"title" => "Love Actually"})
+      rel = %Bolty.Types.UnboundRelationship{id: 5, type: "ACTED_IN"}
+      path = %Path{nodes: [n0, n1], relationships: [rel], sequence: [1, 1]}
+
+      assert Mermaid.flowchart(response([%{"p" => path}])) ==
+               """
+               flowchart TD
+                   n0["Person<br/>name: Bill"]
+                   n1["Movie<br/>title: Love Actually"]
+                   n0 -->|ACTED_IN| n1\
+               """
+    end
+
+    test "reverses edge direction for an incoming hop (255 = -1)" do
+      n0 = node(0, ["Movie"], %{})
+      n1 = node(1, ["Person"], %{})
+      rel = %Bolty.Types.UnboundRelationship{id: 5, type: "ACTED_IN"}
+      # current=n0, rel_index 255 (-1) means incoming: edge is next -> current.
+      path = %Path{nodes: [n0, n1], relationships: [rel], sequence: [255, 1]}
+
+      assert Mermaid.flowchart(response([%{"p" => path}])) =~ "n1 -->|ACTED_IN| n0"
+    end
+  end
+
+  describe "input shapes and escaping" do
+    test "accepts the {:ok, response} tuple" do
+      n = node(0, ["Person"], %{})
+      assert Mermaid.flowchart({:ok, response([%{"n" => n}])}) == "flowchart TD\n    n0[\"Person\"]"
+    end
+
+    test "raises on an error result" do
+      assert_raise ArgumentError, ~r/cannot render an error result/, fn ->
+        Mermaid.flowchart({:error, :boom})
+      end
+    end
+
+    test "empty results render a bare flowchart" do
+      assert Mermaid.flowchart(response([])) == "flowchart TD"
+    end
+
+    test "escapes quotes and angle brackets in label text" do
+      n = node(0, [~s(Wei<rd")], %{"k" => "a & b > c"})
+      rendered = Mermaid.flowchart(response([%{"n" => n}]))
+
+      assert rendered =~ "Wei&lt;rd&quot;"
+      assert rendered =~ "a &amp; b &gt; c"
+      refute rendered =~ ~s(rd")
+    end
+
+    test "sanitizes string element ids into valid mermaid ids when integer id is absent" do
+      n = %Node{id: nil, element_id: "4:abc-def:5", labels: ["X"], properties: %{}}
+      assert Mermaid.flowchart(response([%{"n" => n}])) == "flowchart TD\n    n4_abc_def_5[\"X\"]"
+    end
+  end
+end


### PR DESCRIPTION
Closes #60.

## What

Adds `AshNeo4j.Mermaid.flowchart/2` — render a graph query result (`%Bolty.Response{}` or the `{:ok, response}` tuple from `AshNeo4j.Cypher.run/2`) as a [Mermaid](https://mermaid.js.org/syntax/flowchart.html) flowchart **string**, for `Kino.Mermaid.new/1` in the livebook and Artefact import. No `Kino` dependency in the library — it returns a plain string.

- Renders `%Node{}` (labels joined `:`, stored graph properties), `%Relationship{}` (directed edge), and `%Path{}` (nodes + edges, direction reconstructed from the traversal sequence).
- De-dups nodes by graph id; draws `["?"]` placeholders for relationship endpoints whose node detail wasn't returned; escapes label text.
- Options: `:direction` (`"TD"` default) and `:properties` (`true` / `false` / key list).

## Live tap

- `Cypher.run/2` now emits a `[:ash_neo4j, :query]` telemetry event (`%{duration}` measurements, `%{cypher, params, result}` metadata). No handlers attached by default, so it's ~free.
- `AshNeo4j.Mermaid.tap/0 | last/1 | untap/0` — opt-in interactive helper that stashes the most recent **graph-bearing** response in a small Agent (last-graph-wins, so scalar/stat queries don't clobber the view) and re-renders it on demand. The library stays `Kino`-free; the livebook wires a `Kino.Frame` for live updates.

## Docs

- New "Rendering results as a Mermaid flowchart" section in the AshNeo4j livebook (flowchart → `Kino.Mermaid`, plus the `Kino.Frame` + tap/last/untap live flow), `:kino` added to its `Mix.install`.
- `:telemetry` added as an explicit dep (was already transitive); `AshNeo4j.Mermaid` added to the docs module groups.
- Livebook housekeeping picked up along the way: de-personalised intro, install section now recommends 5.26.x LTS / latest 2026.x without dead links, boltx (not bolt_sips) lineage, Bolt `:versions` pinning to the supported 5.x/6.0 span, and a `BoltyHelper.policy()` cell.

## Tests

- `test/mermaid_test.exs` (pure renderer) + `test/mermaid_tap_test.exs` (telemetry-driven tap) — 31 tests/doctests, no DB needed. Full local suite green (763 passed).

## Note

Path edge direction is reconstructed locally from `nodes`/`relationships`/`sequence` because `Bolty.Types.Path.graph/1` discards relationship endpoints (`UnboundRelationship` has no `start`/`end`) — raised as diffo-dev/bolty#55. The hand-rolled walk is removable once that lands.

Ash-records rendering (resources + loaded relationships) is intentionally deferred to a follow-up — different shape.