### PR TITLE
fix: don't cap the sandbox holder transaction at DBConnection's 15s timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,8 +62,8 @@ jobs:
       - name: Start Neo4j test databases (bolt5 → 7687, bolt6 → 7689, apoc → 7691)
         run: docker compose up -d --wait --wait-timeout 300
 
-      - name: Test (default + cypher25 + bolt6 + apoc)
-        run: mix test --include cypher25 --include bolt6 --include apoc
+      - name: Test (default + cypher25 + bolt6 + apoc + slow)
+        run: mix test --include cypher25 --include bolt6 --include apoc --include slow
 
       - name: Stop Neo4j test databases
         if: always()

--- a/lib/sandbox.ex
+++ b/lib/sandbox.ex
@@ -55,6 +55,13 @@ defmodule AshNeo4j.Sandbox do
 
   @pdict_key :ash_neo4j_sandbox
 
+  # The holder transaction stays checked out for the *whole* test, so it must
+  # not inherit DBConnection's 15s default checkout timeout — a test whose
+  # wall-clock exceeds that would otherwise be force-disconnected mid-run
+  # (#398). Default to :infinity; ExUnit's own per-test timeout still bounds a
+  # genuinely stuck test (its exit signals the holder to roll back).
+  @default_holder_timeout :infinity
+
   @doc """
   Checks out a sandbox connection and begins a Neo4j transaction.
 
@@ -62,10 +69,18 @@ defmodule AshNeo4j.Sandbox do
   executed within the open transaction. The transaction is rolled back
   automatically when the calling process exits.
 
+  ## Options
+
+    * `:timeout` — the DBConnection checkout timeout for the holder transaction,
+      in milliseconds or `:infinity`. The holder is held for the entire test, so
+      this must not be DBConnection's 15s default. Defaults to the application
+      env `config :ash_neo4j, #{inspect(__MODULE__)}, timeout: …`, or
+      `#{inspect(@default_holder_timeout)}` if unset.
+
   Raises if called more than once without an intervening `rollback/0`.
   """
-  @spec checkout() :: :ok
-  def checkout do
+  @spec checkout(keyword()) :: :ok
+  def checkout(opts \\ []) do
     if Process.get(@pdict_key) do
       raise "AshNeo4j.Sandbox already checked out for this process — call rollback/0 first"
     end
@@ -75,6 +90,7 @@ defmodule AshNeo4j.Sandbox do
     # parent's process dictionary, so a `:bolt6` test's pool override has to be
     # read here and passed in.
     pool = AshNeo4j.BoltyHelper.current_pool()
+    timeout = Keyword.get(opts, :timeout, configured_timeout())
 
     holder =
       spawn_link(fn ->
@@ -82,10 +98,14 @@ defmodule AshNeo4j.Sandbox do
         # killing the holder before Bolty.rollback/2 can be called.
         Process.flag(:trap_exit, true)
 
-        Bolty.transaction(pool, fn conn ->
-          send(parent, {:ash_neo4j_sandbox_ready, self()})
-          holder_loop(conn)
-        end)
+        Bolty.transaction(
+          pool,
+          fn conn ->
+            send(parent, {:ash_neo4j_sandbox_ready, self()})
+            holder_loop(conn)
+          end,
+          timeout: timeout
+        )
       end)
 
     receive do
@@ -148,6 +168,12 @@ defmodule AshNeo4j.Sandbox do
           30_000 -> {:error, "AshNeo4j.Sandbox query timed out after 30s"}
         end
     end
+  end
+
+  defp configured_timeout do
+    :ash_neo4j
+    |> Application.get_env(__MODULE__, [])
+    |> Keyword.get(:timeout, @default_holder_timeout)
   end
 
   defp holder_loop(conn) do

--- a/test/sandbox_timeout_test.exs
+++ b/test/sandbox_timeout_test.exs
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.SandboxTimeoutTest do
+  @moduledoc false
+  # Regression for #398: the holder transaction is held for the whole test, so
+  # it must not inherit DBConnection's 15s default checkout timeout. This module
+  # drives its own checkout (no shared `setup` checkout) so it can exercise the
+  # `:timeout` option directly.
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+  alias AshNeo4j.Neo4jHelper
+  alias AshNeo4j.Sandbox
+
+  setup_all do
+    AshNeo4j.BoltyHelper.start()
+  end
+
+  test "checkout/1 passes :timeout to the holder transaction (short timeout disconnects)" do
+    # With a short explicit timeout the held transaction is disconnected once it
+    # outlives it — proving the :timeout reaches DBConnection.transaction at the
+    # call site. If the timeout were dropped, the 15s default would apply and the
+    # query below would still succeed, failing this assertion.
+    log =
+      capture_log(fn ->
+        Sandbox.checkout(timeout: 300)
+        Process.sleep(800)
+        assert {:error, _} = Neo4jHelper.read_nodes(:SandboxTimeoutNode)
+        Sandbox.rollback()
+      end)
+
+    assert log =~ "disconnected" or log =~ "timed out"
+  end
+
+  @tag :slow
+  test "checkout/0 default keeps the holder transaction alive past 15s" do
+    # The default is :infinity, so a transaction held longer than DBConnection's
+    # 15s default still serves queries (the bug in #398 was a disconnect at 15s).
+    Sandbox.checkout()
+    Process.sleep(15_500)
+    assert {:ok, %{records: []}} = Neo4jHelper.read_nodes(:SandboxTimeoutNode)
+    Sandbox.rollback()
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -26,4 +26,6 @@ AshNeo4j.BoltyHelper.start_bolt_apoc()
 # `connection_info` checkouts).
 bolt_pool_size = Application.get_env(:bolty, Bolt)[:pool_size] || 15
 
-ExUnit.start(exclude: [:show_neo4j, :bolt6, :cypher25, :apoc], max_cases: bolt_pool_size)
+# `:slow` — long-running guards (e.g. the >15s sandbox-timeout regression, #398);
+# excluded by default, run in CI via `--include slow`.
+ExUnit.start(exclude: [:show_neo4j, :bolt6, :cypher25, :apoc, :slow], max_cases: bolt_pool_size)


### PR DESCRIPTION
Closes #398.

## Problem
`AshNeo4j.Sandbox.checkout/0` opened the per-test holder transaction with `Bolty.transaction(pool, fn …)` and **no `:timeout`**, so it inherited DBConnection's **15s default checkout timeout**. But the holder is intentionally long-lived — it stays checked out for the whole test. Any test whose wall-clock exceeded 15s (common on CI's lower-concurrency runners, where async inflates per-test wall-clock) was force-disconnected mid-run.

## Fix
Pass an explicit `:timeout` to `Bolty.transaction/3`, defaulting to **`:infinity`** and overridable:
- per call: `AshNeo4j.Sandbox.checkout(timeout: …)`
- app-wide: `config :ash_neo4j, AshNeo4j.Sandbox, timeout: …`

`:infinity` is safe — ExUnit's own per-test timeout still bounds a genuinely stuck test, and its exit signals the holder to roll back. `checkout/0` stays source-compatible (`checkout(opts \\ [])`).

## Tests
- **Fast (always-on):** `checkout(timeout: 300)` then idle past it → the held transaction is disconnected, proving the `:timeout` reaches `DBConnection.transaction` at the call site. If the timeout plumbing were dropped, the 15s default would apply and this assertion would fail.
- **`:slow`:** default checkout keeps a transaction alive past 15s. Excluded by default (kept out of routine local runs); run in CI via `--include slow` (added to the `test` job).

Full suite green locally against 5.26.27 (7687 / +APOC 7691) and 2026.05 (7689): **780 passed**.