### PR TITLE
fix: push vector-distance sort to ORDER BY; never push LIMIT past a client-side sort

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -287,7 +287,8 @@ defmodule AshNeo4j.DataLayer do
               with {:ok, records} <- apply_calculations_to_records(records, calculations, resource),
                    records <- filter_matches(records, drop_pushdown_only(query.filter), query.domain),
                    {:ok, records} <- apply_aggregates_to_records(records, aggregates, resource) do
-                {:ok, apply_calculation_sort(records, query.sort, query.domain)}
+                sorted = apply_calculation_sort(records, query.sort, query.domain)
+                {:ok, apply_deferred_pagination(sorted, query)}
               end
 
             {:error, reason} ->
@@ -1779,6 +1780,22 @@ defmodule AshNeo4j.DataLayer do
       end
     end)
   end
+
+  # When a sort can't be pushed to Cypher (an in-memory calculation), its
+  # LIMIT/OFFSET were withheld from the query so they wouldn't truncate unordered
+  # rows — apply them here, after the in-memory sort above (#407).
+  defp apply_deferred_pagination(records, query) do
+    case QueryHelper.deferred_pagination(query) do
+      {nil, nil} -> records
+      {skip, limit} -> records |> drop_offset(skip) |> take_limit(limit)
+    end
+  end
+
+  defp drop_offset(records, skip) when skip in [nil, 0], do: records
+  defp drop_offset(records, skip), do: Enum.drop(records, skip)
+
+  defp take_limit(records, nil), do: records
+  defp take_limit(records, limit), do: Enum.take(records, limit)
 
   defp apply_calculation_sort(records, sort, _domain) when sort in [nil, []], do: records
 

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -33,10 +33,12 @@ defmodule AshNeo4j.QueryHelper do
     # through rather than running a fabricated query.
     with %Query{} = base <- build_query(ash_query, mapping),
          {:ok, {terms, sort_params}} <- sort_terms(ash_query, mapping) do
+      {push_skip, push_limit} = cypher_pagination(ash_query, terms)
+
       query =
         base
         |> Query.merge_params(sort_params)
-        |> Query.paginate_nodes(terms, ash_query.offset, ash_query.limit)
+        |> Query.paginate_nodes(terms, push_skip, push_limit)
         |> Query.add_order_by(terms)
 
       run_cypher_query(query)
@@ -68,11 +70,13 @@ defmodule AshNeo4j.QueryHelper do
 
     with nil <- Enum.find(branch_queries, &match?({:error, _}, &1)),
          {:ok, {terms, sort_params}} <- sort_terms(ash_query, mapping) do
+      {push_skip, push_limit} = cypher_pagination(ash_query, terms)
+
       query =
         branch_queries
         |> Query.combination_block(union_type: union_type)
         |> Query.merge_params(sort_params)
-        |> Query.paginate_nodes(terms, ash_query.offset, ash_query.limit)
+        |> Query.paginate_nodes(terms, push_skip, push_limit)
         |> Query.add_order_by(terms)
 
       run_cypher_query(query)
@@ -101,11 +105,13 @@ defmodule AshNeo4j.QueryHelper do
           {:ok, []}
         else
           with {:ok, {terms, sort_params}} <- sort_terms(ash_query, mapping) do
+            {push_skip, push_limit} = cypher_pagination(ash_query, terms)
+
             final =
               mapping.label_pair
               |> Query.node_read_by_ids(keep_ids)
               |> Query.merge_params(sort_params)
-              |> Query.paginate_nodes(terms, ash_query.offset, ash_query.limit)
+              |> Query.paginate_nodes(terms, push_skip, push_limit)
               |> Query.add_order_by(terms)
 
             run_cypher_query(final)
@@ -966,6 +972,43 @@ defmodule AshNeo4j.QueryHelper do
   defp attribute_name(atom) when is_atom(atom), do: atom
   defp attribute_name(_), do: nil
 
+  @doc """
+  The `{offset, limit}` to apply **in Elixir** for this query, or `{nil, nil}`
+  when pagination was pushed to Cypher.
+
+  A `LIMIT`/`OFFSET` may only be pushed down when every `sort` term renders to an
+  `ORDER BY` (`sort_terms/2` keeps as many terms as the query has sort entries).
+  When a sort falls back to in-memory evaluation (a non-pushable calculation),
+  pushing `LIMIT` would truncate *unordered* rows, so the data layer instead
+  applies offset/limit after its in-memory sort (#407).
+  """
+  @spec deferred_pagination(Ash.Query.t() | map()) :: {non_neg_integer() | nil, pos_integer() | nil}
+  def deferred_pagination(ash_query) do
+    mapping = ResourceInfo.mapping(ash_query.resource)
+
+    case sort_terms(ash_query, mapping) do
+      {:ok, {terms, _}} ->
+        if fully_pushed_down?(ash_query.sort, terms),
+          do: {nil, nil},
+          else: {ash_query.offset, ash_query.limit}
+
+      _ ->
+        {nil, nil}
+    end
+  end
+
+  # Pagination to push into Cypher: the query's offset/limit when the sort is
+  # fully pushed down, otherwise nothing (deferred to the data layer, #407).
+  defp cypher_pagination(ash_query, terms) do
+    if fully_pushed_down?(ash_query.sort, terms),
+      do: {ash_query.offset, ash_query.limit},
+      else: {nil, nil}
+  end
+
+  # A plain-property sort always renders a term, so a shortfall means a sort
+  # term was dropped to in-memory evaluation.
+  defp fully_pushed_down?(sort, terms), do: length(terms) == length(sort || [])
+
   # Builds the ORDER BY terms and any params they reference.
   #
   # Returns `{terms, params}` where each term is `{order_expression, :asc | :desc}`
