### PR TITLE
Release v0.10.0 — docs, changelog, schema how-to, version bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,8 +112,8 @@ $RECYCLE.BIN/
 
 # End of https://www.toptal.com/developers/gitignore/api/elixir,windows,macos,linux,visualstudiocode
 
-# spark generated
-/documentation
+# spark generated (only dsls/ is generated; how_to/ etc. are authored docs)
+/documentation/dsls
 
 /.notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,15 +69,25 @@ lib/
   bolty_helper.ex              — Pool lifecycle + capability detection: current_pool/0,
                                  with_pool/2, policy/1, cypher25?/1 (cached per pool)
   error.ex                     — AshNeo4j.Error.{RequiresCypher25, GeoDimensionMismatch,
-                                 Unsupported3DGeometry}
+                                 Unsupported3DGeometry, UnresolvableTraversal,
+                                 UnsupportedFilterFragment} + typed data-layer errors (#372).
+                                 Data-layer paths return {:error, Splode}, never raise
+  unknown.ex                   — AshNeo4j.Unknown: the "reached but couldn't determine" value
+                                 (NotLoaded-tradition); never collapse into nil (#329)
   spatial.ex                   — AshNeo4j.Spatial: POINT index lifecycle (operator-invoked)
   vector.ex                    — AshNeo4j.Vector: VECTOR index lifecycle (operator-invoked)
-  types/vector.ex              — AshNeo4j.Type.Vector: embedding attribute (LIST<FLOAT>)
+  constraint.ex                — AshNeo4j.Constraint: identity + PK uniqueness constraint
+                                 lifecycle (operator-invoked, #20/#32)
+  mermaid.ex                   — AshNeo4j.Mermaid: render a query result as a Mermaid graph (#60)
+  type/vector.ex               — AshNeo4j.Type.Vector: embedding attribute (LIST<FLOAT>)
+  type/nx_tensor.ex            — AshNeo4j.Type.NxTensor: rank-generic tensor, Nx-backed (#309)
   geo.ex                       — AshNeo4j.Geo: haversine_meters/2 + 3D variant (match
                                  Neo4j point.distance), force_2d/1 (3D→2D projection)
   functions/                   — Ash.Query.Function modules pushed down to Cypher:
                                  st_* (spatial), vector_similarity / vector_cosine_distance,
+                                 traverse (multi-hop path expression, #321; pushdown-only),
                                  and vector_math.ex (shared in-memory cosine for evaluate/1)
+  calculations/projected_traversal.ex — read-time polymorphic traverse projection (#329)
   resource/info.ex             — All DSL introspection: label/1, module_label/1, domain_label/1,
                                  domain_fragment_label/1, all_labels/1, label_pair/1,
                                  mapping/1, relate/1, translations/1, and relationship helpers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,59 @@ See [Conventional Commits](Https://conventionalcommits.org) for commit guideline
 
 <!-- changelog -->
 
+## [v0.10.0](https://github.com/diffo-dev/ash_neo4j/compare/v0.9.0...v0.10.0) (2026-06-21)
+
+This release opened on functionality and pivoted to industrialisation and integrity: the write path is now atomic and constraint-backed, the read path gains a graph-native traversal expression, and the whole data layer returns typed errors rather than raising. The headline is **graph traversal as a first-class Ash expression** — a multi-hop path that pushes down to Cypher and composes with the rest of your filter, which a relational data layer structurally cannot offer.
+
+### Breaking Changes
+
+* **`AshNeo4j.Types.*` → `AshNeo4j.Type.*`** (#323) — the type namespace is renamed to singular, matching `Ash.Type`. Update `AshNeo4j.Types.Vector` → `AshNeo4j.Type.Vector` (and any other `AshNeo4j.Types.*` reference) in your attribute declarations. No storage or behaviour change.
+
+### Features
+
+* **Graph traversal as an Ash expression** (#321) — `traverse(^hop_chain, projection)` expresses a multi-hop, direction-and-type-selected path *inside* an `Ash.Expr`, and the data layer pushes it down to a Cypher path pattern instead of an imperative load-time Elixir walk. `hop_chain` is a list of `{:forward | :reverse, edge_selector}` hops; `edge_selector` is an Ash relationship name or an explicit `{:edge, label}` / `{:edge, label, dest}`. The reached node composes as a value in a `filter`:
+  - reached-node field comparison — `filter(traverse(^chain, :status) == "active")`
+  - spatial composition (#330, #332) — `filter(st_dwithin(traverse(^chain, :location), ^point, 5_000))` ("services whose site is within 5 km of a point") in one query
+  - membership / cardinality (#334) — `traverse(^chain, :exists) == true`, `traverse(^chain, :count) > 0`
+  - field aggregates (#338) — `traverse(^chain, {:min | :max | :avg | :sum, :field}) <op> value`
+  - reverse-terminal node typing (#336)
+
+  This is radical for Ash: relational data layers model relationships as joins and have no notion of a path as an expression value — so this isn't parity work, it's a graph-native differentiator. The filter context ships now; `sort` (#335), `calculate`/policy, and variable-length are tracked on the open epic #321. See `usage-rules/traverse.md`.
+
+* **Read-time polymorphic projection — `AshNeo4j.Calculations.ProjectedTraversal` + `AshNeo4j.Unknown`** (#329) — a calculation that follows a hop chain and returns the reached node, late-binding its concrete type at read time. Introduces `AshNeo4j.Unknown`, a first-class value complementary to `Ash.NotLoaded`: `NotLoaded` means "not fetched yet"; `Unknown` means "reached, but couldn't be determined in the current view of the graph". Never collapse it into `nil`.
+
+* **Atomic & bulk writes** (#361) — atomic updates render `changeset.atomics` straight to a Cypher `SET` (numeric, string `concat`/`trim`, and enum/atom forms); bulk update and destroy run as a single `update_query/4` / `destroy_query/4` via `Ash.bulk_update` / `Ash.bulk_destroy` with `strategy: :atomic`; a single filtered (optimistic-lock) update or destroy whose guard no longer holds returns `Ash.Error.Changes.StaleRecord` rather than a silent no-op.
+
+* **Atomic upsert** (#379) — create-or-update keyed on an identity renders an atomic Cypher `MERGE`, so concurrent upserts converge on one node instead of racing to duplicates.
+
+* **Identities & primary keys as Neo4j uniqueness constraints** (#20, #32) — `AshNeo4j.Constraint.create_constraints/1` builds `CREATE CONSTRAINT … IS UNIQUE` for every enforceable identity and for the primary key (single and composite, Community Edition). A conflict surfaces as Ash's own `Ash.Error.Changes.InvalidAttribute` ("has already been taken"), so `pre_check?` and its race window are no longer needed. Identities Neo4j can't enforce (`nils_distinct?: false`, filtered `where:`) are refused rather than silently unenforced. Like indexes, AshNeo4j runs no migrations on boot — you invoke the helper. See `usage-rules/identities.md`.
+
+* **Typed tensor attribute — `AshNeo4j.Type.NxTensor`** (#309) — a shape-and-element-typed tensor backed by `Nx.Tensor`, rank 1 to 3 (vector / matrix / 3-tensor), stored row-major as a native property `LIST` (`:property`, default) or a base64 binary blob (`:packed`); neither type nor shape is stored — both are declared constraints recovered on read. Foundation slice of the hybrid tensor/compute epic (#308); structural ops are `Nx`'s own (the value is an `Nx.Tensor`).
+
+* **Dynamic node labels** (#339) — a capability + pattern-position render primitive letting a label be supplied at query time (Cypher 5 ≥ 5.26), groundwork for polymorphic-label reads.
+
+* **Cypher fragment filter escape hatch** (#33) — `cypher_fragment(...)` drops a raw, parameterised Cypher predicate into a `filter` for the rare case the expression surface can't reach, without abandoning the data layer. A caveated last resort, not a default. See `usage-rules/cypher-fragments.md`.
+
+* **Query results as Mermaid flowcharts** (#60) — `AshNeo4j.Mermaid` renders a graph-level query result as a Mermaid diagram for docs and Livebooks.
+
+* **APOC availability healthcheck** (#386) — detects whether APOC procedures are installed on the connected server, so APOC-dependent paths can degrade explicitly.
+
+* **Nested arrays** (#317) — `{:array, {:array, _}}` round-trips via an outer native `LIST` with inner JSON.
+
+### Improvements
+
+* **The data layer returns typed errors, never raises** (#342, #350, #358, #372) — every read/write-path failure is a returned `{:error, Splode}` with a class, not a raised string. New errors: `UnresolvableTraversal` (a traverse filter that can't be formed — never a fabricated edge), `GeoDimensionMismatch`, `Unsupported3DGeometry`, `RequiresCypher25`. Neo4j server errors are surfaced and classified rather than flattened. Bare-string errors throughout the data layer are now typed (#372).
+
+* **Many-to-many modelled as back-to-back `has_many` fails fast** (#127) — with a clear error pointing at a joiner resource node, instead of silently mis-relating.
+
+* **Guarded relationship attach/detach honours `changeset.filter`** (#368) — a `StaleRecord` on miss, consistent with the guarded update/destroy path.
+
+* **Type-check gate** (#347) — CI compiles `--warnings-as-errors` and runs Dialyzer on a clean baseline; the test suite compiles warning-free.
+
+* **Logging unified** (#373, #374) — one data-layer log format; "nothing deleted" demoted from error to debug.
+
+* **CYPHER 5 sunset tripwire** (#363) and **`bolty` 0.2.0** (#362); toolchain bumped to Elixir 1.20 / OTP 29 and Neo4j 5 to 5.26.27 (#318, #320).
+
 ## [v0.9.0](https://github.com/diffo-dev/ash_neo4j/compare/v0.8.1...v0.9.0) (2026-06-09)
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -378,13 +378,40 @@ Calculations can be:
 
 Only `expr(...)` calculations are currently supported. Custom `:calculate` callback modules are not.
 
+## Graph Traversal Expressions
+
+`traverse(^hop_chain, projection)` expresses a multi-hop graph traversal as an `Ash.Expr` value and pushes it down to a single Cypher path pattern — so a multi-hop reach composes inside a `filter` instead of being an imperative load-time walk. A relational data layer models relationships as joins and has no notion of a path as an expression value; this is something a graph data layer can offer that the relational ones structurally cannot.
+
+```elixir
+require Ash.Query
+import Ash.Expr
+
+chain = [{:forward, :posts}]                 # {:forward | :reverse, relationship_or_edge}
+
+# reached-node field comparison
+Author |> Ash.Query.filter(traverse(^chain, :score) > 50) |> Ash.read!()
+
+# compose with spatial — "services within 5 km of their site", one query
+Service |> Ash.Query.filter(st_dwithin(traverse(^chain, :location), ^point, 5_000)) |> Ash.read!()
+
+# membership / cardinality / aggregate over the reached set
+Service |> Ash.Query.filter(traverse(^chain, :exists) == true)
+Party   |> Ash.Query.filter(traverse(^chain, {:max, :population}) <= 5_200_000)
+```
+
+`traverse` is pushdown-only (it needs the graph) and lands in `filter` first — `sort`, `calculate`/policy and variable-length are tracked on epic [#321](https://github.com/diffo-dev/ash_neo4j/issues/321). To *return* a reached value rather than filter on it, use `AshNeo4j.Calculations.ProjectedTraversal`, which late-binds the reached node's type and yields `AshNeo4j.Unknown` when it can't be determined. See `usage-rules/traverse.md`.
+
+## Atomic and Bulk Writes
+
+AshNeo4j renders Ash atomics straight to Cypher — the new value is computed by the database in a `SET`, with no read-modify-write round trip. `Ash.bulk_update` / `Ash.bulk_destroy` with `strategy: :atomic` run as a single `update_query` / `destroy_query`; a create-or-update keyed on an identity renders an atomic `MERGE` so concurrent upserts converge on one node. A single filtered (optimistic-lock) update or destroy whose guard no longer holds returns `Ash.Error.Changes.StaleRecord` rather than a silent no-op, so lost updates are observable. See `usage-rules/atomics.md`.
+
 ## Cypher Fragments
 
 `fragment(...)` is a filter escape hatch — embed a snippet of raw Cypher in a filter for a condition AshNeo4j doesn't push down (e.g. an APOC function), so the read stays a normal Ash query instead of being hand-written as a raw Cypher query (and losing authorization, the resource model and composability). `?` arguments are bound safely: an attribute reference renders to `s.<property>`, a literal to a `$param`. The fragment must be the whole filter, and arguments must be attribute references or literals — anything else is refused (`AshNeo4j.Error.UnsupportedFilterFragment`), never silently dropped. (This is the *expression* `fragment/N`, not an Ash *resource* fragment.) See `usage-rules/cypher-fragments.md`.
 
 ## Limitations and Future Work
 
-Ash Neo4j has support for Ash create, update, read, destroy actions, aggregates, expression calculations, spatial types, and vector embeddings. The cypher is now parameterised but is by no means optimised. The DSL is likely to evolve further and this may break back compatibility. Storage formats are subject to infrequent change so upgrade *may* require data migration (not included).
+Ash Neo4j has support for Ash create, update, read, destroy actions (including atomic and bulk writes with optimistic locking), aggregates, expression calculations, graph traversal expressions, spatial types, and vector embeddings. The cypher is now parameterised but is by no means optimised. The DSL is likely to evolve further and this may break back compatibility. Storage formats are subject to infrequent change so upgrade *may* require data migration (not included).
 
 Vector similarity search is currently a full scan — Neo4j does not use the HNSW vector index for `vector.similarity.cosine` in a `WHERE`/`ORDER BY`. Indexed top-K (via `db.index.vector.queryNodes` / the Cypher 25 `SEARCH` clause) is tracked in [#297](https://github.com/diffo-dev/ash_neo4j/issues/297).
 

--- a/documentation/how_to/managing_schema.livemd
+++ b/documentation/how_to/managing_schema.livemd
@@ -1,0 +1,232 @@
+<!--
+SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+
+SPDX-License-Identifier: MIT
+-->
+
+# Managing Neo4j Schema
+
+```elixir
+Mix.install(
+  [
+    {:ash_neo4j, "~> 0.10"},
+    {:kino, "~> 0.14"}
+  ],
+  consolidate_protocols: false
+)
+```
+
+## What this guide covers
+
+AshNeo4j has three manual DDL surfaces and a deliberate **no-migrations-on-boot** stance:
+
+* **identity uniqueness constraints** and **primary-key constraints** — `AshNeo4j.Constraint` (#20, #32)
+* **vector indexes** — `AshNeo4j.Vector` (#74)
+* (spatial POINT indexes — `AshNeo4j.Spatial` — follow the same shape; see `usage-rules/spatial.md`)
+
+This guide is a cohesive, runnable walk-through of creating and maintaining them.
+
+### Why manual
+
+AshNeo4j runs **no migrations on boot**. It never silently mutates your database schema on application start. Instead you call these helpers yourself — typically from a start-up or release task — so schema changes are explicit, reviewable, and under your control.
+
+Every statement uses `IF NOT EXISTS` / `IF EXISTS`, so the helpers are **idempotent and safe to re-run**. The dry-run functions (`constraint_statements/1`, `index_statements/3`) return the exact Cypher **without touching the database** — so the constraint/index sections below are runnable for review even before you connect.
+
+## Connecting
+
+Update the configuration for your local Neo4j and evaluate. (Only the live "create / drop / SHOW" cells need a connection — the dry-run cells do not.)
+
+```elixir
+config = [
+  uri: "bolt://localhost:7687",
+  auth: [username: "neo4j", password: "password"],
+  user_agent: "ashNeo4jSchemaHowTo/1",
+  pool_size: 5,
+  prefix: :default,
+  name: Bolt,
+  versions: [6.0, {5, 6..8}, {5, 0..4}],
+  log: false
+]
+
+AshNeo4j.BoltyHelper.start(config)
+AshNeo4j.BoltyHelper.is_connected()
+```
+
+## Example resources
+
+A small domain with three constraint shapes: a single-attribute identity, a **composite** primary key, and a vector attribute.
+
+```elixir
+defmodule Schema.Domain do
+  use Ash.Domain, validate_config_inclusion?: false
+
+  resources do
+    allow_unregistered? true
+  end
+end
+
+defmodule Schema.Product do
+  use Ash.Resource, domain: Schema.Domain, data_layer: AshNeo4j.DataLayer
+
+  neo4j do
+    label :Product
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :sku, :string, allow_nil?: false, public?: true
+    attribute :name, :string, public?: true
+  end
+
+  identities do
+    # a single-attribute identity → one uniqueness constraint
+    identity :unique_sku, [:sku]
+  end
+end
+
+defmodule Schema.Listing do
+  use Ash.Resource, domain: Schema.Domain, data_layer: AshNeo4j.DataLayer
+
+  neo4j do
+    label :Listing
+  end
+
+  attributes do
+    # a composite primary key → one composite IS UNIQUE constraint
+    attribute :marketplace, :string, allow_nil?: false, primary_key?: true, public?: true
+    attribute :sku, :string, allow_nil?: false, primary_key?: true, public?: true
+    attribute :price, :integer, public?: true
+  end
+end
+
+defmodule Schema.Note do
+  use Ash.Resource, domain: Schema.Domain, data_layer: AshNeo4j.DataLayer
+
+  neo4j do
+    label :Note
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :body, :string, public?: true
+    # a vector attribute → a VECTOR index (Cypher 25 / Neo4j ≥ 2025.06)
+    attribute :embedding, AshNeo4j.Type.Vector,
+      constraints: [element_type: :float32, dimensions: 1536],
+      public?: true
+  end
+end
+```
+
+## Identities → uniqueness constraints (#20)
+
+An Ash `identity` is enforced at the database level with a Neo4j uniqueness constraint — so you don't need `pre_check?` and its race window. A conflicting create surfaces as Ash's own `Ash.Error.Changes.InvalidAttribute` ("has already been taken").
+
+Inspect the Cypher first (no database needed):
+
+```elixir
+AshNeo4j.Constraint.constraint_statements(Schema.Product)
+#=> {:ok, ["CREATE CONSTRAINT product_pk IF NOT EXISTS FOR (n:Product) REQUIRE n.uuid IS UNIQUE",
+#         "CREATE CONSTRAINT product_unique_sku IF NOT EXISTS FOR (n:Product) REQUIRE n.sku IS UNIQUE"]}
+```
+
+Then create them (this one touches the database):
+
+```elixir
+AshNeo4j.Constraint.create_constraints(Schema.Product)
+#=> {:ok, [%Bolty.Response{}, ...]}   # one per constraint; safe to re-run (IF NOT EXISTS)
+```
+
+Constraint names are derived: `<label_lower>_<identity_name>` for an identity (`product_unique_sku`), and `<label_lower>_pk` for the primary key (`product_pk`).
+
+## Composite primary keys (#32)
+
+The resource's **primary key** also gets a uniqueness constraint — composite keys included, on Neo4j **Community Edition**. `Schema.Listing` has a composite `[:marketplace, :sku]` primary key:
+
+```elixir
+AshNeo4j.Constraint.constraint_statements(Schema.Listing)
+#=> {:ok, ["CREATE CONSTRAINT listing_pk IF NOT EXISTS FOR (n:Listing) REQUIRE (n.marketplace, n.sku) IS UNIQUE"]}
+```
+
+The primary-key constraint is **deduped**: if an identity already constrains the same attribute set, no redundant `_pk` constraint is created. Primary-key attributes are always required, so the constraint is always enforceable.
+
+```elixir
+AshNeo4j.Constraint.create_constraints(Schema.Listing)
+```
+
+## What's refused (not silently skipped)
+
+Some identities **cannot** be enforced as a Neo4j uniqueness constraint:
+
+* `nils_distinct?: false` — Neo4j treats nulls as always-distinct in a uniqueness constraint
+* a **filtered** identity (`where:`) — a constraint can't carry a predicate
+
+Rather than silently leave such an identity unenforced (and permit the duplicates the constraint exists to prevent), AshNeo4j **refuses** — returning `{:error, %AshNeo4j.Error.UnsupportedIdentity{}}` and creating **nothing** for that resource (all-or-nothing). The same cases are rejected at compile time by `AshNeo4j.Verifiers.VerifyIdentities`, so you find out when you define the resource, not in production.
+
+```elixir
+defmodule Schema.Loose do
+  use Ash.Resource, domain: Schema.Domain, data_layer: AshNeo4j.DataLayer
+
+  neo4j do
+    label :Loose
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :email, :string, public?: true
+  end
+
+  identities do
+    identity :unique_email, [:email], nils_distinct?: false
+  end
+end
+
+AshNeo4j.Constraint.constraint_statements(Schema.Loose)
+#=> {:error, %AshNeo4j.Error.UnsupportedIdentity{reason: :nils_not_distinct, ...}}
+```
+
+## Vector indexes (#74)
+
+A vector attribute is searchable without an index (a full scan), but an HNSW **VECTOR index** is what makes similarity search scale. Like constraints, you create it yourself. It requires Cypher 25 (Neo4j ≥ 2025.06).
+
+Dimensions and element type come from the attribute's `constraints`; the index options control naming, recreation, and the similarity function.
+
+```elixir
+AshNeo4j.Vector.index_statements(Schema.Note, :embedding)
+#=> {:ok, "CREATE VECTOR INDEX note_embedding_vector IF NOT EXISTS FOR (n:Note) ON (n.embedding) " <>
+#         "OPTIONS {indexConfig: {`vector.dimensions`: 1536, `vector.similarity_function`: 'cosine'}}"}
+```
+
+```elixir
+# create it (Cypher 25 required)
+AshNeo4j.Vector.create_index(Schema.Note, :embedding)
+
+# changed :dimensions or :similarity_function? recreate drops then re-creates:
+AshNeo4j.Vector.create_index(Schema.Note, :embedding, recreate: true, similarity_function: :euclidean)
+```
+
+## Maintaining
+
+Inspect what's actually on the server with native Cypher via the data layer's pool:
+
+```elixir
+{:ok, constraints} = AshNeo4j.Cypher.run("SHOW CONSTRAINTS")
+{:ok, indexes} = AshNeo4j.Cypher.run("SHOW INDEXES")
+{constraints, indexes}
+```
+
+Drop when a resource's schema changes (both use `IF EXISTS`, so they're no-ops when absent):
+
+```elixir
+AshNeo4j.Constraint.drop_constraints(Schema.Product)
+AshNeo4j.Vector.drop_index(Schema.Note, :embedding)
+```
+
+A typical **release task** creates the schema for every resource on deploy — idempotent, so it's safe on every release:
+
+```elixir
+for resource <- [Schema.Product, Schema.Listing] do
+  {resource, AshNeo4j.Constraint.create_constraints(resource)}
+end
+```
+
+That's the whole schema surface: declare constraints and indexes in code, inspect the Cypher with the dry-run helpers, create them from a release task, and re-run freely. No migrations on boot, nothing implicit.

--- a/lib/type/nx_tensor.ex
+++ b/lib/type/nx_tensor.ex
@@ -4,8 +4,11 @@
 
 defmodule AshNeo4j.Type.NxTensor do
   @moduledoc """
-  Ash attribute type for a rank-generic typed tensor (#309), backed by
+  Ash attribute type for a typed tensor of rank 1 to 3 (#309), backed by
   `Nx.Tensor`.
+
+  The flat row-major encoding with a declared shape covers vectors, matrices
+  and 3-tensors; rank > 3 is not supported this release.
 
   The Elixir-side value is an `Nx.Tensor` — so the value-blind structural ops
   (`Nx.transpose/2` (lazy), `Nx.reshape/2`, `Nx.slice/3`, `Nx.stack/2`,
@@ -32,8 +35,9 @@ defmodule AshNeo4j.Type.NxTensor do
     * `:type` — Nx element type, one of a closed set of shorthands (`:u8`,
       `:s64`, `:f32`, `:f8`, `:c64`, …). Defaults to `:u8`. Declared, never
       inferred — input is cast to it, read reconstructs from it.
-    * `:shape` — **required** tensor shape (e.g. `[9, 9]`). Declared schema, used
-      on write and read; never stored or inferred (no honest default exists).
+    * `:shape` — **required** tensor shape (e.g. `[9, 9]`), rank 1 to 3. Declared
+      schema, used on write and read; never stored or inferred (no honest default
+      exists).
     * `:store` — `:property` (default) or `:packed`.
 
   ## Usage
@@ -89,7 +93,7 @@ defmodule AshNeo4j.Type.NxTensor do
       shape: [
         type: {:list, :pos_integer},
         required: true,
-        doc: "The tensor shape (e.g. `[9, 9]`). Declared schema — used on write and read; never stored or inferred."
+        doc: "The tensor shape (e.g. `[9, 9]`), rank 1 to 3. Declared schema — used on write and read; never stored or inferred."
       ],
       store: [
         type: {:one_of, [:property, :packed]},

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule AshNeo4j.MixProject do
   @moduledoc false
   use Mix.Project
 
-  @version "0.9.0"
+  @version "0.10.0"
   @name "AshNeo4j"
   @description "Ash DataLayer for Neo4j"
   @github_url "https://github.com/diffo-dev/ash_neo4j"
@@ -70,6 +70,7 @@ defmodule AshNeo4j.MixProject do
         {"README.md", title: "Home"},
         {"LICENSES/MIT.md", title: "License"},
         {"ash_neo4j_datalayer.livemd", title: "AshNeo4j Livebook"},
+        {"documentation/how_to/managing_schema.livemd", title: "Managing Neo4j Schema"},
         {"documentation/dsls/DSL-AshNeo4j.DataLayer.md", search_data: Spark.Docs.search_data_for(AshNeo4j.DataLayer)},
         "CHANGELOG.md"
       ],

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -125,6 +125,69 @@ Calculations on embedded struct fields (`Ash.TypedStruct`, nested types) work th
 
 Custom calculation modules (`:calculate` callback) are not currently supported — only expression (`expr(...)`) calculations.
 
+## Graph traversal expressions — `traverse/2` (#321)
+
+**This is the graph-native differentiator — reach for it before a join-shaped load or an imperative multi-query walk.** `traverse(^hop_chain, projection)` expresses a multi-hop, direction-and-type-selected path *inside* an `Ash.Expr`, and the data layer pushes it down to a single Cypher path pattern. A relational data layer can't do this — it models relationships as joins and has no notion of a path as an expression value.
+
+```elixir
+require Ash.Query
+import Ash.Expr
+
+# hop_chain — a list of {:forward | :reverse, edge_selector}.
+# :forward walks an outgoing edge, :reverse an incoming one.
+# edge_selector is an Ash relationship name (resolved on the source resource
+# to its edge label + destination), or {:edge, LABEL} / {:edge, LABEL, DEST}.
+chain = [{:forward, :posts}]
+
+# reached-node field comparison — authors who wrote a post scoring > 50
+Author
+|> Ash.Query.filter(traverse(^chain, :score) > 50)
+|> Ash.read!()
+```
+
+Projection (the second argument, default `:node`) selects what to pull from the reached set:
+
+```elixir
+# compose with spatial — "services whose site is within 5 km of a point", one query
+Service |> Ash.Query.filter(st_dwithin(traverse(^chain, :location), ^point, 5_000))
+
+# membership / cardinality over the reached set (#334)
+Service |> Ash.Query.filter(traverse(^chain, :exists) == true)    # reaches a node
+Service |> Ash.Query.filter(traverse(^chain, :exists) == false)   # reaches none
+Service |> Ash.Query.filter(traverse(^chain, :count) > 0)
+
+# field aggregates over the reached set (#338)
+Party |> Ash.Query.filter(traverse(^chain, {:min, :population}) > 5_200_000)
+```
+
+`traverse` is **pushdown-only** — it needs the graph, so it has no in-memory value and is recognised in **`filter`** in this slice. `sort` (#335), `calculate`/policy, and variable-length are fast-follows (open epic #321). A chain that can't be formed (unknown relationship, missing field, unreachable type) returns `{:error, %AshNeo4j.Error.UnresolvableTraversal{}}` — it never fabricates an edge. To **return** a reached value (not filter on it), use `AshNeo4j.Calculations.ProjectedTraversal` (below). Full rules in `usage-rules/traverse.md`.
+
+## Atomic and bulk writes (#361, #379)
+
+AshNeo4j renders Ash atomics straight to Cypher — no read-modify-write round trip.
+
+```elixir
+require Ash.Query
+import Ash.Expr
+
+# atomic update — changeset.atomics render to a Cypher SET (numeric, string
+# concat/trim, enum/atom forms)
+post |> Ash.Changeset.for_update(:update) |> Ash.Changeset.atomic_update(:score, expr(score + 1)) |> Ash.update!()
+
+# bulk atomic update — one UPDATE query, not N round-trips
+Post |> Ash.Query.filter(draft == true) |> Ash.bulk_update!(:publish, %{}, strategy: :atomic)
+
+# bulk atomic destroy — "delete what matches"; a guarded node is skipped, not deleted
+Specification |> Ash.bulk_destroy!(:destroy, %{}, strategy: :atomic)
+
+# atomic upsert — create-or-update keyed on an identity renders a Cypher MERGE,
+# so concurrent upserts converge on one node
+Ash.create!(Upsert, %{first_name: "Donald", surname: "Duck", field: "two"},
+  upsert?: true, upsert_identity: :full_name)
+```
+
+A single **filtered (optimistic-lock) update or destroy** whose guard no longer holds returns `Ash.Error.Changes.StaleRecord` — not a silent no-op — so a lost update is observable. The same guard-on-miss → `StaleRecord` rule applies to guarded relationship attach/detach (#368). Full rules in `usage-rules/atomics.md`.
+
 ## Spatial types and expressions
 
 AshNeo4j stores geometries using [`ash_geo`](https://hex.pm/packages/ash_geo) types — declare attributes as `AshGeo.GeoJson` with a `geo_types` constraint, carrying [`%Geo.*{}`](https://hex.pm/packages/geo) structs. `st_*` expression functions (`st_contains`, `st_within`, `st_intersects`, `st_distance`, `st_distance_in_meters`, `st_dwithin`, `st_closest_point`) match ash_geo / PostGIS signatures. Predicates push down to Neo4j's native `point.distance` and `point.withinBBox` wherever possible.

--- a/usage-rules/atomics.md
+++ b/usage-rules/atomics.md
@@ -1,0 +1,78 @@
+<!--
+SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+
+SPDX-License-Identifier: MIT
+-->
+
+# Atomic, bulk and optimistic-lock writes (#361, #379)
+
+AshNeo4j renders Ash atomics straight to Cypher — the new value is computed by
+the database in a `SET`, not read into Elixir, mutated, and written back. This
+removes a read-modify-write round trip and the lost-update race that comes with
+it.
+
+## Atomic update
+
+`changeset.atomics` render to a Cypher `SET`. Numeric expressions, string
+`concat` / `trim`, and enum/atom forms (via their stored string) are supported.
+
+```elixir
+require Ash.Query
+import Ash.Expr
+
+post
+|> Ash.Changeset.for_update(:update)
+|> Ash.Changeset.atomic_update(:score, expr(score + 1))
+|> Ash.update!()
+```
+
+## Bulk update and destroy
+
+`Ash.bulk_update` / `Ash.bulk_destroy` with `strategy: :atomic` run as a single
+`update_query/4` / `destroy_query/4` — one Cypher statement over the matched
+set, not N round trips.
+
+```elixir
+# bulk atomic update
+Post
+|> Ash.Query.filter(draft == true)
+|> Ash.bulk_update!(:publish, %{}, strategy: :atomic)
+
+# bulk atomic destroy — "delete what matches"; a guard-protected node is
+# skipped, not deleted
+Specification
+|> Ash.bulk_destroy!(:destroy, %{}, strategy: :atomic, return_records?: true)
+```
+
+## Optimistic locking — `StaleRecord` on miss
+
+A single **filtered** update or destroy carries its filter into the Cypher as a
+guard. If the guard no longer holds (someone else moved the value first), the
+write touches nothing and returns `Ash.Error.Changes.StaleRecord` — the lost
+update is **observable**, not a silent no-op.
+
+```elixir
+# only succeeds while score is still 5; otherwise StaleRecord
+post
+|> Ash.Changeset.for_update(:update)
+|> Ash.Changeset.filter(expr(score == 5))
+|> Ash.Changeset.atomic_update(:score, expr(score + 1))
+|> Ash.update()
+#=> {:error, %Ash.Error.Changes.StaleRecord{}}   # if the guard missed
+```
+
+The same guard-on-miss → `StaleRecord` rule applies to guarded relationship
+attach/detach (#368), so optimistic locking behaves consistently across the
+write path.
+
+## Atomic upsert — `MERGE` (#379)
+
+A create-or-update keyed on an identity renders an atomic Cypher `MERGE`, so
+concurrent upserts converge on a single node instead of racing to duplicates.
+Pair it with the uniqueness constraint for that identity (see
+`usage-rules/identities.md`) for a database-enforced guarantee.
+
+```elixir
+Ash.create!(Upsert, %{first_name: "Donald", surname: "Duck", field: "two"},
+  upsert?: true, upsert_identity: :full_name)
+```

--- a/usage-rules/traverse.md
+++ b/usage-rules/traverse.md
@@ -1,0 +1,99 @@
+<!--
+SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+
+SPDX-License-Identifier: MIT
+-->
+
+# Graph traversal expressions — `traverse/2` (#321)
+
+`traverse(^hop_chain, projection)` expresses a multi-hop graph traversal as an
+`Ash.Expr` value and pushes it down to a single Cypher path pattern. From the
+queried node, follow a chain of typed and directed edges, reach the node(s) at
+the far end, and use that reached node inside a `filter`.
+
+This is graph-native: a relational data layer models relationships as joins and
+has **no notion of a path as an expression value**. So `traverse` isn't
+parity work — it's something a graph data layer can offer that the relational
+ones structurally cannot. Reach for it before a join-shaped load or an
+imperative multi-query walk.
+
+```elixir
+require Ash.Query
+import Ash.Expr
+
+# A hop chain — each hop is {:forward | :reverse, edge_selector}.
+#   :forward — walk an outgoing edge (the queried node is the edge source)
+#   :reverse — walk an incoming edge (the queried node is the edge target)
+#   edge_selector — an Ash relationship name (resolved on the source resource
+#     to its edge label + destination label), or an explicit
+#     {:edge, LABEL} / {:edge, LABEL, DEST_LABEL}.
+chain = [{:forward, :posts}]
+
+Author
+|> Ash.Query.filter(traverse(^chain, :score) > 50)
+|> Ash.read!()
+```
+
+## Projection — what to pull from the reached set
+
+The second argument (default `:node`) selects the value the reached set
+contributes to the expression:
+
+| Projection | Renders to | Use |
+|---|---|---|
+| `:node` (default) | the reached node | identity / existence |
+| a field atom (`:status`, `:location`) | `d.<property>` | compare, or feed to `st_*` / `vector_*` |
+| `:exists` | `EXISTS {}` / `NOT EXISTS {}` | membership — spell `== true` / `== false` |
+| `:count` | `COUNT { … } <op> n` | cardinality of distinct reached nodes |
+| `{:min \| :max \| :avg \| :sum, :field}` | the reached-set aggregate | aggregate, then compare |
+
+```elixir
+# spatial composition — "services whose site is within 5 km of a point", one query
+Service |> Ash.Query.filter(st_dwithin(traverse(^chain, :location), ^point, 5_000))
+
+# membership / cardinality (#334)
+Service |> Ash.Query.filter(traverse(^chain, :exists) == true)
+Service |> Ash.Query.filter(traverse(^chain, :count) > 0)
+
+# field aggregate over the reached set (#338)
+Party |> Ash.Query.filter(traverse(^chain, {:max, :population}) <= 5_200_000)
+```
+
+Ash's own `count()` / `sum()` are inline aggregates welded to a relationship
+path and expanded at filter hydration, so they can't nest as
+`traverse(count())` — the aggregate is carried as the projection literal
+(`:count`, `{:sum, :field}`) instead.
+
+## Pushdown-only, and where it applies
+
+Traversal needs the graph: it can't be computed from argument values, so it has
+**no in-memory value**. The data layer applies it exactly in Cypher and excludes
+it from the in-memory correctness re-filter. Two consequences:
+
+- It is recognised in **`filter`** in this slice. `sort` (#335),
+  `calculate` / policy contexts, and variable-length traversal (`*`, with
+  nearest / root / path / all modes) are fast-follows tracked on the open epic
+  **#321**.
+- A chain that **can't be formed** — an unknown relationship, a missing field,
+  a hop that reaches no known type — returns
+  `{:error, %AshNeo4j.Error.UnresolvableTraversal{}}`. It **never fabricates an
+  edge label** to make the path render.
+
+## Returning a reached value — `ProjectedTraversal`
+
+`traverse` is for **filtering** on a reached node. To **return** the reached
+node as a loaded value (late-binding its concrete type at read time), declare an
+`AshNeo4j.Calculations.ProjectedTraversal` calculation:
+
+```elixir
+calculate :site, :struct,
+  {AshNeo4j.Calculations.ProjectedTraversal,
+   chain: [{:forward, :place_ref}, {:forward, :place}]}
+```
+
+Per record it returns the concrete record, `%AshNeo4j.Unknown{}` (a node was
+reached but resolves to no loaded world), `nil` (nothing reached), or
+`%Ash.NotLoaded{}` (until loaded). Pattern-match `AshNeo4j.Unknown` alongside
+`nil` and concrete values — it means "reached, but couldn't be determined",
+distinct from "not fetched yet" (`NotLoaded`) and "absent" (`nil`). Never
+collapse it into `nil`.


### PR DESCRIPTION
Release-prep for **v0.10.0**: documents what landed since v0.9.0 and cuts the version. No functional code changes — docs, changelog, a new how-to Livebook, and the version bump.

## Why now
The cycle pivoted functionality → industrialisation/integrity and reached a coherent close: atomic + constraint-backed writes, graph-native traversal reads, and a typed-error/no-raise data layer. Everything the next diffo phase needs is landed; this cuts the release so work can move to diffo / diffo_example.

## What's here

**Changelog** — hand-curated `v0.10.0` entry, leading with **graph traversal as an Ash expression** (#321), then atomics/upsert (#361/#379), uniqueness constraints (#20/#32), `NxTensor` (#309), and the integrity/no-raise improvements. `AshNeo4j.Types.* → AshNeo4j.Type.*` flagged breaking (#323).

**Agent-facing docs** (so downstream agents pick the capabilities up via `mix usage_rules.sync`)
- `usage-rules.md`: new **Graph traversal expressions** and **Atomic and bulk writes** sections
- new `usage-rules/traverse.md`, `usage-rules/atomics.md` — grounded in the `Traverse` moduledoc and the live tests
- `AGENTS.md`: project-structure refresh (`type/` rename, traverse, constraint, mermaid, nx_tensor, unknown, projected_traversal; "data layer returns {:error}, never raises")

**Human docs** — `README.md` Graph Traversal Expressions + Atomic and Bulk Writes sections; Limitations updated.

**`#384` how-to Livebook** — `documentation/how_to/managing_schema.livemd`: runnable guide to the manual DDL surfaces (identity + composite-PK uniqueness constraints, vector indexes) and the no-migrations-on-boot stance.

**NxTensor scope** — moduledoc now states **rank 1–3** as deliberate scope (flat row-major + declared shape), matching the code guard. Subgraph storage for higher ranks stays a deferred opt-in `:store` codec under epic #308 — not mentioned in shipped docs.

**Version** — `@version` 0.9.0 → 0.10.0; how-to wired into docs `extras`.

## Decisions to sanity-check
1. **`.gitignore` narrowed** `/documentation` → `/documentation/dsls`. Only `dsls/` is spark-generated; the `groups_for_extras` regex already designates `documentation/how_to` for authored guides, so the broad ignore was hiding authored docs. The how-to lives there per the #384 proposal. (Alternative: root-level livemd like `ash_neo4j_datalayer.livemd`.)
2. **Issue reconciliation done out-of-band**: #329 and #309 closed as delivered; #321 epic given a delivered/remaining checklist comment. #335/#327 stay open as the genuine traverse tail.

## Not included (deliberately deferred)
#297 (indexed vector — no near-term need), #370, #383, #243, the epics (#307/#308/#314), #270 Phase 2, #326/#327/#335/#356.