### PR TITLE
fix: return a typed error for a non-vector query embedding

### DIFF
--- a/lib/error.ex
+++ b/lib/error.ex
@@ -65,6 +65,27 @@ defmodule AshNeo4j.Error.UnsupportedAtomic do
   end
 end
 
+defmodule AshNeo4j.Error.UnsupportedVectorParam do
+  @moduledoc """
+  **Returned** (never raised) when a `vector_similarity` / `vector_cosine_distance`
+  query embedding isn't a list of numbers or a `%Bolty.Types.Vector{}` (#412).
+
+  `vector_similarity(embedding, ^value)` performs no cast on `value` (its
+  `args` are `[:any, :any]`), so a non-vector `value` (e.g. a string) reaches the
+  pushdown builder unconverted. Rather than let `to_vector_param/1` raise a
+  `FunctionClauseError` deep in the data layer, we refuse up front with a typed,
+  user-facing error, consistent with the rest of the returned-error family (#350).
+
+  Pass the query embedding as a list of numbers (`[1.0, 0.0, 0.0]`) or a
+  `%Bolty.Types.Vector{}`.
+  """
+  use Splode.Error, fields: [:value], class: :invalid
+
+  def message(%{value: value}) do
+    "vector query embedding must be a list of numbers or a %Bolty.Types.Vector{}, got #{inspect(value)}"
+  end
+end
+
 defmodule AshNeo4j.Error.GeoDimensionMismatch do
   @moduledoc """
   Returned (never raised) when a spatial operation combines geometries of

--- a/lib/query_helper.ex
+++ b/lib/query_helper.ex
@@ -839,14 +839,16 @@ defmodule AshNeo4j.QueryHelper do
 
       %{operator: op, left: %AshNeo4j.Functions.VectorSimilarity{arguments: [ref, query_vec]}, right: threshold}
       when op in [:<, :<=, :>, :>=, :==, :!=] and is_number(threshold) ->
-        with :ok <- AshNeo4j.Cypher.require_cypher25() do
-          {property_name(mapping, ref), :vector_similarity, {op, to_vector_param(query_vec), threshold}, false}
+        with :ok <- AshNeo4j.Cypher.require_cypher25(),
+             {:ok, vec} <- to_vector_param(query_vec) do
+          {property_name(mapping, ref), :vector_similarity, {op, vec, threshold}, false}
         end
 
       %{operator: op, left: %AshNeo4j.Functions.VectorCosineDistance{arguments: [ref, query_vec]}, right: threshold}
       when op in [:<, :<=, :>, :>=, :==, :!=] and is_number(threshold) ->
-        with :ok <- AshNeo4j.Cypher.require_cypher25() do
-          {property_name(mapping, ref), :vector_cosine_distance, {op, to_vector_param(query_vec), threshold}, false}
+        with :ok <- AshNeo4j.Cypher.require_cypher25(),
+             {:ok, vec} <- to_vector_param(query_vec) do
+          {property_name(mapping, ref), :vector_cosine_distance, {op, vec, threshold}, false}
         end
 
       predicate ->
@@ -1040,11 +1042,12 @@ defmodule AshNeo4j.QueryHelper do
   defp sort_term(mapping, %Ash.Query.Calculation{module: Ash.Resource.Calculation.Expression, opts: opts}, order, index) do
     case vector_call(Keyword.get(opts, :expr)) do
       {fname, ref, query_vec} ->
-        with :ok <- AshNeo4j.Cypher.require_cypher25() do
+        with :ok <- AshNeo4j.Cypher.require_cypher25(),
+             {:ok, vec} <- to_vector_param(query_vec) do
           prop = property_name(mapping, ref)
           key = "sort_#{Cypher.sanitize_param(prop)}_#{index}_vec"
           expr = Cypher.vector_scalar(fname, :s, prop, "$#{key}")
-          {{expr, order}, %{key => to_vector_param(query_vec)}}
+          {{expr, order}, %{key => vec}}
         end
 
       nil ->
@@ -1101,8 +1104,13 @@ defmodule AshNeo4j.QueryHelper do
 
   # The query embedding is passed as a plain LIST<FLOAT> param — what
   # `vector.similarity.cosine/2` expects, and consistent with list storage.
-  defp to_vector_param(value) when is_list(value), do: Enum.map(value, &(&1 / 1))
-  defp to_vector_param(%Bolty.Types.Vector{data: data}), do: Enum.map(data, &(&1 / 1))
+  # `vector_similarity`/`vector_cosine_distance` don't cast the embedding, so a
+  # non-vector value (e.g. a string) reaches here unconverted; refuse it with a
+  # typed error rather than raising a FunctionClauseError deep in the data layer
+  # (#412).
+  defp to_vector_param(value) when is_list(value), do: {:ok, Enum.map(value, &(&1 / 1))}
+  defp to_vector_param(%Bolty.Types.Vector{data: data}), do: {:ok, Enum.map(data, &(&1 / 1))}
+  defp to_vector_param(value), do: {:error, AshNeo4j.Error.UnsupportedVectorParam.exception(value: value)}
 
   # Builds the on-disk property name for a Point attribute under the symmetric
   # split — `<attr>.point` is where the native Neo4j POINT lives (the indexable

--- a/test/vector_bad_param_test.exs
+++ b/test/vector_bad_param_test.exs
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 ash_neo4j contributors <https://github.com/diffo-dev/ash_neo4j/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshNeo4j.VectorBadParamTest do
+  @moduledoc """
+  A `vector_similarity` / `vector_cosine_distance` query embedding that isn't a
+  list of numbers or a `%Bolty.Types.Vector{}` returns (never raises)
+  `{:error, %AshNeo4j.Error.UnsupportedVectorParam{}}` (#412).
+
+  Tagged `:cypher25` and routed to the `Bolt6` pool (Neo4j 2026.05) because the
+  builder checks `require_cypher25/0` first — on a non-Cypher-25 server that
+  check short-circuits before the embedding is ever converted, so the bad-param
+  path is only reachable when Cypher 25 is available.
+  """
+  use ExUnit.Case, async: false
+
+  require Ash.Query
+  import Ash.Expr
+
+  alias AshNeo4j.BoltyHelper
+  alias AshNeo4j.Error.UnsupportedVectorParam
+  alias AshNeo4j.Sandbox
+  alias AshNeo4j.Test.Resource.ThingNote
+
+  @moduletag :cypher25
+
+  setup_all do
+    BoltyHelper.start()
+    :ok
+  end
+
+  setup do
+    Process.put(:ash_neo4j_pool, Bolt6)
+    Sandbox.checkout()
+    on_exit(&Sandbox.rollback/0)
+    :ok
+  end
+
+  defp flatten(%{errors: errors}) when is_list(errors), do: Enum.flat_map(errors, &flatten/1)
+  defp flatten(e), do: [e]
+
+  test "a vector_similarity filter with a non-vector embedding returns a typed error, not a raise" do
+    {:error, error} =
+      ThingNote
+      |> Ash.Query.filter(vector_similarity(embedding, ^"oops") > 0.5)
+      |> Ash.read()
+
+    assert Enum.any?(flatten(error), &match?(%UnsupportedVectorParam{}, &1))
+  end
+
+  test "a vector_cosine_distance sort with a non-vector embedding returns a typed error, not a raise" do
+    {:error, error} =
+      ThingNote
+      |> Ash.Query.sort({calc(vector_cosine_distance(embedding, ^"oops"), type: :float), :asc})
+      |> Ash.read()
+
+    assert Enum.any?(flatten(error), &match?(%UnsupportedVectorParam{}, &1))
+  end
+end


### PR DESCRIPTION
Closes #412.

## Problem
`vector_similarity`/`vector_cosine_distance` declare `args` as `[[:any, :any]]`, so Ash performs no cast on the query embedding. A non-vector argument (e.g. a string) reaches `to_vector_param/1` unconverted, which only matched a list or `%Bolty.Types.Vector{}` and raised a `FunctionClauseError` deep in the data layer:

```elixir
Ash.Query.filter(vector_similarity(embedding, ^"oops") > 0.5)
# ** (FunctionClauseError) no function clause matching in AshNeo4j.QueryHelper.to_vector_param/1
```

That is inconsistent with the rest of the data layer, which returns typed errors rather than raising (#350).

## Fix
Add a catch-all clause to `to_vector_param/1` that returns `{:error, %AshNeo4j.Error.UnsupportedVectorParam{}}`, and thread the `{:ok, vec}` through the two filter branches and the sort branch (all already guarded by `with :ok <- require_cypher25()`), so the error surfaces via `finalize_conditions`/`sort_terms` instead of raising. `UnsupportedVectorParam` follows the existing `Unsupported*` family (`:invalid`, returned never raised).

`vector_similarity(embedding, ^"oops")` now returns `{:error, %UnsupportedVectorParam{}}` on both the filter and sort paths; a list or `%Bolty.Types.Vector{}` embedding is unchanged.

## Tests
`test/vector_bad_param_test.exs` asserts the typed error is returned (never raised) on both paths. Tagged `:cypher25` and routed to the `Bolt6` pool, because the builder checks `require_cypher25/0` first, so the bad-param path is only reachable on a Cypher 25 server. `mix compile --warnings-as-errors` (1.20 type checker) passes.