@@ -995,8 +1038,8 @@ defmodule AshNeo4j.QueryHelper do
   # vector_similarity / vector_cosine_distance sort — pushed down as the scalar
   # expression, with the query embedding bound as a param.
   defp sort_term(mapping, %Ash.Query.Calculation{module: Ash.Resource.Calculation.Expression, opts: opts}, order, index) do
-    case Keyword.get(opts, :expr) do
-      %Ash.Query.Call{name: fname, args: [ref, query_vec]} when fname in [:vector_similarity, :vector_cosine_distance] ->
+    case vector_call(Keyword.get(opts, :expr)) do
+      {fname, ref, query_vec} ->
         with :ok <- AshNeo4j.Cypher.require_cypher25() do
           prop = property_name(mapping, ref)
           key = "sort_#{Cypher.sanitize_param(prop)}_#{index}_vec"
@@ -1004,7 +1047,7 @@ defmodule AshNeo4j.QueryHelper do
           {{expr, order}, %{key => to_vector_param(query_vec)}}
         end
 
-      _ ->
+      nil ->
         nil
     end
   end
@@ -1017,6 +1060,24 @@ defmodule AshNeo4j.QueryHelper do
     prop = Keyword.get(mapping.properties, name, name)
     {{"s.#{prop}", order}, %{}}
   end
+
+  # Extracts `{fname, ref, query_vec}` from a vector-distance sort expression.
+  #
+  # `calc(vector_*(field, q), type: …)` arrives prepared as a `type(inner, …)`
+  # wrapper around the function struct (`AshNeo4j.Functions.Vector*`, carrying
+  # `name`/`arguments`); peel the `type` wrapper so the inner function matches.
+  # The bare `Ash.Query.Call` form (`args`) is also accepted for the unwrapped /
+  # untyped case. Anything else returns nil → Ash sorts it in-memory (#407).
+  @vector_sort_fns [:vector_similarity, :vector_cosine_distance]
+  defp vector_call(%Ash.Query.Function.Type{arguments: [inner | _]}), do: vector_call(inner)
+
+  defp vector_call(%Ash.Query.Call{name: fname, args: [ref, query_vec]}) when fname in @vector_sort_fns,
+    do: {fname, ref, query_vec}
+
+  defp vector_call(%{name: fname, arguments: [ref, query_vec]}) when fname in @vector_sort_fns,
+    do: {fname, ref, query_vec}
+
+  defp vector_call(_), do: nil
 
   defp ref_or_atom?(%Ash.Query.Ref{}), do: true
   defp ref_or_atom?(value) when is_atom(value), do: true

--- a/test/sort_limit_test.exs
+++ b/test/sort_limit_test.exs
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.SortLimitTest do
+  @moduledoc """
+  `LIMIT`/`OFFSET` must not be pushed to Cypher when the sort can't be (#407). An
+  in-memory calculation sort (`score_doubled = score * 2`) doesn't render to an
+  `ORDER BY`, so pushing the limit would truncate *unordered* rows — the data
+  layer must instead apply the limit after its in-memory sort.
+  """
+  use ExUnit.Case, async: true
+  require Ash.Query
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.Comment
+
+  setup_all do
+    AshNeo4j.BoltyHelper.start()
+  end
+
+  setup do
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+  end
+
+  test "sort by an in-memory calculation + limit returns the calculation's top-k" do
+    # Titles ascend opposite to score, and Comment has a prepared `sort:
+    # [title: :asc]` that *does* push down. So a limit pushed onto that partial
+    # `ORDER BY s.title` would pick {a, b} (lowest scores); the score_doubled
+    # top-2 is {c, b}. Only deferring the limit to the in-memory sort gives {c, b}.
+    a = Comment |> Ash.create!(%{title: "a", score: 1})
+    b = Comment |> Ash.create!(%{title: "b", score: 2})
+    c = Comment |> Ash.create!(%{title: "c", score: 3})
+
+    {:ok, results} =
+      Comment
+      |> Ash.Query.filter(id in ^[a.id, b.id, c.id])
+      |> Ash.Query.sort(score_doubled: :desc)
+      |> Ash.Query.limit(2)
+      |> Ash.read()
+
+    assert Enum.map(results, & &1.id) == [c.id, b.id]
+  end
+end

