### PR TITLE
fix: emit a single CYPHER 25 selector on the %Query{} run path

### DIFF
--- a/lib/cypher.ex
+++ b/lib/cypher.ex
@@ -531,7 +531,9 @@ defmodule AshNeo4j.Cypher do
   ```
   """
   def run(%Query{} = query) do
-    {cypher, params} = render(query)
+    # Render without the selector — the arity-2 string clause is the single place
+    # that prepends `cypher25_prefix/0`, otherwise it would be doubled (#397).
+    {cypher, params} = render(query, prefix?: false)
     run(cypher, params)
   end
 
@@ -561,7 +563,8 @@ defmodule AshNeo4j.Cypher do
   end
 
   def run_expecting_deletions(%Query{} = query) do
-    {cypher, params} = render(query)
+    # Same as run/1: let the string clause add the single selector (#397).
+    {cypher, params} = render(query, prefix?: false)
     run_expecting_deletions(cypher, params)
   end
 

--- a/test/cypher_selector_test.exs
+++ b/test/cypher_selector_test.exs
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.CypherSelectorTest do
+  @moduledoc """
+  The `%Query{}` run path must emit the `CYPHER 25` language selector exactly
+  once (#397). `render/2` defaults to `prefix?: true`, so the `%Query{}` clauses
+  of `run/1` and `run_expecting_deletions/1` render unprefixed and let the
+  arity-2 string clause add the single selector — otherwise it is doubled
+  (`CYPHER 25 CYPHER 25 …`).
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias AshNeo4j.Cypher
+  alias AshNeo4j.Cypher.{DetachDelete, Match, Query, Return}
+  alias AshNeo4j.Sandbox
+
+  setup_all do
+    AshNeo4j.BoltyHelper.start()
+    :ok
+  end
+
+  describe "CYPHER 25 selector on the %Query{} run path" do
+    @describetag :cypher25
+
+    setup do
+      # The selector is only emitted on a Cypher 25 server (the Bolt6 / 2026.05
+      # pool). run/2 and run_expecting_deletions/2 log the rendered Cypher at
+      # :debug, so capture it there.
+      Process.put(:ash_neo4j_pool, Bolt6)
+      Sandbox.checkout()
+
+      level = Logger.level()
+      Logger.configure(level: :debug)
+
+      on_exit(fn ->
+        Logger.configure(level: level)
+        Sandbox.rollback()
+      end)
+
+      :ok
+    end
+
+    test "run/1 emits a single selector" do
+      query = %Query{
+        clauses: [%Match{pattern: "(n:Selector397 {id: $id})"}, %Return{items: ["n"]}],
+        params: %{id: "x"}
+      }
+
+      log = capture_log(fn -> Cypher.run(query) end)
+
+      assert log =~ "AshNeo4j.Cypher: run(CYPHER 25 MATCH"
+      refute log =~ "CYPHER 25 CYPHER 25"
+    end
+
+    test "run_expecting_deletions/1 emits a single selector" do
+      query = %Query{
+        clauses: [%Match{pattern: "(n:Selector397)"}, %DetachDelete{items: ["n"]}],
+        params: %{}
+      }
+
+      log = capture_log(fn -> Cypher.run_expecting_deletions(query) end)
+
+      assert log =~ "AshNeo4j.Cypher: run_expecting_deletions(CYPHER 25 MATCH"
+      refute log =~ "CYPHER 25 CYPHER 25"
+    end
+  end
+end


### PR DESCRIPTION
Closes #397.

## Problem
`Cypher.run/1` and `run_expecting_deletions/1` on the `%Query{}` path rendered the query with `render/2`'s default `prefix?: true` (which prepends `CYPHER 25 `) and then delegated to the arity-2 **string** clause, which prepends the selector **again** — emitting `CYPHER 25 CYPHER 25 MERGE …` against a Cypher 25 server. Neo4j 2026.05 tolerates it (suites stay green), but it reads wrong in logs/telemetry. Present in 0.10.1 and on dev.

## Fix
Render the `%Query{}` with `prefix?: false`, making the string clause the single place that adds the selector — mirroring how inner `CALL { … }` branches are already rendered unprefixed (#299).

## Test
A `:cypher25` regression test (Bolt6 / 2026.05 pool) asserts both run paths log exactly one `CYPHER 25 ` selector and never the doubled form. Verified it fails without the fix (0/2) and passes with it (2/2).

Full suite green locally across 5.26.27 (7687 / +APOC 7691) and 2026.05 (7689): **782 passed**.