--- a/test/vector_test.exs
+++ b/test/vector_test.exs
@@ -73,6 +73,12 @@ defmodule AshNeo4j.VectorSearchTest do
     #   a → identical (similarity 1.0, distance 0.0)
     #   b → orthogonal (similarity 0.5, distance 1.0)
     #   c → opposite   (similarity 0.0, distance 2.0)
+    #
+    # Each search below scopes to these three ids (`id in [...]`) so the ordering
+    # is over a known universe — `ThingNote` has nothing partitioning the search,
+    # so any other note on the shared Bolt6 server would otherwise creep into the
+    # ranking (and silently displace `b` under `limit`), making the exact-order
+    # assertions flaky (#407).
     defp seed_notes do
       a = ThingNote |> Ash.create!(%{body: "a", embedding: [1.0, 0.0, 0.0]})
       b = ThingNote |> Ash.create!(%{body: "b", embedding: [0.0, 1.0, 0.0]})
@@ -87,12 +93,12 @@ defmodule AshNeo4j.VectorSearchTest do
     end
 
     test "filters by vector_cosine_distance threshold" do
-      {a, b, _c} = seed_notes()
+      {a, b, c} = seed_notes()
       q = [1.0, 0.0, 0.0]
 
       {:ok, results} =
         ThingNote
-        |> Ash.Query.filter(vector_cosine_distance(embedding, ^q) < 1.5)
+        |> Ash.Query.filter(id in ^[a.id, b.id, c.id] and vector_cosine_distance(embedding, ^q) < 1.5)
         |> Ash.read()
 
       ids = MapSet.new(results, & &1.id)
@@ -106,6 +112,7 @@ defmodule AshNeo4j.VectorSearchTest do
 
       {:ok, results} =
         ThingNote
+        |> Ash.Query.filter(id in ^[a.id, b.id, c.id])
         |> Ash.Query.sort({calc(vector_cosine_distance(embedding, ^q), type: :float), :asc})
         |> Ash.read()
 
@@ -118,6 +125,7 @@ defmodule AshNeo4j.VectorSearchTest do
 
       {:ok, results} =
         ThingNote
+        |> Ash.Query.filter(id in ^[a.id, b.id, c.id])
         |> Ash.Query.sort({calc(vector_similarity(embedding, ^q), type: :float), :desc})
         |> Ash.read()
 
@@ -125,11 +133,12 @@ defmodule AshNeo4j.VectorSearchTest do
     end
 
     test "sort + limit returns the top-k nearest" do
-      {a, b, _c} = seed_notes()
+      {a, b, c} = seed_notes()
       q = [1.0, 0.0, 0.0]
 
       {:ok, results} =
         ThingNote
+        |> Ash.Query.filter(id in ^[a.id, b.id, c.id])
         |> Ash.Query.sort({calc(vector_cosine_distance(embedding, ^q), type: :float), :asc})
         |> Ash.Query.limit(2)
         |> Ash.read()


### PR DESCRIPTION
Closes #407.

The flaky vector-ordering test was masking **two real data-layer correctness bugs** — not a test isolation issue.

## 1. Vector-distance sorts never pushed down
`calc(vector_*(field, q), type: :float)` reaches the data layer prepared as an `Ash.Query.Function.Type` wrapper around an `AshNeo4j.Functions.Vector*` struct (with `name`/`arguments`). The `sort_term` matcher only matched a bare `Ash.Query.Call` (`args`), so it never matched the prepared form — the `ORDER BY` was silently dropped and every vector sort ran in-memory over a full-label scan.

## 2. `LIMIT`/`OFFSET` pushed regardless of whether the sort pushed down
With the sort client-side, the query was `… WITH s LIMIT n … RETURN` (no `ORDER BY`), truncating **unordered** rows. So `sort |> limit` returned the wrong rows — non-deterministically, which is what CI surfaced.

## Fixes
- **`vector_call/1`** peels the `type(...)` wrapper and matches the prepared function struct (still accepting the bare `Call` form), so vector sorts render an `ORDER BY` and the pushed `LIMIT` picks the correct top-k. Verified the generated Cypher is now `WITH s ORDER BY (…cosine…) ASC LIMIT 2`.
- **Limit guard:** push `LIMIT`/`OFFSET` only when *every* sort term pushed down; otherwise withhold them and apply in Elixir after the in-memory sort. General correctness floor for any non-pushable sort — and de-risks #335 (traverse-in-sort) when it lands.

## Tests
- `vector_test.exs`: search queries scope to the seeded ids (`id in [...]`) so ordering is over a known universe — isolation-independent on the shared Bolt6 server.
- `sort_limit_test.exs`: an in-memory calc sort (`score_doubled`) + `limit` returns the calculation's top-k. **Mutation-verified** it fails (0/1) under pre-#407 behavior.

Full suite green locally across 5.26.27 (7687 / +APOC 7691) and 2026.05 (7689): **783 passed**. Dialyzer clean.